### PR TITLE
Handle case when start timer was not called (rspec-retry issue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### 0.36.0
 
 * Show messages about not executed test files as warnings in logs.
+* Handle case when start timer was not called (rspec-retry issue).
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/33
 
 https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.35.0...v0.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Show messages about not executed test files as warnings in logs.
 
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.35.0...v0.36.0
+
 ### 0.35.0
 
 * Add `RSpecQueueProfileFormatterExtension` to show profile summary only once at the very end of RSpec Queue Mode output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * TODO
 
+### 0.36.0
+
+* Show messages about not executed test files as warnings in logs.
+
 ### 0.35.0
 
 * Add `RSpecQueueProfileFormatterExtension` to show profile summary only once at the very end of RSpec Queue Mode output.

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -4,7 +4,7 @@ module KnapsackPro
       test_files = KnapsackPro.tracker.to_a
 
       if test_files.empty?
-        KnapsackPro.logger.info("No test files were executed on this CI node. When you use knapsack_pro regular mode then probably reason might be very narrowed tests list - you run only tests with specified tag and there are fewer test files with the tag than node total number.")
+        KnapsackPro.logger.warn("No test files were executed on this CI node. When you use knapsack_pro regular mode then probably reason might be very narrowed tests list - you run only tests with specified tag and there are fewer test files with the tag than node total number.")
       end
 
       create_build_subset(test_files)
@@ -35,7 +35,7 @@ module KnapsackPro
       end
 
       if test_files.empty?
-        KnapsackPro.logger.info("No test files were executed on this CI node. When you use knapsack_pro queue mode then probably reason might be that CI node was started after the test files from the queue were already executed by other CI nodes. That is why this CI node has no test files to execute.")
+        KnapsackPro.logger.warn("No test files were executed on this CI node. When you use knapsack_pro queue mode then probably reason might be that CI node was started after the test files from the queue were already executed by other CI nodes. That is why this CI node has no test files to execute.")
       end
 
       create_build_subset(test_files)

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -18,7 +18,7 @@ module KnapsackPro
     end
 
     def stop_timer
-      @execution_time = now_without_mock_time.to_f - @start_time
+      @execution_time = @start_time ? now_without_mock_time.to_f - @start_time : 0.0
       update_global_time
       update_test_file_time
       @execution_time

--- a/lib/knapsack_pro/version.rb
+++ b/lib/knapsack_pro/version.rb
@@ -1,3 +1,3 @@
 module KnapsackPro
-  VERSION = '0.35.0'
+  VERSION = '0.36.0'
 end

--- a/spec/knapsack_pro/tracker_spec.rb
+++ b/spec/knapsack_pro/tracker_spec.rb
@@ -85,6 +85,22 @@ describe KnapsackPro::Tracker do
       it { expect(tracker.test_files_with_time['b_spec.rb']).to be_within(delta).of(0) }
       it_behaves_like '#to_a'
     end
+
+    # https://github.com/KnapsackPro/knapsack_pro-ruby/issues/32
+    context 'when start timer was not called (rspec-retry issue)' do
+      before do
+        test_paths.each_with_index do |test_path, index|
+          tracker.current_test_path = test_path
+          tracker.stop_timer
+        end
+      end
+
+      it { expect(tracker.global_time).to eq 0 }
+      it { expect(tracker.test_files_with_time.keys.size).to eql 2 }
+      it { expect(tracker.test_files_with_time['a_spec.rb']).to eq 0 }
+      it { expect(tracker.test_files_with_time['b_spec.rb']).to eq 0 }
+      it_behaves_like '#to_a'
+    end
   end
 
   describe '#reset!' do


### PR DESCRIPTION
Related to issue with: rspec-retry
https://github.com/KnapsackPro/knapsack_pro-ruby/issues/32