### PR TITLE
Clear RSpec examples without shared examples in similar way as in RSpec 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 0.42.0
+
+* Clear RSpec examples without shared examples in similar way as in RSpec 3.6.0
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/42
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.41.0...v0.42.0
+
 ### 0.41.0
 
 * Add after subset queue hook and example how to use JUnit formatter in Queue Mode.

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -50,26 +50,7 @@ module KnapsackPro
             exit_code = RSpec::Core::Runner.new(options).run($stderr, $stdout)
             exitstatus = exit_code if exit_code != 0
 
-            if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new('3.6.0')
-              RSpec.clear_examples
-            else
-              # RSpec.world.reset does below in < rspec 3.6.0
-              if RSpec::ExampleGroups.respond_to?(:remove_all_constants)
-                RSpec::ExampleGroups.remove_all_constants
-              else
-                RSpec::ExampleGroups.constants.each do |constant|
-                  RSpec::ExampleGroups.__send__(:remove_const, constant)
-                end
-              end
-              RSpec.world.example_groups.clear
-
-              # it simulates behavior of RSpec.configuration.reset_reporter from rspec >= 3.6.0
-              RSpec.configuration.instance_variable_set(:@reporter, nil)
-              RSpec.configuration.instance_variable_set(:@formatter_loader, nil)
-
-              RSpec.configuration.start_time = ::RSpec::Core::Time.now
-              RSpec.configuration.reset_filters
-            end
+            rspec_clear_examples
 
             KnapsackPro::Hooks::Queue.call_after_subset_queue
 
@@ -94,6 +75,23 @@ module KnapsackPro
             "bundle exec rspec #{stringify_cli_args} " +
             KnapsackPro::TestFilePresenter.stringify_paths(test_file_paths)
           )
+        end
+
+        # Clear rspec examples without the shared examples:
+        # https://github.com/rspec/rspec-core/pull/2379
+        #
+        # Keep formatters and report to accumulate info about failed/pending tests
+        def self.rspec_clear_examples
+          if RSpec::ExampleGroups.respond_to?(:remove_all_constants)
+            RSpec::ExampleGroups.remove_all_constants
+          else
+            RSpec::ExampleGroups.constants.each do |constant|
+              RSpec::ExampleGroups.__send__(:remove_const, constant)
+            end
+          end
+          RSpec.world.example_groups.clear
+          RSpec.configuration.start_time = ::RSpec::Core::Time.now
+          RSpec.configuration.reset_filters
         end
       end
     end

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -97,7 +97,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
         expect(RSpec::Core::Runner).to receive(:new).with(options).and_return(rspec_core_runner)
         expect(rspec_core_runner).to receive(:run).with($stderr, $stdout).and_return(exit_code)
 
-        expect(RSpec).to receive_message_chain(:world, :example_groups, :clear)
+        expect(described_class).to receive(:rspec_clear_examples)
 
         expect(KnapsackPro::Hooks::Queue).to receive(:call_after_subset_queue)
 


### PR DESCRIPTION
This should fix Queue Mode for RSpec. This change is based on changes introduced in RSpec 3.6.0

https://github.com/rspec/rspec-core/pull/2379

# General context

* `RSpec.clear_examples` in rspec 3.6.0 clears examples __without__ shared examples. That's good because we want to have loaded shared examples between rspec runs.

* `RSpec.clear_examples` in rspec < 3.6.0 clears examples __and__ shared examples. That's bad because the tests fails because shared examples are not loaded.

`RSpec.clear_examples` does an additional thing which is cleared formatters and report. We don't want that because we want to accumulate info about failed/pending tests so we can show at the very end of Queue Mode output the info about summary of tests (what failed and what's pending).

# Solution

Instead of using `RSpec.clear_examples` we do exactly the same thing as the `RSpec.clear_examples` method in rspec 3.6.0 except we don't clear formatters and report. 



