### PR TITLE
Change file path patterns to support 1-level symlinks by default

### DIFF
--- a/lib/knapsack_pro/adapters/base_adapter.rb
+++ b/lib/knapsack_pro/adapters/base_adapter.rb
@@ -2,7 +2,7 @@ module KnapsackPro
   module Adapters
     class BaseAdapter
       # Just example, please overwrite constant in subclass
-      TEST_DIR_PATTERN = 'test/**/*_test.rb'
+      TEST_DIR_PATTERN = 'test/**{,/*/**}/*_test.rb'
 
       def self.bind
         adapter = new

--- a/lib/knapsack_pro/adapters/cucumber_adapter.rb
+++ b/lib/knapsack_pro/adapters/cucumber_adapter.rb
@@ -1,7 +1,7 @@
 module KnapsackPro
   module Adapters
     class CucumberAdapter < BaseAdapter
-      TEST_DIR_PATTERN = 'features/**/*.feature'
+      TEST_DIR_PATTERN = 'features/**{,/*/**}/*.feature'
 
       def self.test_path(scenario_or_outline_table)
         if scenario_or_outline_table.respond_to?(:file)

--- a/lib/knapsack_pro/adapters/minitest_adapter.rb
+++ b/lib/knapsack_pro/adapters/minitest_adapter.rb
@@ -1,7 +1,7 @@
 module KnapsackPro
   module Adapters
     class MinitestAdapter < BaseAdapter
-      TEST_DIR_PATTERN = 'test/**/*_test.rb'
+      TEST_DIR_PATTERN = 'test/**{,/*/**}/*_test.rb'
       @@parent_of_test_dir = nil
 
       def self.test_path(obj)

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -1,7 +1,7 @@
 module KnapsackPro
   module Adapters
     class RSpecAdapter < BaseAdapter
-      TEST_DIR_PATTERN = 'spec/**/*_spec.rb'
+      TEST_DIR_PATTERN = 'spec/**{,/*/**}/*_spec.rb'
 
       def self.test_path(example_group)
         unless example_group[:turnip]

--- a/spec/knapsack_pro/adapters/base_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/base_adapter_spec.rb
@@ -1,6 +1,6 @@
 describe KnapsackPro::Adapters::BaseAdapter do
   it do
-    expect(described_class::TEST_DIR_PATTERN).to eq 'test/**/*_test.rb'
+    expect(described_class::TEST_DIR_PATTERN).to eq 'test/**{,/*/**}/*_test.rb'
   end
 
   describe '.bind' do

--- a/spec/knapsack_pro/adapters/cucumber_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/cucumber_adapter_spec.rb
@@ -1,6 +1,6 @@
 describe KnapsackPro::Adapters::CucumberAdapter do
   it do
-    expect(described_class::TEST_DIR_PATTERN).to eq 'features/**/*.feature'
+    expect(described_class::TEST_DIR_PATTERN).to eq 'features/**{,/*/**}/*.feature'
   end
 
   context do

--- a/spec/knapsack_pro/adapters/minitest_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/minitest_adapter_spec.rb
@@ -6,7 +6,7 @@ end
 
 describe KnapsackPro::Adapters::MinitestAdapter do
   it do
-    expect(described_class::TEST_DIR_PATTERN).to eq 'test/**/*_test.rb'
+    expect(described_class::TEST_DIR_PATTERN).to eq 'test/**{,/*/**}/*_test.rb'
   end
 
   describe '.test_path' do

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -1,6 +1,6 @@
 describe KnapsackPro::Adapters::RSpecAdapter do
   it do
-    expect(described_class::TEST_DIR_PATTERN).to eq 'spec/**/*_spec.rb'
+    expect(described_class::TEST_DIR_PATTERN).to eq 'spec/**{,/*/**}/*_spec.rb'
   end
 
   context do


### PR DESCRIPTION
As proposed in the PR for the knapsack repo.

https://github.com/ArturT/knapsack/pull/27