### PR TITLE
Add ability to set test_dir using an environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 0.44.0
+
+* Add ability to set test_dir using an environment variable.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/45
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.43.0...v0.44.0
+
 ### 0.43.0
 
 * Extract correct test directory from test file pattern that has multiple patterns.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The knapsack_pro has also [queue mode](#queue-mode) to get an optimal test suite
     - [How to call `before(:suite)` and `after(:suite)` RSpec hooks only once in Queue Mode?](#how-to-call-beforesuite-and-aftersuite-rspec-hooks-only-once-in-queue-mode)
     - [How to run knapsack_pro with parallel_tests gem?](#how-to-run-knapsack_pro-with-parallel_tests-gem)
     - [How to retry failed tests (flaky tests)?](#how-to-retry-failed-tests-flaky-tests)
+    - [How can I run tests from multiple directories?](#how-can-i-run-tests-from-multiple-directories)
   - [Questions around data usage and security](#questions-around-data-usage-and-security)
     - [What data is sent to your servers?](#what-data-is-sent-to-your-servers)
     - [How is that data secured?](#how-is-that-data-secured)
@@ -1314,6 +1315,24 @@ bundle exec rake knapsack_pro:queue:rspec
 
 # run only failed tests from tmp/rspec_examples.txt
 bundle exec rspec --only-failures
+```
+
+#### How can I run tests from multiple directories?
+
+The test file pattern config option supports any glob pattern handled by [`Dir.glob`](http://ruby-doc.org/core-2.4.1/Dir.html#method-c-glob) and can be configured to pull test files from multiple directories. An example of this when using RSpec would be `"{spec,engines/**/spec}/**{,/*/**}/*_spec.rb"`. For complex cases like this, the test directory can't be extracted and must be specified manually using the `KNAPSACK_PRO_TEST_DIR` environment variable:
+
+```
+$ KNAPSACK_PRO_TEST_DIR=spec KNAPSACK_PRO_TEST_FILE_PATTERN="{spec,engines/**/spec}/**{,/*/**}/*_spec.rb" bundle exec rake knapsack_pro:queue:rspec
+```
+
+`KNAPSACK_PRO_TEST_DIR` will be your default path for rspec so you should put there your `spec_helper.rb`. Please ensure you will require it in your test files this way:
+
+```ruby
+# good
+require_relative 'spec_helper'
+
+# bad - won't work
+require 'spec_helper'
 ```
 
 ### Questions around data usage and security

--- a/README.md
+++ b/README.md
@@ -1319,13 +1319,24 @@ bundle exec rspec --only-failures
 
 #### How can I run tests from multiple directories?
 
-The test file pattern config option supports any glob pattern handled by [`Dir.glob`](http://ruby-doc.org/core-2.4.1/Dir.html#method-c-glob) and can be configured to pull test files from multiple directories. An example of this when using RSpec would be `"{spec,engines/**/spec}/**{,/*/**}/*_spec.rb"`. For complex cases like this, the test directory can't be extracted and must be specified manually using the `KNAPSACK_PRO_TEST_DIR` environment variable:
+The test file pattern config option supports any glob pattern handled by [`Dir.glob`](http://ruby-doc.org/core-2.4.1/Dir.html#method-c-glob) and can be configured to pull test files from multiple directories. An example of this when using RSpec would be `""{spec,engines/*/spec}/**/*_spec.rb" "`. For complex cases like this, the test directory can't be extracted and must be specified manually using the `KNAPSACK_PRO_TEST_DIR` environment variable:
 
 ```
-$ KNAPSACK_PRO_TEST_DIR=spec KNAPSACK_PRO_TEST_FILE_PATTERN="{spec,engines/**/spec}/**{,/*/**}/*_spec.rb" bundle exec rake knapsack_pro:queue:rspec
+# This is example where you have in engines directory multiple projects
+# and each project directory has a spec folder and you would like to run tests for it.
+# You want to use the spec_helper from the main spec directory.
+#
+# Tree:
+# * spec
+# * engines
+#   * project_a
+#     * spec
+#   * project_b
+#     * spec
+$ KNAPSACK_PRO_TEST_DIR=spec KNAPSACK_PRO_TEST_FILE_PATTERN="{spec,engines/*/spec}/**/*_spec.rb" bundle exec rake knapsack_pro:queue:rspec
 ```
 
-`KNAPSACK_PRO_TEST_DIR` will be your default path for rspec so you should put there your `spec_helper.rb`. Please ensure you will require it in your test files this way:
+`KNAPSACK_PRO_TEST_DIR` will be your default path for rspec so you should put there your `spec_helper.rb`. Please ensure you will require it in your test files this way if something doesn't work:
 
 ```ruby
 # good

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -9,7 +9,7 @@ module KnapsackPro
     end
 
     def test_dir
-      test_file_pattern.split('/').first.gsub(/({)/, '')
+      KnapsackPro::Config::Env.test_dir || test_file_pattern.split('/').first.gsub(/({)/, '')
     end
 
     private

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -39,6 +39,10 @@ module KnapsackPro
           ENV['KNAPSACK_PRO_TEST_FILE_PATTERN']
         end
 
+        def test_dir
+          ENV['KNAPSACK_PRO_TEST_DIR']
+        end
+
         def repository_adapter
           ENV['KNAPSACK_PRO_REPOSITORY_ADAPTER']
         end

--- a/spec/knapsack_pro/base_allocator_builder_spec.rb
+++ b/spec/knapsack_pro/base_allocator_builder_spec.rb
@@ -14,19 +14,33 @@ describe KnapsackPro::BaseAllocatorBuilder do
     subject { allocator_builder.test_dir }
 
     before do
-      expect(KnapsackPro::TestFilePattern).to receive(:call).with(adapter_class).and_return(test_file_pattern)
+      expect(KnapsackPro::Config::Env).to receive(:test_dir).and_return(test_dir)
     end
 
-    context 'when single pattern' do
-      let(:test_file_pattern) { 'spec/**{,/*/**}/*_spec.rb' }
+    context 'when test_dir is defined in ENV' do
+      let(:test_dir) { double }
 
-      it { should eq 'spec' }
+      it { should eq test_dir }
     end
 
-    context 'when multiple patterns' do
-      let(:test_file_pattern) { '{spec/controllers/**/*.rb,spec/decorators/**/*.rb}' }
+    context 'when test_dir is not defined in ENV' do
+      let(:test_dir) { nil }
 
-      it { should eq 'spec' }
+      before do
+        expect(KnapsackPro::TestFilePattern).to receive(:call).with(adapter_class).and_return(test_file_pattern)
+      end
+
+      context 'when single pattern' do
+        let(:test_file_pattern) { 'spec/**{,/*/**}/*_spec.rb' }
+
+        it { should eq 'spec' }
+      end
+
+      context 'when multiple patterns' do
+        let(:test_file_pattern) { '{spec/controllers/**/*.rb,spec/decorators/**/*.rb}' }
+
+        it { should eq 'spec' }
+      end
     end
   end
 end

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -153,6 +153,20 @@ describe KnapsackPro::Config::Env do
     end
   end
 
+  describe '.test_dir' do
+    subject { described_class.test_dir }
+
+    context 'when ENV exists' do
+      let(:test_dir) { 'spec' }
+      before { stub_const("ENV", { 'KNAPSACK_PRO_TEST_DIR' => test_dir }) }
+      it { should eql test_dir }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should be_nil }
+    end
+  end
+
   describe '.repository_adapter' do
     subject { described_class.repository_adapter }
 


### PR DESCRIPTION
* Add KNAPSACK_PRO_TEST_DIR and support for it
* Run tests from multiple directories 

This is based on PR: https://github.com/ArturT/knapsack/pull/35