### PR TITLE
Add in Queue Mode the RSpec summary with info about examples, failures and pending tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 * TODO
 
+### 0.47.0
+
+* Add in Queue Mode the RSpec summary with info about examples, failures and pending tests.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/48
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.46.0...v0.47.0
+
 ### 0.46.0
 
-* Autoload knapsack_pro rake tasks with Rails Railties
+* Autoload knapsack_pro rake tasks with Rails Railties.
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/47
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 0.47.0
 
 * Add in Queue Mode the RSpec summary with info about examples, failures and pending tests.
+* Fix not working message `Global time execution for tests` at end of each subset of tests from work queue.
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/48
 

--- a/lib/knapsack_pro/adapters/base_adapter.rb
+++ b/lib/knapsack_pro/adapters/base_adapter.rb
@@ -19,6 +19,7 @@ module KnapsackPro
 
         if KnapsackPro::Config::Env.queue_recording_enabled?
           KnapsackPro.logger.debug('Test suite time execution queue recording enabled.')
+          bind_tracker_reset
           bind_before_queue_hook
           bind_time_tracker
           bind_save_queue_report
@@ -34,6 +35,10 @@ module KnapsackPro
       end
 
       def bind_save_queue_report
+        raise NotImplementedError
+      end
+
+      def bind_tracker_reset
         raise NotImplementedError
       end
 

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -58,6 +58,14 @@ module KnapsackPro
         end
       end
 
+      def bind_tracker_reset
+        ::RSpec.configure do |config|
+          config.before(:suite) do
+            KnapsackPro.tracker.reset!
+          end
+        end
+      end
+
       def bind_before_queue_hook
         ::RSpec.configure do |config|
           config.before(:suite) do

--- a/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
@@ -10,7 +10,7 @@ module KnapsackPro
     end
 
     class RSpecQueueSummaryFormatter < RSpec::Core::Formatters::BaseFormatter
-      RSpec::Core::Formatters.register self, :dump_failures, :dump_pending
+      RSpec::Core::Formatters.register self, :dump_summary, :dump_failures, :dump_pending
 
       def self.registered_output=(output)
         @registered_output = {
@@ -85,6 +85,10 @@ module KnapsackPro
       def dump_pending(notification)
         return if notification.pending_examples.empty?
         self.class.most_recent_pending = notification.fully_formatted_pending_examples
+      end
+
+      def dump_summary(summary)
+        self.class.most_recent_summary = summary.fully_formatted
       end
     end
   end

--- a/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
@@ -88,7 +88,18 @@ module KnapsackPro
       end
 
       def dump_summary(summary)
-        self.class.most_recent_summary = summary.fully_formatted
+        colorizer = ::RSpec::Core::Formatters::ConsoleCodes
+        duration = KnapsackPro.tracker.global_time
+        formatted_duration = ::RSpec::Core::Formatters::Helpers.format_duration(duration)
+
+        formatted = "\nFinished in #{formatted_duration}\n" \
+          "#{summary.colorized_totals_line(colorizer)}\n"
+
+        unless summary.failed_examples.empty?
+          formatted += (summary.colorized_rerun_commands(colorizer) + "\n")
+        end
+
+        self.class.most_recent_summary = formatted
       end
     end
   end

--- a/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
@@ -89,7 +89,7 @@ module KnapsackPro
 
       def dump_summary(summary)
         colorizer = ::RSpec::Core::Formatters::ConsoleCodes
-        duration = KnapsackPro.tracker.global_time
+        duration = KnapsackPro.tracker.global_time_since_beginning
         formatted_duration = ::RSpec::Core::Formatters::Helpers.format_duration(duration)
 
         formatted = "\nFinished in #{formatted_duration}\n" \

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -12,7 +12,6 @@ module KnapsackPro
 
     def self.save_subset_queue_to_file
       test_files = KnapsackPro.tracker.to_a
-      KnapsackPro.tracker.reset!
 
       subset_queue_id = KnapsackPro::Config::Env.subset_queue_id
 

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -2,10 +2,11 @@ module KnapsackPro
   class Tracker
     include Singleton
 
-    attr_reader :global_time, :test_files_with_time
+    attr_reader :global_time_since_beginning, :global_time, :test_files_with_time
     attr_writer :current_test_path
 
     def initialize
+      @global_time_since_beginning = 0
       set_defaults
     end
 
@@ -18,10 +19,10 @@ module KnapsackPro
     end
 
     def stop_timer
-      @execution_time = @start_time ? now_without_mock_time.to_f - @start_time : 0.0
-      update_global_time
-      update_test_file_time
-      @execution_time
+      execution_time = @start_time ? now_without_mock_time.to_f - @start_time : 0.0
+      update_global_time(execution_time)
+      update_test_file_time(execution_time)
+      execution_time
     end
 
     def current_test_path
@@ -48,13 +49,14 @@ module KnapsackPro
       @test_path = nil
     end
 
-    def update_global_time
-      @global_time += @execution_time
+    def update_global_time(execution_time)
+      @global_time += execution_time
+      @global_time_since_beginning += execution_time
     end
 
-    def update_test_file_time
+    def update_test_file_time(execution_time)
       @test_files_with_time[current_test_path] ||= 0
-      @test_files_with_time[current_test_path] += @execution_time
+      @test_files_with_time[current_test_path] += execution_time
     end
 
     def now_without_mock_time

--- a/spec/knapsack_pro/adapters/base_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/base_adapter_spec.rb
@@ -95,6 +95,14 @@ describe KnapsackPro::Adapters::BaseAdapter do
     end
   end
 
+  describe '#bind_tracker_reset' do
+    it do
+      expect {
+        subject.bind_tracker_reset
+      }.to raise_error(NotImplementedError)
+    end
+  end
+
   describe '#bind_before_queue_hook' do
     it do
       expect {

--- a/spec/knapsack_pro/adapters/base_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/base_adapter_spec.rb
@@ -48,6 +48,7 @@ describe KnapsackPro::Adapters::BaseAdapter do
       let(:queue_recording_enabled?) { true }
 
       before do
+        allow(subject).to receive(:bind_tracker_reset)
         allow(subject).to receive(:bind_before_queue_hook)
         allow(subject).to receive(:bind_time_tracker)
         allow(subject).to receive(:bind_save_queue_report)
@@ -58,12 +59,14 @@ describe KnapsackPro::Adapters::BaseAdapter do
         expect(KnapsackPro).to receive(:logger).and_return(logger)
         expect(logger).to receive(:debug).with('Test suite time execution queue recording enabled.')
       end
+      it { expect(subject).to receive(:bind_tracker_reset) }
       it { expect(subject).to receive(:bind_before_queue_hook) }
       it { expect(subject).to receive(:bind_time_tracker) }
       it { expect(subject).to receive(:bind_save_queue_report) }
     end
 
     context 'when recording disabled' do
+      it { expect(subject).not_to receive(:bind_tracker_reset) }
       it { expect(subject).not_to receive(:bind_time_tracker) }
       it { expect(subject).not_to receive(:bind_save_report) }
       it { expect(subject).not_to receive(:bind_save_queue_report) }

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -124,6 +124,19 @@ describe KnapsackPro::Adapters::RSpecAdapter do
       end
     end
 
+    describe '#bind_tracker_reset' do
+      it do
+        expect(config).to receive(:before).with(:suite).and_yield
+        expect(::RSpec).to receive(:configure).and_yield(config)
+
+        tracker = instance_double(KnapsackPro::Tracker)
+        expect(KnapsackPro).to receive(:tracker).and_return(tracker)
+        expect(tracker).to receive(:reset!)
+
+        subject.bind_tracker_reset
+      end
+    end
+
     describe '#bind_before_queue_hook' do
       it do
         expect(config).to receive(:before).with(:suite).and_yield

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -20,8 +20,7 @@ describe KnapsackPro::Report do
     before do
       test_files = [{path: fake_path}]
       tracker = instance_double(KnapsackPro::Tracker, to_a: test_files)
-      expect(KnapsackPro).to receive(:tracker).twice.and_return(tracker)
-      expect(tracker).to receive(:reset!)
+      expect(KnapsackPro).to receive(:tracker).and_return(tracker)
 
       subset_queue_id = 'fake-subset-queue-id'
       expect(KnapsackPro::Config::Env).to receive(:subset_queue_id).and_return(subset_queue_id)

--- a/spec/knapsack_pro/tracker_spec.rb
+++ b/spec/knapsack_pro/tracker_spec.rb
@@ -114,5 +114,9 @@ describe KnapsackPro::Tracker do
     end
 
     it_behaves_like 'default trakcer attributes'
+
+    it "global time since beginning won't be reset" do
+      expect(tracker.global_time_since_beginning).to be >= 0.1
+    end
   end
 end


### PR DESCRIPTION
This PR changes a few related things:

# Add in Queue Mode the RSpec summary with info about examples, failures and pending tests
Example summary output from normal RSpec.

```
Finished in 0.01862 seconds (files took 0.11808 seconds to load)
23 examples, 3 failures, 2 pending

Failed examples:

rspec ./spec/features/calculator_spec.rb:7 # Calculator when try to add without provided numbers result is 0
rspec ./spec/bar_spec.rb:2 # Bar should equal false
rspec ./spec/foo_spec.rb:2 # Foo should equal false
```

This is what RSpec output will look like in Queue Mode thanks to this PR.
Note there is missing part `(files took 0.11808 seconds to load)`. It's on purpose because there is multiple intermediates reloads of test examples. We don't track the total load time in Queue Mode.

```
Finished in 0.01862 seconds
23 examples, 3 failures, 2 pending

Failed examples:

rspec ./spec/features/calculator_spec.rb:7 # Calculator when try to add without provided numbers result is 0
rspec ./spec/bar_spec.rb:2 # Bar should equal false
rspec ./spec/foo_spec.rb:2 # Foo should equal false
```

# Fix problem with always 0 value for gobal time execution log
Here is how fixed log about global time looks like now in Queue Mode.

```
D, [2017-08-13T14:57:03.726424 #67351] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.002721071243286133s
```

# Introduced `global_time_since_beginning`
We added a way to track global time execution since tracker object creation. Thanks to that we can in Queue Mode track the total global time across intermediates runs of a subset of tests from work queue.
We show `KnapsackPro.tracker.global_time_since_beginning` in RSpec summary output for Queue Mode.