### PR TITLE
Add before and after queue hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 0.45.0
+
+* Add before and after queue hooks
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/46
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.44.0...v0.45.0
+
 ### 0.44.0
 
 * Add ability to set test_dir using an environment variable.

--- a/lib/knapsack_pro/adapters/base_adapter.rb
+++ b/lib/knapsack_pro/adapters/base_adapter.rb
@@ -19,6 +19,7 @@ module KnapsackPro
 
         if KnapsackPro::Config::Env.queue_recording_enabled?
           KnapsackPro.logger.debug('Test suite time execution queue recording enabled.')
+          bind_before_queue_hook
           bind_time_tracker
           bind_save_queue_report
         end
@@ -33,6 +34,10 @@ module KnapsackPro
       end
 
       def bind_save_queue_report
+        raise NotImplementedError
+      end
+
+      def bind_before_queue_hook
         raise NotImplementedError
       end
     end

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -57,6 +57,17 @@ module KnapsackPro
           end
         end
       end
+
+      def bind_before_queue_hook
+        ::RSpec.configure do |config|
+          config.before(:suite) do
+            unless ENV['KNAPSACK_PRO_BEFORE_QUEUE_HOOK_CALLED']
+              KnapsackPro::Hooks::Queue.call_before_queue
+              ENV['KNAPSACK_PRO_BEFORE_QUEUE_HOOK_CALLED'] = 'true'
+            end
+          end
+        end
+      end
     end
 
     # This is added to provide backwards compatibility

--- a/lib/knapsack_pro/hooks/queue.rb
+++ b/lib/knapsack_pro/hooks/queue.rb
@@ -2,14 +2,39 @@ module KnapsackPro
   module Hooks
     class Queue
       class << self
-        attr_reader :after_subset_queue
+        attr_reader :before_queue,
+          :after_subset_queue,
+          :after_queue
+
+        def reset_before_queue
+          @before_queue = nil
+        end
 
         def reset_after_subset_queue
           @after_subset_queue = nil
         end
 
+        def reset_after_queue
+          @after_queue = nil
+        end
+
+        def before_queue(&block)
+          @before_queue ||= block
+        end
+
         def after_subset_queue(&block)
           @after_subset_queue ||= block
+        end
+
+        def after_queue(&block)
+          @after_queue ||= block
+        end
+
+        def call_before_queue
+          return unless before_queue
+          before_queue.call(
+            KnapsackPro::Config::Env.queue_id
+          )
         end
 
         def call_after_subset_queue
@@ -17,6 +42,13 @@ module KnapsackPro
           after_subset_queue.call(
             KnapsackPro::Config::Env.queue_id,
             KnapsackPro::Config::Env.subset_queue_id
+          )
+        end
+
+        def call_after_queue
+          return unless after_queue
+          after_queue.call(
+            KnapsackPro::Config::Env.queue_id
           )
         end
       end

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -27,8 +27,6 @@ module KnapsackPro
         def self.run_tests(runner, can_initialize_queue, args, exitstatus, all_test_file_paths)
           test_file_paths = runner.test_file_paths(can_initialize_queue: can_initialize_queue)
 
-          KnapsackPro::Hooks::Queue.call_before_queue if can_initialize_queue
-
           if test_file_paths.empty?
             unless all_test_file_paths.empty?
               KnapsackPro::Formatters::RSpecQueueSummaryFormatter.print_summary

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -27,6 +27,8 @@ module KnapsackPro
         def self.run_tests(runner, can_initialize_queue, args, exitstatus, all_test_file_paths)
           test_file_paths = runner.test_file_paths(can_initialize_queue: can_initialize_queue)
 
+          KnapsackPro::Hooks::Queue.call_before_queue if can_initialize_queue
+
           if test_file_paths.empty?
             unless all_test_file_paths.empty?
               KnapsackPro::Formatters::RSpecQueueSummaryFormatter.print_summary
@@ -34,6 +36,8 @@ module KnapsackPro
 
               log_rspec_command(args, all_test_file_paths, :end_of_queue)
             end
+
+            KnapsackPro::Hooks::Queue.call_after_queue
 
             KnapsackPro::Report.save_node_queue_to_api
             exit(exitstatus)

--- a/spec/knapsack_pro/adapters/base_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/base_adapter_spec.rb
@@ -48,6 +48,7 @@ describe KnapsackPro::Adapters::BaseAdapter do
       let(:queue_recording_enabled?) { true }
 
       before do
+        allow(subject).to receive(:bind_before_queue_hook)
         allow(subject).to receive(:bind_time_tracker)
         allow(subject).to receive(:bind_save_queue_report)
       end
@@ -57,6 +58,7 @@ describe KnapsackPro::Adapters::BaseAdapter do
         expect(KnapsackPro).to receive(:logger).and_return(logger)
         expect(logger).to receive(:debug).with('Test suite time execution queue recording enabled.')
       end
+      it { expect(subject).to receive(:bind_before_queue_hook) }
       it { expect(subject).to receive(:bind_time_tracker) }
       it { expect(subject).to receive(:bind_save_queue_report) }
     end
@@ -65,6 +67,7 @@ describe KnapsackPro::Adapters::BaseAdapter do
       it { expect(subject).not_to receive(:bind_time_tracker) }
       it { expect(subject).not_to receive(:bind_save_report) }
       it { expect(subject).not_to receive(:bind_save_queue_report) }
+      it { expect(subject).not_to receive(:bind_before_queue_hook) }
     end
   end
 
@@ -88,6 +91,14 @@ describe KnapsackPro::Adapters::BaseAdapter do
     it do
       expect {
         subject.bind_save_queue_report
+      }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#bind_before_queue_hook' do
+    it do
+      expect {
+        subject.bind_before_queue_hook
       }.to raise_error(NotImplementedError)
     end
   end

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -123,5 +123,16 @@ describe KnapsackPro::Adapters::RSpecAdapter do
         subject.bind_save_queue_report
       end
     end
+
+    describe '#bind_before_queue_hook' do
+      it do
+        expect(config).to receive(:before).with(:suite).and_yield
+        expect(::RSpec).to receive(:configure).and_yield(config)
+
+        expect(KnapsackPro::Hooks::Queue).to receive(:call_before_queue)
+
+        subject.bind_before_queue_hook
+      end
+    end
   end
 end

--- a/spec/knapsack_pro/hooks/queue_spec.rb
+++ b/spec/knapsack_pro/hooks/queue_spec.rb
@@ -1,4 +1,30 @@
 describe KnapsackPro::Hooks::Queue do
+  describe '.call_before_queue' do
+    subject { described_class.call_before_queue }
+
+    context 'when callback is not set' do
+      before do
+        described_class.reset_before_queue
+      end
+
+      it { should be_nil }
+    end
+
+    context 'when callback is set' do
+      let(:queue_id) { double }
+
+      before do
+        expect(KnapsackPro::Config::Env).to receive(:queue_id).and_return(queue_id)
+
+        described_class.before_queue do |q_id|
+          [:fake_value, q_id]
+        end
+      end
+
+      it { should eq [:fake_value, queue_id] }
+    end
+  end
+
   describe '.call_after_subset_queue' do
     subject { described_class.call_after_subset_queue }
 
@@ -24,6 +50,32 @@ describe KnapsackPro::Hooks::Queue do
       end
 
       it { should eq [:fake_value, queue_id, subset_queue_id] }
+    end
+  end
+
+  describe '.call_after_queue' do
+    subject { described_class.call_after_queue }
+
+    context 'when callback is not set' do
+      before do
+        described_class.reset_after_queue
+      end
+
+      it { should be_nil }
+    end
+
+    context 'when callback is set' do
+      let(:queue_id) { double }
+
+      before do
+        expect(KnapsackPro::Config::Env).to receive(:queue_id).and_return(queue_id)
+
+        described_class.after_queue do |q_id|
+          [:fake_value, q_id]
+        end
+      end
+
+      it { should eq [:fake_value, queue_id] }
     end
   end
 end

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -75,6 +75,8 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
     before do
       expect(runner).to receive(:test_file_paths).with(can_initialize_queue: can_initialize_queue).and_return(test_file_paths)
+
+      expect(KnapsackPro::Hooks::Queue).to receive(:call_before_queue)
     end
 
     context 'when test files exist' do
@@ -136,6 +138,8 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
       let(:test_file_paths) { [] }
 
       it do
+        expect(KnapsackPro::Hooks::Queue).to receive(:call_after_queue)
+
         expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
         expect(described_class).to receive(:exit).with(exitstatus)
 

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -75,8 +75,6 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
     before do
       expect(runner).to receive(:test_file_paths).with(can_initialize_queue: can_initialize_queue).and_return(test_file_paths)
-
-      expect(KnapsackPro::Hooks::Queue).to receive(:call_before_queue)
     end
 
     context 'when test files exist' do


### PR DESCRIPTION
Add a way to defined before queue hook and after queue hook in Knapsack Pro Queue Mode.

```ruby
# spec_helper.rb or rails_helper.rb

KnapsackPro::Hooks::Queue.before_queue do |queue_id|
  # This will be called only once before the tests started on the CI node.
  # It will be run inside of the RSpec before(:suite) block only once.
  # It means you will have access to whatever RSpec provides in the context of the before(:suite) block.
end

KnapsackPro::Hooks::Queue.after_queue do |queue_id|
  # This will be called only once after test suite is completed.
  # Note this hook won't be called inside of RSpec after(:suite) block because
  # we are not able to determine which after(:suite) block will be called as the last one
  # due to the fact the Knapsack Pro Queue Mode allocates tests in dynamic way.
end
```


Context:
* The before queue hook is run in context of the `RSpec.before(:suite)` so you have access to whatever method RSpec provides.
* The after queue hook is run outside of `RSpec.after(:suite)` context due to the fact we know when the queue is ended only when all tests fetched from Knapsack Pro API are executed hence we are not able to define `RSpec.after(:suite)` before the last run of a subset of tests from the work queue because we don't know which subset will be the last one. 

Here is related PR with after subset queue hook: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/41