### PR TITLE
Add RSpec Queue Formatter to hide duplicated pending and failed tests in Queue Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 * TODO
 
+### 0.33.0
+
+* Add RSpec Queue Formatter to hide duplicated pending and failed tests in Queue Mode
+
+  You can keep duplicated pending/failed summary with flag `KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS`. More can be found in read me.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/31
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.32.0...v0.33.0
+
 ### 0.32.0
 
 * Add encryption for branch names

--- a/README.md
+++ b/README.md
@@ -823,16 +823,18 @@ knapack_pro gem cannot determine the git commit hash and branch name. To fix thi
 
 ##### Why when I use Queue Mode for RSpec and test fails then I see multiple times info about failed test in RSpec result?
 
-RSpec collects information about failed tests and presents it at the end of RSpec result.
+The problem may happen when you use old knapsack_pro `< 0.33.0` or if you use custom rspec formatter, or when you set flag [KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS=false](#knapsack_pro_modify_default_rspec_formatters-hide-duplicated-summary-of-pending-and-failed-tests).
+
 When you use Queue Mode then knapack_pro does multiple requests to Knapsack Pro API and fetches a few test files to execute.
-This means RSpec will remember failed tests so far and it will present them at the end of each executed test subset.
+This means RSpec will remember failed tests so far and it will present them at the end of each executed test subset if flag `KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS=false`.
 You can see the list of all failed test files at the end of knapack_pro queue mode command.
 
 ##### Why when I use Queue Mode for RSpec then I see multiple times the same pending tests?
 
-RSpec collects information about pending tests and presents it at the end of RSpec result.
+The problem may happen when you use old knapsack_pro `< 0.33.0` or if you use custom rspec formatter, or when you set flag [KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS=false](#knapsack_pro_modify_default_rspec_formatters-hide-duplicated-summary-of-pending-and-failed-tests).
+
 When you use Queue Mode then knapack_pro does multiple requests to Knapsack Pro API and fetches a few test files to execute.
-This means RSpec will remember pending tests so far and it will present them at the end of each executed test subset.
+This means RSpec will remember pending tests so far and it will present them at the end of each executed test subset if flag `KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS=false`.
 You can see the list of all pending test files at the end of knapack_pro queue mode command.
 
 ##### Does in Queue Mode the RSpec is initialized many times that causes Rails load over and over again?

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The knapsack_pro has also [queue mode](#queue-mode) to get most optimal test sui
   - [Additional info about queue mode](#additional-info-about-queue-mode)
   - [Extra configuration for Queue Mode](#extra-configuration-for-queue-mode)
     - [KNAPSACK_PRO_FIXED_QUEUE_SPLIT (remember queue split on retry CI node)](#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node)
+    - [KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS (hide duplicated summary of pending and failed tests)](#knapsack_pro_modify_default_rspec_formatters-hide-duplicated-summary-of-pending-and-failed-tests)
   - [Supported test runners in queue mode](#supported-test-runners-in-queue-mode)
 - [Extra configuration for CI server](#extra-configuration-for-ci-server)
   - [Info about ENV variables](#info-about-env-variables)
@@ -413,6 +414,18 @@ There might be some cached test suite splits for git commits you run in past for
        [knapsack_pro] {"queue_name"=>nil, "test_files"=>[{"path"=>"spec/foo_spec.rb", "time_execution"=>1.23}]}
 
   To [reproduce tests executed on CI node](#for-knapsack_pro-queue-mode) in development environment please see FAQ.
+
+#### KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS (hide duplicated summary of pending and failed tests)
+
+* `KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS=true` (default)
+
+  By default, the knapack_pro will monkey patch [RSpec Formatters](https://www.relishapp.com/rspec/rspec-core/v/2-6/docs/command-line/format-option) in order to
+  hide the summary of pending and failed tests after each intermediate run of tests fetched from the work queue on Knapsack Pro API.
+  knapack_pro shows summary of all pending and failed tests at the very end when work queue ended. If you use your custom formatter and you have problem with it then you can disable `KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS=false` monkey patching.
+
+* `KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS=false`
+
+  It causes to show summary of pending and failed tests after each intermediate tests run from the work queue. The summary will grown cumulatively after each intermediate tests run so it means you will see multiple times summary of the same pending/failed tests. It doesn't mean the test files are executed twice. Test files are executed only once. Only summary report grows cumulatively.
 
 ### Supported test runners in queue mode
 

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -76,7 +76,7 @@ module KnapsackPro
         end
 
         def modify_default_rspec_formatters
-          ENV['KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS'] || true
+          ENV.fetch('KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS', true)
         end
 
         def modify_default_rspec_formatters?

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -75,6 +75,14 @@ module KnapsackPro
           test_files_encrypted == 'true'
         end
 
+        def modify_default_rspec_formatters
+          ENV['KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS'] || true
+        end
+
+        def modify_default_rspec_formatters?
+          modify_default_rspec_formatters.to_s == 'true'
+        end
+
         def branch_encrypted
           ENV['KNAPSACK_PRO_BRANCH_ENCRYPTED']
         end

--- a/lib/knapsack_pro/formatters/rspec_queue_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_queue_formatter.rb
@@ -1,0 +1,97 @@
+RSpec::Support.require_rspec_core('formatters/base_formatter')
+RSpec::Support.require_rspec_core('formatters/base_text_formatter')
+
+module KnapsackPro
+  module Formatters
+    module RSpecHideFailuresAndPendingExtension
+      def dump_failures(notification); end
+      def dump_pending(notification); end
+      def dump_summary(summary); end
+    end
+
+    class RSpecQueueFormatter < RSpec::Core::Formatters::BaseFormatter
+      RSpec::Core::Formatters.register self, :dump_failures, :dump_pending
+
+      def self.registered_output=(output)
+        @registered_output = {
+          ENV['KNAPSACK_PRO_QUEUE_ID'] => output
+        }
+      end
+
+      def self.registered_output
+        @registered_output[ENV['KNAPSACK_PRO_QUEUE_ID']]
+      end
+
+      def self.most_recent_failures_summary=(fully_formatted_failed_examples)
+        @most_recent_failures_summary = {
+          ENV['KNAPSACK_PRO_QUEUE_ID'] => fully_formatted_failed_examples
+        }
+      end
+
+      def self.most_recent_failures_summary
+        @most_recent_failures_summary ||= {}
+        @most_recent_failures_summary[ENV['KNAPSACK_PRO_QUEUE_ID']] || []
+      end
+
+      def self.most_recent_pending=(fully_formatted_pending_examples)
+        @most_recent_pending = {
+          ENV['KNAPSACK_PRO_QUEUE_ID'] => fully_formatted_pending_examples
+        }
+      end
+
+      def self.most_recent_pending
+        @most_recent_pending ||= {}
+        @most_recent_pending[ENV['KNAPSACK_PRO_QUEUE_ID']] || []
+      end
+
+      def self.most_recent_summary=(fully_formatted)
+        @most_recent_summary = {
+          ENV['KNAPSACK_PRO_QUEUE_ID'] => fully_formatted
+        }
+      end
+
+      def self.most_recent_summary
+        @most_recent_summary ||= {}
+        @most_recent_summary[ENV['KNAPSACK_PRO_QUEUE_ID']] || []
+      end
+
+      def self.print_summary
+        registered_output.puts('Knapsack Pro Queue finished!')
+        registered_output.puts('')
+
+        unless most_recent_pending.empty?
+          registered_output.puts('All pending tests on this CI node:')
+          registered_output.puts(most_recent_pending)
+        end
+
+        unless most_recent_failures_summary.empty?
+          registered_output.puts('All failed tests on this CI node:')
+          registered_output.puts(most_recent_failures_summary)
+        end
+
+        registered_output.puts(most_recent_summary)
+      end
+
+      def initialize(output)
+        super
+        self.class.registered_output = output
+      end
+
+      def dump_failures(notification)
+        return if notification.failure_notifications.empty?
+        self.class.most_recent_failures_summary = notification.fully_formatted_failed_examples
+      end
+
+      def dump_pending(notification)
+        return if notification.pending_examples.empty?
+        self.class.most_recent_pending = notification.fully_formatted_pending_examples
+      end
+    end
+  end
+end
+
+if KnapsackPro::Config::Env.modify_default_rspec_formatters?
+  class RSpec::Core::Formatters::BaseTextFormatter
+    prepend KnapsackPro::Formatters::RSpecHideFailuresAndPendingExtension
+  end
+end

--- a/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
@@ -9,7 +9,7 @@ module KnapsackPro
       def dump_summary(summary); end
     end
 
-    class RSpecQueueFormatter < RSpec::Core::Formatters::BaseFormatter
+    class RSpecQueueSummaryFormatter < RSpec::Core::Formatters::BaseFormatter
       RSpec::Core::Formatters.register self, :dump_failures, :dump_pending
 
       def self.registered_output=(output)

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -4,6 +4,7 @@ module KnapsackPro
       class RSpecRunner < BaseRunner
         def self.run(args)
           require 'rspec/core'
+          require_relative '../../formatters/rspec_queue_formatter'
 
           ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN'] = KnapsackPro::Config::Env.test_suite_token_rspec
           ENV['KNAPSACK_PRO_QUEUE_RECORDING_ENABLED'] = 'true'
@@ -11,7 +12,12 @@ module KnapsackPro
 
           runner = new(KnapsackPro::Adapters::RSpecAdapter)
 
-          cli_args = (args || '').split + [
+          cli_args = (args || '').split
+          # if user didn't provide the format then use explicitly default progress formatter
+          # in order to avoid KnapsackPro::Formatters::RSpecQueueFormatter being the only default formatter
+          cli_args += ['--format', 'progress'] unless cli_args.include?('--format')
+          cli_args += [
+            '--format', KnapsackPro::Formatters::RSpecQueueFormatter.to_s,
             '--default-path', runner.test_dir,
           ]
           run_tests(runner, true, cli_args, 0, [])
@@ -21,6 +27,8 @@ module KnapsackPro
           test_file_paths = runner.test_file_paths(can_initialize_queue: can_initialize_queue)
 
           if test_file_paths.empty?
+            KnapsackPro::Formatters::RSpecQueueFormatter.print_summary
+
             unless all_test_file_paths.empty?
               cli_args = args + all_test_file_paths
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -4,7 +4,7 @@ module KnapsackPro
       class RSpecRunner < BaseRunner
         def self.run(args)
           require 'rspec/core'
-          require_relative '../../formatters/rspec_queue_formatter'
+          require_relative '../../formatters/rspec_queue_summary_formatter'
 
           ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN'] = KnapsackPro::Config::Env.test_suite_token_rspec
           ENV['KNAPSACK_PRO_QUEUE_RECORDING_ENABLED'] = 'true'
@@ -14,10 +14,10 @@ module KnapsackPro
 
           cli_args = (args || '').split
           # if user didn't provide the format then use explicitly default progress formatter
-          # in order to avoid KnapsackPro::Formatters::RSpecQueueFormatter being the only default formatter
+          # in order to avoid KnapsackPro::Formatters::RSpecQueueSummaryFormatter being the only default formatter
           cli_args += ['--format', 'progress'] unless cli_args.include?('--format')
           cli_args += [
-            '--format', KnapsackPro::Formatters::RSpecQueueFormatter.to_s,
+            '--format', KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s,
             '--default-path', runner.test_dir,
           ]
           run_tests(runner, true, cli_args, 0, [])
@@ -28,7 +28,7 @@ module KnapsackPro
 
           if test_file_paths.empty?
             unless all_test_file_paths.empty?
-              KnapsackPro::Formatters::RSpecQueueFormatter.print_summary
+              KnapsackPro::Formatters::RSpecQueueSummaryFormatter.print_summary
 
               cli_args = args + all_test_file_paths
               log_rspec_command(cli_args, :end_of_queue)

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -27,11 +27,10 @@ module KnapsackPro
           test_file_paths = runner.test_file_paths(can_initialize_queue: can_initialize_queue)
 
           if test_file_paths.empty?
-            KnapsackPro::Formatters::RSpecQueueFormatter.print_summary
-
             unless all_test_file_paths.empty?
-              cli_args = args + all_test_file_paths
+              KnapsackPro::Formatters::RSpecQueueFormatter.print_summary
 
+              cli_args = args + all_test_file_paths
               log_rspec_command(cli_args, :end_of_queue)
             end
 

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -302,6 +302,40 @@ describe KnapsackPro::Config::Env do
     end
   end
 
+  describe '.modify_default_rspec_formatters' do
+    subject { described_class.modify_default_rspec_formatters }
+
+    context 'when ENV exists' do
+      let(:modify_default_rspec_formatters) { 'false' }
+      before { stub_const("ENV", { 'KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS' => modify_default_rspec_formatters }) }
+      it { should eq modify_default_rspec_formatters }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should be true }
+    end
+  end
+
+  describe '.modify_default_rspec_formatters?' do
+    subject { described_class.modify_default_rspec_formatters? }
+
+    before do
+      expect(described_class).to receive(:modify_default_rspec_formatters).and_return(modify_default_rspec_formatters)
+    end
+
+    context 'when enabled' do
+      let(:modify_default_rspec_formatters) { true }
+
+      it { should be true }
+    end
+
+    context 'when disabled' do
+      let(:modify_default_rspec_formatters) { false }
+
+      it { should be false }
+    end
+  end
+
   describe '.branch_encrypted' do
     subject { described_class.branch_encrypted }
 

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -1,4 +1,4 @@
-require KnapsackPro.root + '/lib/knapsack_pro/formatters/rspec_queue_formatter'
+require KnapsackPro.root + '/lib/knapsack_pro/formatters/rspec_queue_summary_formatter'
 
 describe KnapsackPro::Runners::Queue::RSpecRunner do
   describe '.run' do
@@ -32,7 +32,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
         it 'uses default formatter progress' do
           result = double
-          expect(described_class).to receive(:run_tests).with(runner, true, ['--example-arg', 'example-value', '--format', 'progress', '--format', 'KnapsackPro::Formatters::RSpecQueueFormatter', '--default-path', 'fake-test-dir'], 0, []).and_return(result)
+          expect(described_class).to receive(:run_tests).with(runner, true, ['--example-arg', 'example-value', '--format', 'progress', '--format', 'KnapsackPro::Formatters::RSpecQueueSummaryFormatter', '--default-path', 'fake-test-dir'], 0, []).and_return(result)
 
           expect(subject).to eq result
         end
@@ -43,7 +43,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
         it 'uses provided format param instead of default formatter progress' do
           result = double
-          expect(described_class).to receive(:run_tests).with(runner, true, ['--format', 'documentation', '--format', 'KnapsackPro::Formatters::RSpecQueueFormatter', '--default-path', 'fake-test-dir'], 0, []).and_return(result)
+          expect(described_class).to receive(:run_tests).with(runner, true, ['--format', 'documentation', '--format', 'KnapsackPro::Formatters::RSpecQueueSummaryFormatter', '--default-path', 'fake-test-dir'], 0, []).and_return(result)
 
           expect(subject).to eq result
         end
@@ -55,7 +55,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
       it do
         result = double
-        expect(described_class).to receive(:run_tests).with(runner, true, ['--format', 'progress', '--format', 'KnapsackPro::Formatters::RSpecQueueFormatter', '--default-path', 'fake-test-dir'], 0, []).and_return(result)
+        expect(described_class).to receive(:run_tests).with(runner, true, ['--format', 'progress', '--format', 'KnapsackPro::Formatters::RSpecQueueSummaryFormatter', '--default-path', 'fake-test-dir'], 0, []).and_return(result)
 
         expect(subject).to eq result
       end
@@ -104,7 +104,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
         let(:exit_code) { 0 }
 
         it do
-          expect(KnapsackPro::Formatters::RSpecQueueFormatter).to receive(:print_summary)
+          expect(KnapsackPro::Formatters::RSpecQueueSummaryFormatter).to receive(:print_summary)
           expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
           expect(described_class).to receive(:exit).with(exitstatus)
 
@@ -116,7 +116,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
         let(:exit_code) { double }
 
         it do
-          expect(KnapsackPro::Formatters::RSpecQueueFormatter).to receive(:print_summary)
+          expect(KnapsackPro::Formatters::RSpecQueueSummaryFormatter).to receive(:print_summary)
           expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
           expect(described_class).to receive(:exit).with(exit_code)
 
@@ -129,7 +129,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
       let(:test_file_paths) { [] }
 
       it do
-        expect(KnapsackPro::Formatters::RSpecQueueFormatter).to receive(:print_summary)
+        expect(KnapsackPro::Formatters::RSpecQueueSummaryFormatter).to receive(:print_summary)
         expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
         expect(described_class).to receive(:exit).with(exitstatus)
 

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -1,6 +1,13 @@
-require KnapsackPro.root + '/lib/knapsack_pro/formatters/rspec_queue_summary_formatter'
 
 describe KnapsackPro::Runners::Queue::RSpecRunner do
+  before do
+    # we don't want to modify rspec formatters because we want to see tests summary at the end
+    # when you run this test file or whole test suite for the knapsack_pro gem
+    stub_const('ENV', { 'KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS' => false })
+
+    require KnapsackPro.root + '/lib/knapsack_pro/formatters/rspec_queue_summary_formatter'
+  end
+
   describe '.run' do
     let(:test_suite_token_rspec) { 'fake-token' }
     let(:queue_id) { 'fake-queue-id' }
@@ -12,10 +19,6 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
     subject { described_class.run(args) }
 
     before do
-      # we don't want to modify rspec formatters because we want to see tests summary at the end
-      # when you run this test file or whole test suite for the knapsack_pro gem
-      stub_const('ENV', { 'KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS' => false })
-
       expect(KnapsackPro::Config::Env).to receive(:test_suite_token_rspec).and_return(test_suite_token_rspec)
       expect(KnapsackPro::Config::EnvGenerator).to receive(:set_queue_id).and_return(queue_id)
 
@@ -129,7 +132,6 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
       let(:test_file_paths) { [] }
 
       it do
-        expect(KnapsackPro::Formatters::RSpecQueueSummaryFormatter).to receive(:print_summary)
         expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
         expect(described_class).to receive(:exit).with(exitstatus)
 


### PR DESCRIPTION
* Add RSpec queue formatter and show summary of failed and pending tests at the end of queue mode run. 
* Hide pending and failed tests for intermediate tests runs after each fetched test files from Knapsack Pro API. In order to do that we monkey patch default rspec formatters.
* Allow user to disable monkey patching for default rspec formatters with flag `KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS`

Related to: https://github.com/rspec/rspec-core/issues/2416