### PR TITLE
Fix bug in queue mode with recording test files time execution data

### DIFF
--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -7,6 +7,8 @@ module KnapsackPro
 
     def self.save_subset_queue_to_file
       test_files = KnapsackPro.tracker.to_a
+      KnapsackPro.tracker.reset!
+
       subset_queue_id = KnapsackPro::Config::Env.subset_queue_id
 
       FileUtils.mkdir_p(queue_path)

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -20,7 +20,8 @@ describe KnapsackPro::Report do
     before do
       test_files = [{path: fake_path}]
       tracker = instance_double(KnapsackPro::Tracker, to_a: test_files)
-      expect(KnapsackPro).to receive(:tracker).and_return(tracker)
+      expect(KnapsackPro).to receive(:tracker).twice.and_return(tracker)
+      expect(tracker).to receive(:reset!)
 
       subset_queue_id = 'fake-subset-queue-id'
       expect(KnapsackPro::Config::Env).to receive(:subset_queue_id).and_return(subset_queue_id)


### PR DESCRIPTION
Fix bug in queue mode with recording test files time execution data. Previously the same test files time execution data where multiple times send to Knapsack Pro API.
