### PR TITLE
Autoload knapsack_pro rake tasks with Rails Railties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 0.46.0
+
+* Autoload knapsack_pro rake tasks with Rails Railties
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/47
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.45.0...v0.46.0
+
 ### 0.45.0
 
 * Add before and after queue hooks

--- a/README.md
+++ b/README.md
@@ -159,12 +159,16 @@ end
 
 And then execute:
 
-    $ bundle install
+```
+$ bundle install
+```
 
-
-Add this line at the bottom of `Rakefile` if your project has one:
+If you are not using Rails then add this line at the bottom of `Rakefile`:
 
 ```ruby
+# Add this only if you are not using Rails.
+# If you use Rails then knapsack_pro rake tasks are already loaded
+# so there is no need to explicitly load them.
 KnapsackPro.load_tasks if defined?(KnapsackPro)
 ```
 

--- a/lib/knapsack_pro.rb
+++ b/lib/knapsack_pro.rb
@@ -61,6 +61,8 @@ require_relative 'knapsack_pro/crypto/branch_encryptor'
 require_relative 'knapsack_pro/crypto/decryptor'
 require_relative 'knapsack_pro/crypto/digestor'
 
+require 'knapsack_pro/railtie' if defined?(Rails::Railtie)
+
 module KnapsackPro
   class << self
     def root

--- a/lib/knapsack_pro/railtie.rb
+++ b/lib/knapsack_pro/railtie.rb
@@ -1,0 +1,10 @@
+require 'rails'
+require 'knapsack_pro'
+
+module KnapsackPro
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      KnapsackPro.load_tasks
+    end
+  end
+end


### PR DESCRIPTION
If you use Rails then knapsack_pro can autoload knapsack_pro rake tasks.
Thanks to that you don't need to modify Rakefile in your project.

Example how other gems load rake tasks:
https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed_job.rb#L20
https://github.com/bugsnag/bugsnag-ruby/blob/master/lib/bugsnag.rb#L124

Related change in docs: TODO