### PR TITLE
Don't fail when there is no tests to run on a node

### DIFF
--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -1,13 +1,20 @@
 module KnapsackPro
   class Report
     def self.save
+      test_files = KnapsackPro.tracker.to_a
+
+      if test_files.empty?
+        KnapsackPro.logger.info("Didn't save time execution report on API server because there are no test files matching criteria on this node. Probably reason might be very narrowed tests list - you run only tests with specified tag and there are fewer test files with the tag than node total number.")
+        return
+      end
+
       repository_adapter = KnapsackPro::RepositoryAdapterInitiator.call
       action = KnapsackPro::Client::API::V1::BuildSubsets.create(
         commit_hash: repository_adapter.commit_hash,
         branch: repository_adapter.branch,
         node_total: KnapsackPro::Config::Env.ci_node_total,
         node_index: KnapsackPro::Config::Env.ci_node_index,
-        test_files: KnapsackPro.tracker.to_a,
+        test_files: test_files,
       )
       connection = KnapsackPro::Client::Connection.new(action)
       response = connection.call

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -3,66 +3,82 @@ describe KnapsackPro::Report do
     subject { described_class.save }
 
     before do
-      commit_hash = double
-      branch = double
-      repository_adapter = instance_double(KnapsackPro::RepositoryAdapters::EnvAdapter, commit_hash: commit_hash, branch: branch)
-      expect(KnapsackPro::RepositoryAdapterInitiator).to receive(:call).and_return(repository_adapter)
-
-      node_total = double
-      node_index = double
-      expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(node_total)
-      expect(KnapsackPro::Config::Env).to receive(:ci_node_index).and_return(node_index)
-
-      test_files = double
       tracker = instance_double(KnapsackPro::Tracker, to_a: test_files)
       expect(KnapsackPro).to receive(:tracker).and_return(tracker)
-
-      action = double
-      expect(KnapsackPro::Client::API::V1::BuildSubsets).to receive(:create).with({
-        commit_hash: commit_hash,
-        branch: branch,
-        node_total: node_total,
-        node_index: node_index,
-        test_files: test_files,
-      }).and_return(action)
-
-      connection = instance_double(KnapsackPro::Client::Connection, success?: success?, errors?: errors?)
-      expect(KnapsackPro::Client::Connection).to receive(:new).with(action).and_return(connection).and_return(connection)
-
-      response = double
-      expect(connection).to receive(:call).and_return(response)
     end
 
-    context 'when success' do
-      let(:success?) { true }
+    context "when test files doesn't exist" do
+      let(:test_files) { [] }
 
-      context 'when response has errors' do
-        let(:errors?) { true }
+      it do
+        logger = instance_double(Logger)
+        expect(KnapsackPro).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:info).with("Didn't save time execution report on API server because there are no test files matching criteria on this node. Probably reason might be very narrowed tests list - you run only tests with specified tag and there are fewer test files with the tag than node total number.")
+        subject
+      end
+    end
 
-        it do
-          expect {
+    context 'when test files exists' do
+      let(:test_files) { [double] }
+
+      before do
+        commit_hash = double
+        branch = double
+        repository_adapter = instance_double(KnapsackPro::RepositoryAdapters::EnvAdapter, commit_hash: commit_hash, branch: branch)
+        expect(KnapsackPro::RepositoryAdapterInitiator).to receive(:call).and_return(repository_adapter)
+
+        node_total = double
+        node_index = double
+        expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(node_total)
+        expect(KnapsackPro::Config::Env).to receive(:ci_node_index).and_return(node_index)
+
+        action = double
+        expect(KnapsackPro::Client::API::V1::BuildSubsets).to receive(:create).with({
+          commit_hash: commit_hash,
+          branch: branch,
+          node_total: node_total,
+          node_index: node_index,
+          test_files: test_files,
+        }).and_return(action)
+
+        connection = instance_double(KnapsackPro::Client::Connection, success?: success?, errors?: errors?)
+        expect(KnapsackPro::Client::Connection).to receive(:new).with(action).and_return(connection).and_return(connection)
+
+        response = double
+        expect(connection).to receive(:call).and_return(response)
+      end
+
+      context 'when success' do
+        let(:success?) { true }
+
+        context 'when response has errors' do
+          let(:errors?) { true }
+
+          it do
+            expect {
+              subject
+            }.to raise_error(ArgumentError)
+          end
+        end
+
+        context 'when response has no errors' do
+          let(:errors?) { false }
+
+          it do
+            logger = instance_double(Logger)
+            expect(KnapsackPro).to receive(:logger).and_return(logger)
+            expect(logger).to receive(:info).with('Saved time execution report on API server.')
             subject
-          }.to raise_error(ArgumentError)
+          end
         end
       end
 
-      context 'when response has no errors' do
-        let(:errors?) { false }
+      context 'when failure' do
+        let(:success?) { false }
+        let(:errors?) { nil }
 
-        it do
-          logger = instance_double(Logger)
-          expect(KnapsackPro).to receive(:logger).and_return(logger)
-          expect(logger).to receive(:info).with('Saved time execution report on API server.')
-          subject
-        end
+        it { subject }
       end
-    end
-
-    context 'when failure' do
-      let(:success?) { false }
-      let(:errors?) { nil }
-
-      it { subject }
     end
   end
 end


### PR DESCRIPTION
Related issue: https://github.com/KnapsackPro/knapsack_pro-ruby/issues/7