### PR TITLE
Preserve cucumber latest error message with exit code to fix problem …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 0.7.2
+
+* Preserve cucumber latest error message with exit code to fix problem with false positive cucumber failed tests
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/10
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.7.1...v0.7.2
+
 ### 0.7.1
 
 * Don't fail when there are no tests to run on a node

--- a/lib/knapsack_pro/adapters/cucumber_adapter.rb
+++ b/lib/knapsack_pro/adapters/cucumber_adapter.rb
@@ -41,9 +41,16 @@ module KnapsackPro
         end
       end
 
-      def bind_save_report
+      def bind_save_report(latest_error = nil)
         ::Kernel.at_exit do
+          # $! is latest error message
+          latest_error = (latest_error || $!)
+          exit_status = latest_error.status if latest_error.is_a?(SystemExit)
+          #require 'pry'; binding.pry
+          # saving report makes API call which changes exit status
+          # from cucumber so we need to preserve cucumber exit status
           KnapsackPro::Report.save
+          ::Kernel.exit exit_status if exit_status
         end
       end
 

--- a/spec/knapsack_pro/adapters/cucumber_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/cucumber_adapter_spec.rb
@@ -129,6 +129,21 @@ describe KnapsackPro::Adapters::CucumberAdapter do
 
         subject.bind_save_report
       end
+
+      context 'when cucumber tests failed' do
+        let(:exit_status) { double }
+        let(:latest_error) { instance_double(SystemExit, status: exit_status) }
+
+        it 'preserves cucumber latest error message exit status' do
+          expect(::Kernel).to receive(:at_exit).and_yield
+
+          expect(latest_error).to receive(:is_a?).with(SystemExit).and_return(true)
+          expect(KnapsackPro::Report).to receive(:save)
+          expect(::Kernel).to receive(:exit).with(exit_status)
+
+          subject.bind_save_report(latest_error)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
…with false positive cucumber failed tests