### PR TITLE
Improvements in log levels and messages for debug and info levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Allow `KNAPSACK_PRO_LOG_LEVEL` case insensitive.
 * Move all messages related to requests to Knapsack Pro API in log `debug` level and keep `info` level only for important messages like how to retry tests in development or info why something works this way or the other (for instance why tests were not executed on the CI node).
 
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/29
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.30.0...v0.31.0
+
 ### 0.30.0
 
 * Update license to MIT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 * TODO
 
+### 0.31.0
+
+* Add supported for log levels `fatal` and `error` by `KNAPSACK_PRO_LOG_LEVEL` environment variable.
+* Allow `KNAPSACK_PRO_LOG_LEVEL` case insensitive.
+* Move all messages related to requests to Knapsack Pro API in log `debug` level and keep `info` level only for important messages like how to retry tests in development or info why something works this way or the other (for instance why tests were not executed on the CI node).
+
 ### 0.30.0
 
 * Update license to MIT.

--- a/README.md
+++ b/README.md
@@ -259,8 +259,10 @@ You can change default Knapsack Pro configuration for RSpec, Cucumber, Minitest 
 # you can use your own logger
 require 'logger'
 KnapsackPro.logger = Logger.new(STDOUT)
-KnapsackPro.logger.level = Logger::INFO
+KnapsackPro.logger.level = Logger::DEBUG
 ```
+
+Debug is default log level and it is recommend to log details about requests to Knapsack Pro API. Thanks to that you can debug things or ensure everything works.
 
 ### Setup your CI server (How to set up 2 of 3)
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ KnapsackPro.logger = Logger.new(STDOUT)
 KnapsackPro.logger.level = Logger::DEBUG
 ```
 
-Debug is default log level and it is recommend to log details about requests to Knapsack Pro API. Thanks to that you can debug things or ensure everything works.
+Debug is default log level and it is recommended as default. [Read more](#how-can-i-change-log-level).
 
 ### Setup your CI server (How to set up 2 of 3)
 
@@ -854,9 +854,14 @@ knapack_pro gem will retry requests to Knapsack Pro API multiple times every few
 
 You can change log level by specifying the `KNAPSACK_PRO_LOG_LEVEL` environment variable.
 
-    KNAPSACK_PRO_LOG_LEVEL=warn bundle exec rake knapsack_pro:rspec
+    KNAPSACK_PRO_LOG_LEVEL=info bundle exec rake knapsack_pro:rspec
 
-Available values are `debug`, `info`, and `warn`. The default log level is `info`.
+Available values are `debug` (default), `info`, `warn`, `error` and `fatal`.
+
+Recommended log levels you can use:
+
+* `debug` is default log level and it is recommended to log details about requests to Knapsack Pro API. Thanks to that you can debug things or ensure everything works. For instance in [user dashboard](https://knapsackpro.com/dashboard) you can find tips referring to debug logs.
+* `info` level shows message like how to retry tests in development or info why something works this way or the other (for instance why tests were not executed on the CI node). You can use `info` level when you really don't want to see all debug messages from default log level.
 
 ### How to split tests based on test level instead of test file level?
 

--- a/lib/knapsack_pro/adapters/base_adapter.rb
+++ b/lib/knapsack_pro/adapters/base_adapter.rb
@@ -12,13 +12,13 @@ module KnapsackPro
 
       def bind
         if KnapsackPro::Config::Env.recording_enabled?
-          KnapsackPro.logger.info('Test suite time execution recording enabled.')
+          KnapsackPro.logger.debug('Test suite time execution recording enabled.')
           bind_time_tracker
           bind_save_report
         end
 
         if KnapsackPro::Config::Env.queue_recording_enabled?
-          KnapsackPro.logger.info('Test suite time execution queue recording enabled.')
+          KnapsackPro.logger.debug('Test suite time execution queue recording enabled.')
           bind_time_tracker
           bind_save_queue_report
         end

--- a/lib/knapsack_pro/adapters/cucumber_adapter.rb
+++ b/lib/knapsack_pro/adapters/cucumber_adapter.rb
@@ -37,7 +37,7 @@ module KnapsackPro
         end
 
         ::Kernel.at_exit do
-          KnapsackPro.logger.info(KnapsackPro::Presenter.global_time)
+          KnapsackPro.logger.debug(KnapsackPro::Presenter.global_time)
         end
       end
 

--- a/lib/knapsack_pro/adapters/minitest_adapter.rb
+++ b/lib/knapsack_pro/adapters/minitest_adapter.rb
@@ -39,7 +39,7 @@ module KnapsackPro
         ::Minitest::Test.send(:include, BindTimeTrackerMinitestPlugin)
 
         add_post_run_callback do
-          KnapsackPro.logger.info(KnapsackPro::Presenter.global_time)
+          KnapsackPro.logger.debug(KnapsackPro::Presenter.global_time)
         end
       end
 

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -37,7 +37,7 @@ module KnapsackPro
           end
 
           config.after(:suite) do
-            KnapsackPro.logger.info(KnapsackPro::Presenter.global_time)
+            KnapsackPro.logger.debug(KnapsackPro::Presenter.global_time)
           end
         end
       end

--- a/lib/knapsack_pro/adapters/spinach_adapter.rb
+++ b/lib/knapsack_pro/adapters/spinach_adapter.rb
@@ -18,7 +18,7 @@ module KnapsackPro
         end
 
         ::Spinach.hooks.after_run do
-          KnapsackPro.logger.info(KnapsackPro::Presenter.global_time)
+          KnapsackPro.logger.debug(KnapsackPro::Presenter.global_time)
         end
       end
 

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -90,13 +90,13 @@ module KnapsackPro
 
         request_uuid = http_response.header['X-Request-Id']
 
-        logger.info("API request UUID: #{request_uuid}")
-        logger.info("Test suite split seed: #{seed}") if has_seed?
-        logger.info('API response:')
+        logger.debug("API request UUID: #{request_uuid}")
+        logger.debug("Test suite split seed: #{seed}") if has_seed?
+        logger.debug('API response:')
         if errors?
           logger.error(response)
         else
-          logger.info(response)
+          logger.debug(response)
         end
 
         response

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -148,10 +148,12 @@ module KnapsackPro
 
         def log_level
           {
-            'debug' => ::Logger::DEBUG,
-            'info'  => ::Logger::INFO,
+            'fatal'  => ::Logger::FATAL,
+            'error'  => ::Logger::ERROR,
             'warn'  => ::Logger::WARN,
-          }[ENV['KNAPSACK_PRO_LOG_LEVEL']] || ::Logger::INFO
+            'info'  => ::Logger::INFO,
+            'debug' => ::Logger::DEBUG,
+          }[ENV['KNAPSACK_PRO_LOG_LEVEL']] || ::Logger::DEBUG
         end
 
         private

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -153,7 +153,7 @@ module KnapsackPro
             'warn'  => ::Logger::WARN,
             'info'  => ::Logger::INFO,
             'debug' => ::Logger::DEBUG,
-          }[ENV['KNAPSACK_PRO_LOG_LEVEL']] || ::Logger::DEBUG
+          }[ENV['KNAPSACK_PRO_LOG_LEVEL'].to_s.downcase] || ::Logger::DEBUG
         end
 
         private

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -56,7 +56,7 @@ module KnapsackPro
       response = connection.call
       if connection.success?
         raise ArgumentError.new(response) if connection.errors?
-        KnapsackPro.logger.info('Saved time execution report on API server.')
+        KnapsackPro.logger.debug('Saved time execution report on API server.')
       end
     end
 

--- a/spec/knapsack_pro/adapters/base_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/base_adapter_spec.rb
@@ -38,7 +38,7 @@ describe KnapsackPro::Adapters::BaseAdapter do
       it do
         logger = instance_double(Logger)
         expect(KnapsackPro).to receive(:logger).and_return(logger)
-        expect(logger).to receive(:info).with('Test suite time execution recording enabled.')
+        expect(logger).to receive(:debug).with('Test suite time execution recording enabled.')
       end
       it { expect(subject).to receive(:bind_time_tracker) }
       it { expect(subject).to receive(:bind_save_report) }
@@ -55,7 +55,7 @@ describe KnapsackPro::Adapters::BaseAdapter do
       it do
         logger = instance_double(Logger)
         expect(KnapsackPro).to receive(:logger).and_return(logger)
-        expect(logger).to receive(:info).with('Test suite time execution queue recording enabled.')
+        expect(logger).to receive(:debug).with('Test suite time execution queue recording enabled.')
       end
       it { expect(subject).to receive(:bind_time_tracker) }
       it { expect(subject).to receive(:bind_save_queue_report) }

--- a/spec/knapsack_pro/adapters/cucumber_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/cucumber_adapter_spec.rb
@@ -91,7 +91,7 @@ describe KnapsackPro::Adapters::CucumberAdapter do
           expect(::Kernel).to receive(:at_exit).and_yield
           expect(KnapsackPro::Presenter).to receive(:global_time).and_return(global_time)
           expect(KnapsackPro).to receive(:logger).and_return(logger)
-          expect(logger).to receive(:info).with(global_time)
+          expect(logger).to receive(:debug).with(global_time)
 
           subject.bind_time_tracker
         end
@@ -114,7 +114,7 @@ describe KnapsackPro::Adapters::CucumberAdapter do
           expect(::Kernel).to receive(:at_exit).and_yield
           expect(KnapsackPro::Presenter).to receive(:global_time).and_return(global_time)
           expect(KnapsackPro).to receive(:logger).and_return(logger)
-          expect(logger).to receive(:info).with(global_time)
+          expect(logger).to receive(:debug).with(global_time)
 
           subject.bind_time_tracker
         end

--- a/spec/knapsack_pro/adapters/minitest_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/minitest_adapter_spec.rb
@@ -95,7 +95,7 @@ describe KnapsackPro::Adapters::MinitestAdapter do
 
         expect(KnapsackPro::Presenter).to receive(:global_time).and_return(global_time)
         expect(KnapsackPro).to receive(:logger).and_return(logger)
-        expect(logger).to receive(:info).with(global_time)
+        expect(logger).to receive(:debug).with(global_time)
 
         subject.bind_time_tracker
       end

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -96,7 +96,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
 
         expect(KnapsackPro::Presenter).to receive(:global_time).and_return(global_time)
         expect(KnapsackPro).to receive(:logger).and_return(logger)
-        expect(logger).to receive(:info).with(global_time)
+        expect(logger).to receive(:debug).with(global_time)
 
         subject.bind_time_tracker
       end

--- a/spec/knapsack_pro/adapters/spinach_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/spinach_adapter_spec.rb
@@ -42,7 +42,7 @@ describe KnapsackPro::Adapters::SpinachAdapter do
         expect(Spinach.hooks).to receive(:after_run).and_yield
         expect(KnapsackPro::Presenter).to receive(:global_time).and_return(global_time)
         expect(KnapsackPro).to receive(:logger).and_return(logger)
-        expect(logger).to receive(:info).with(global_time)
+        expect(logger).to receive(:debug).with(global_time)
 
         subject.bind_time_tracker
       end

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -52,8 +52,8 @@ describe KnapsackPro::Client::Connection do
 
         before do
           expect(KnapsackPro).to receive(:logger).exactly(3).and_return(logger)
-          expect(logger).to receive(:info).with('API request UUID: fake-uuid')
-          expect(logger).to receive(:info).with('API response:')
+          expect(logger).to receive(:debug).with('API request UUID: fake-uuid')
+          expect(logger).to receive(:debug).with('API response:')
         end
 
         it do
@@ -72,15 +72,15 @@ describe KnapsackPro::Client::Connection do
 
         before do
           expect(KnapsackPro).to receive(:logger).exactly(4).and_return(logger)
-          expect(logger).to receive(:info).with('API request UUID: fake-uuid')
-          expect(logger).to receive(:info).with("Test suite split seed: seed-uuid")
-          expect(logger).to receive(:info).with('API response:')
+          expect(logger).to receive(:debug).with('API request UUID: fake-uuid')
+          expect(logger).to receive(:debug).with("Test suite split seed: seed-uuid")
+          expect(logger).to receive(:debug).with('API response:')
         end
 
         it do
           parsed_response = { 'build_distribution_id' => 'seed-uuid' }
 
-          expect(logger).to receive(:info).with(parsed_response)
+          expect(logger).to receive(:debug).with(parsed_response)
 
           expect(subject).to eq(parsed_response)
           expect(connection.success?).to be true
@@ -93,12 +93,12 @@ describe KnapsackPro::Client::Connection do
 
         before do
           expect(KnapsackPro).to receive(:logger).exactly(3).and_return(logger)
-          expect(logger).to receive(:info).with('API request UUID: fake-uuid')
-          expect(logger).to receive(:info).with('API response:')
+          expect(logger).to receive(:debug).with('API request UUID: fake-uuid')
+          expect(logger).to receive(:debug).with('API response:')
         end
 
         it do
-          expect(logger).to receive(:info).with('')
+          expect(logger).to receive(:debug).with('')
 
           expect(subject).to eq('')
           expect(connection.success?).to be true

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -575,6 +575,12 @@ describe KnapsackPro::Config::Env do
       it { should eql ::Logger::INFO }
     end
 
+    context 'when ENV set with capital letters' do
+      let(:log_level) { 'WARN' }
+      before { stub_const('ENV', { 'KNAPSACK_PRO_LOG_LEVEL' => log_level }) }
+      it { should eql ::Logger::WARN }
+    end
+
     context "when ENV doesn't exist" do
       it { should eql ::Logger::DEBUG }
     end

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -551,14 +551,32 @@ describe KnapsackPro::Config::Env do
   describe '.log_level' do
     subject { described_class.log_level }
 
-    context 'when ENV exists' do
-      let(:log_level) { 'debug' }
+    context 'when ENV set to fatal' do
+      let(:log_level) { 'fatal' }
       before { stub_const('ENV', { 'KNAPSACK_PRO_LOG_LEVEL' => log_level }) }
-      it { should eql ::Logger::DEBUG }
+      it { should eql ::Logger::FATAL }
+    end
+
+    context 'when ENV set to error' do
+      let(:log_level) { 'error' }
+      before { stub_const('ENV', { 'KNAPSACK_PRO_LOG_LEVEL' => log_level }) }
+      it { should eql ::Logger::ERROR }
+    end
+
+    context 'when ENV set to warn' do
+      let(:log_level) { 'warn' }
+      before { stub_const('ENV', { 'KNAPSACK_PRO_LOG_LEVEL' => log_level }) }
+      it { should eql ::Logger::WARN }
+    end
+
+    context 'when ENV set to info' do
+      let(:log_level) { 'info' }
+      before { stub_const('ENV', { 'KNAPSACK_PRO_LOG_LEVEL' => log_level }) }
+      it { should eql ::Logger::INFO }
     end
 
     context "when ENV doesn't exist" do
-      it { should eql ::Logger::INFO }
+      it { should eql ::Logger::DEBUG }
     end
   end
 end

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -130,7 +130,7 @@ describe KnapsackPro::Report do
           it do
             logger = instance_double(Logger)
             expect(KnapsackPro).to receive(:logger).and_return(logger)
-            expect(logger).to receive(:info).with('Saved time execution report on API server.')
+            expect(logger).to receive(:debug).with('Saved time execution report on API server.')
             subject
           end
         end

--- a/spec/knapsack_pro_spec.rb
+++ b/spec/knapsack_pro_spec.rb
@@ -18,7 +18,7 @@ describe KnapsackPro do
 
       before do
         expect(Logger).to receive(:new).with(STDOUT).and_return(logger)
-        expect(logger).to receive(:level=).with(Logger::INFO)
+        expect(logger).to receive(:level=).with(Logger::DEBUG)
         expect(KnapsackPro::LoggerWrapper).to receive(:new).with(logger).and_return(logger_wrapper)
       end
 


### PR DESCRIPTION
* Add supported for log levels `fatal` and `error` by `KNAPSACK_PRO_LOG_LEVEL` environment variable.
* Allow `KNAPSACK_PRO_LOG_LEVEL` case insensitive.
* Move all messages related to requests to Knapsack Pro API in log `debug` level and keep `info` level only for important messages like how to retry tests in development or info why something works this way or the other (for instance why tests were not executed on the CI node).
