### PR TITLE
Changed rake task in minitest_runner.rb to have no warnings output

### DIFF
--- a/lib/knapsack_pro/runners/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/minitest_runner.rb
@@ -14,6 +14,7 @@ module KnapsackPro
         end
 
         Rake::TestTask.new(task_name) do |t|
+          t.warning = false
           t.libs << runner.test_dir
           t.test_files = runner.test_file_paths
           t.options = args


### PR DESCRIPTION
Due to the changes in [this PR on Rake itself](https://github.com/ruby/rake/pull/97), executing the minitest rake task for Knapsack caused our test output to be filled with so many extraneous warning messages during test execution it both caused the output to be unreadably long and caused the semaphoreci threads to error out, apparently due to lack of memory. This reverts the setting for warnings on the Rake task defined in minitest_runner.rb to the pre-Rake v11.0.0 default, resolving both issues.