### PR TITLE
Fallback mode for Queue Mode when Knapsack Pro API doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 0.48.0
+
+* Fallback mode for Queue Mode when Knapsack Pro API doesn't work.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/49
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.47.0...v0.48.0
+
 ### 0.47.0
 
 * Add in Queue Mode the RSpec summary with info about examples, failures and pending tests.

--- a/README.md
+++ b/README.md
@@ -1014,11 +1014,11 @@ There are a few ways to reproduce tests executed on CI node in your development 
 
 ##### for knapack_pro regular mode
 
-knapack_pro gem will retry requests to Knapsack Pro API multiple times every few seconds til it switch to fallback behaviour and it will split test files across CI nodes based on popular test directory names.
+knapack_pro gem will retry requests to Knapsack Pro API multiple times every few seconds til it switch to fallback behavior and it will split test files across CI nodes based on popular test directory names. When knapack_pro starts fallback mode then you will see a warning in the output.
 
 ##### for knapsack_pro queue mode
 
-knapack_pro gem will retry requests to Knapsack Pro API multiple times every few seconds til it fails.
+knapack_pro gem will retry requests to Knapsack Pro API multiple times every few seconds till it switches to fallback behavior and it will split test files across CI nodes based on popular test directory names. Note that if one of CI nodes will lose connection to Knapsack Pro API but other not then you may see that some of the test files will be executed on multiple CI nodes. Fallback mode guarantees each of test files is run at least once across CI nodes. Thanks to that we know if the whole test suite is green or not. When knapack_pro starts fallback mode then you will see a warning in the output.
 
 #### How can I change log level?
 

--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -14,7 +14,7 @@ module KnapsackPro
         raise ArgumentError.new(response) if connection.errors?
         prepare_test_files(response)
       else
-        KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby")
+        KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby#what-happens-when-knapsack-pro-api-is-not-availablenot-reachable-temporarily")
         fallback_test_files
       end
     end

--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -14,6 +14,7 @@ module KnapsackPro
         raise ArgumentError.new(response) if connection.errors?
         prepare_test_files(response)
       else
+        KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby")
         fallback_test_files
       end
     end

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -103,7 +103,7 @@ module KnapsackPro
       rescue Errno::ECONNREFUSED, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
         logger.warn(e.inspect)
         retries += 1
-        if retries < 5
+        if retries < 3
           wait = retries * REQUEST_RETRY_TIMEBOX
           logger.warn("Wait #{wait}s and retry request to Knapsack Pro API.")
           sleep wait

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -1,7 +1,7 @@
 module KnapsackPro
   module Client
     class Connection
-      TIMEOUT = 30
+      TIMEOUT = 15
       REQUEST_RETRY_TIMEBOX = 2
 
       def initialize(action)

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -18,7 +18,7 @@ module KnapsackPro
         prepare_test_files(response)
       else
         @fallback_activated = true
-        KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. If other CI nodes were able to connect with Knapsack Pro API then you may notice that some of the test files will be executed twice across CI nodes. The most important thing is to guarantee each of test files is run at least once! Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby")
+        KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. If other CI nodes were able to connect with Knapsack Pro API then you may notice that some of the test files will be executed twice across CI nodes. The most important thing is to guarantee each of test files is run at least once! Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby#what-happens-when-knapsack-pro-api-is-not-availablenot-reachable-temporarily")
         fallback_test_files(executed_test_files)
       end
     end

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -9,6 +9,7 @@ module KnapsackPro
     end
 
     def test_file_paths(can_initialize_queue, executed_test_files)
+      return [] if @fallback_activated
       action = build_action(can_initialize_queue)
       connection = KnapsackPro::Client::Connection.new(action)
       response = connection.call
@@ -16,6 +17,7 @@ module KnapsackPro
         raise ArgumentError.new(response) if connection.errors?
         prepare_test_files(response)
       else
+        @fallback_activated = true
         KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. If other CI nodes were able to connect with Knapsack Pro API then you may notice that some of the test files will be executed twice across CI nodes. The most important thing is to guarantee each of test files is run at least once! Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby")
         fallback_test_files(executed_test_files)
       end

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -59,8 +59,7 @@ module KnapsackPro
     def fallback_test_files(executed_test_files)
       test_flat_distributor = KnapsackPro::TestFlatDistributor.new(test_files, ci_node_total)
       test_files_for_node_index = test_flat_distributor.test_files_for_node(ci_node_index)
-      not_executed_test_files_for_node_index = test_files_for_node_index - executed_test_files
-      KnapsackPro::TestFilePresenter.paths(not_executed_test_files_for_node_index)
+      KnapsackPro::TestFilePresenter.paths(test_files_for_node_index) - executed_test_files
     end
   end
 end

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -16,7 +16,7 @@ module KnapsackPro
         raise ArgumentError.new(response) if connection.errors?
         prepare_test_files(response)
       else
-        KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. If other CI nodes were able to connect with Knapsack Pro API then you may notice that some of test files will be executed twice across CI nodes. The most important thing is to guarantee your test files were run at least once! Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby")
+        KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. If other CI nodes were able to connect with Knapsack Pro API then you may notice that some of the test files will be executed twice across CI nodes. The most important thing is to guarantee each of test files is run at least once! Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby")
         fallback_test_files(executed_test_files)
       end
     end

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -8,7 +8,7 @@ module KnapsackPro
       @repository_adapter = args.fetch(:repository_adapter)
     end
 
-    def test_file_paths(can_initialize_queue)
+    def test_file_paths(can_initialize_queue, executed_test_files)
       action = build_action(can_initialize_queue)
       connection = KnapsackPro::Client::Connection.new(action)
       response = connection.call
@@ -16,7 +16,8 @@ module KnapsackPro
         raise ArgumentError.new(response) if connection.errors?
         prepare_test_files(response)
       else
-        raise ArgumentError.new("Couldn't connect with Knapsack Pro API. Response: #{response}")
+        KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. If other CI nodes were able to connect with Knapsack Pro API then you may notice that some of test files will be executed twice across CI nodes. The most important thing is to guarantee your test files were run at least once! Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby")
+        fallback_test_files(executed_test_files)
       end
     end
 
@@ -51,6 +52,13 @@ module KnapsackPro
     def prepare_test_files(response)
       decrypted_test_files = KnapsackPro::Crypto::Decryptor.call(test_files, response['test_files'])
       KnapsackPro::TestFilePresenter.paths(decrypted_test_files)
+    end
+
+    def fallback_test_files(executed_test_files)
+      test_flat_distributor = KnapsackPro::TestFlatDistributor.new(test_files, ci_node_total)
+      test_files_for_node_index = test_flat_distributor.test_files_for_node(ci_node_index)
+      not_executed_test_files_for_node_index = test_files_for_node_index - executed_test_files
+      KnapsackPro::TestFilePresenter.paths(not_executed_test_files_for_node_index)
     end
   end
 end

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -57,9 +57,9 @@ module KnapsackPro
       response = connection.call
       if connection.success?
         raise ArgumentError.new(response) if connection.errors?
-        KnapsackPro.logger.debug('Saved time execution report on API server.')
+        KnapsackPro.logger.debug('Saved time execution report on Knapsack Pro API server.')
       else
-        KnapsackPro.logger.warn('Time execution report was not saved on API server due to network problem.')
+        KnapsackPro.logger.warn('Time execution report was not saved on Knapsack Pro API server due to connection problem.')
       end
     end
 

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -58,6 +58,8 @@ module KnapsackPro
       if connection.success?
         raise ArgumentError.new(response) if connection.errors?
         KnapsackPro.logger.debug('Saved time execution report on API server.')
+      else
+        KnapsackPro.logger.warn('Time execution report was not saved on API server due to network problem.')
       end
     end
 

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -17,7 +17,8 @@ module KnapsackPro
 
         def test_file_paths(args)
           can_initialize_queue = args.fetch(:can_initialize_queue)
-          allocator.test_file_paths(can_initialize_queue)
+          executed_test_files = args.fetch(:executed_test_files)
+          allocator.test_file_paths(can_initialize_queue, executed_test_files)
         end
 
         def test_dir

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -25,7 +25,10 @@ module KnapsackPro
         end
 
         def self.run_tests(runner, can_initialize_queue, args, exitstatus, all_test_file_paths)
-          test_file_paths = runner.test_file_paths(can_initialize_queue: can_initialize_queue)
+          test_file_paths = runner.test_file_paths(
+            can_initialize_queue: can_initialize_queue,
+            executed_test_files: all_test_file_paths
+          )
 
           if test_file_paths.empty?
             unless all_test_file_paths.empty?

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -30,8 +30,8 @@ describe KnapsackPro::Client::Connection do
         expect(Net::HTTP).to receive(:new).with('api.knapsackpro.dev', 3000).and_return(http)
 
         expect(http).to receive(:use_ssl=).with(false)
-        expect(http).to receive(:open_timeout=).with(30)
-        expect(http).to receive(:read_timeout=).with(30)
+        expect(http).to receive(:open_timeout=).with(15)
+        expect(http).to receive(:read_timeout=).with(15)
 
         header = { 'X-Request-Id' => 'fake-uuid' }
         http_response = instance_double(Net::HTTPOK, body: body, header: header)

--- a/spec/knapsack_pro/queue_allocator_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_spec.rb
@@ -17,9 +17,10 @@ describe KnapsackPro::QueueAllocator do
 
   describe '#test_file_paths' do
     let(:can_initialize_queue) { double }
+    let(:executed_test_files) { [] }
     let(:response) { double }
 
-    subject { queue_allocator.test_file_paths(can_initialize_queue) }
+    subject { queue_allocator.test_file_paths(can_initialize_queue, executed_test_files) }
 
     before do
       encrypted_test_files = double
@@ -80,8 +81,30 @@ describe KnapsackPro::QueueAllocator do
       let(:success?) { false }
       let(:errors?) { false }
 
-      it do
-        expect { subject }.to raise_error("Couldn't connect with Knapsack Pro API. Response: #{response}")
+
+      before do
+        test_flat_distributor = instance_double(KnapsackPro::TestFlatDistributor)
+        expect(KnapsackPro::TestFlatDistributor).to receive(:new).with(test_files, ci_node_total).and_return(test_flat_distributor)
+        expect(test_flat_distributor).to receive(:test_files_for_node).with(ci_node_index).and_return([
+          { 'path' => 'c_spec.rb' },
+          { 'path' => 'd_spec.rb' },
+        ])
+      end
+
+      context 'when no test files were executed yet' do
+        let(:executed_test_files) { [] }
+
+        it 'enables fallback mode and returns fallback test files' do
+          expect(subject).to eq ['c_spec.rb', 'd_spec.rb']
+        end
+      end
+
+      context 'when test files were already executed' do
+        let(:executed_test_files) { ['c_spec.rb', 'additional_executed_spec.rb'] }
+
+        it 'enables fallback mode and returns fallback test files' do
+          expect(subject).to eq ['d_spec.rb']
+        end
       end
     end
   end

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -142,7 +142,12 @@ describe KnapsackPro::Report do
         let(:success?) { false }
         let(:errors?) { nil }
 
-        it { subject }
+        it do
+          logger = instance_double(Logger)
+          expect(KnapsackPro).to receive(:logger).and_return(logger)
+          expect(logger).to receive(:warn).with('Time execution report was not saved on API server due to network problem.')
+          subject
+        end
       end
     end
 

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -132,7 +132,7 @@ describe KnapsackPro::Report do
           it do
             logger = instance_double(Logger)
             expect(KnapsackPro).to receive(:logger).and_return(logger)
-            expect(logger).to receive(:debug).with('Saved time execution report on API server.')
+            expect(logger).to receive(:debug).with('Saved time execution report on Knapsack Pro API server.')
             subject
           end
         end
@@ -145,7 +145,7 @@ describe KnapsackPro::Report do
         it do
           logger = instance_double(Logger)
           expect(KnapsackPro).to receive(:logger).and_return(logger)
-          expect(logger).to receive(:warn).with('Time execution report was not saved on API server due to network problem.')
+          expect(logger).to receive(:warn).with('Time execution report was not saved on Knapsack Pro API server due to connection problem.')
           subject
         end
       end

--- a/spec/knapsack_pro/runners/queue/base_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/base_runner_spec.rb
@@ -33,11 +33,17 @@ describe KnapsackPro::Runners::Queue::BaseRunner do
 
       context 'when can_initialize_queue flag has value' do
         let(:can_initialize_queue) { double }
-        let(:args) { { can_initialize_queue: can_initialize_queue } }
+        let(:executed_test_files) { double }
+        let(:args) do
+          {
+            can_initialize_queue: can_initialize_queue,
+            executed_test_files: executed_test_files,
+          }
+        end
         let(:test_file_paths) { double }
 
         before do
-          expect(allocator).to receive(:test_file_paths).and_return(test_file_paths)
+          expect(allocator).to receive(:test_file_paths).with(can_initialize_queue, executed_test_files).and_return(test_file_paths)
         end
 
         it { should eq test_file_paths }

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -74,7 +74,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
     subject { described_class.run_tests(runner, can_initialize_queue, args, exitstatus, []) }
 
     before do
-      expect(runner).to receive(:test_file_paths).with(can_initialize_queue: can_initialize_queue).and_return(test_file_paths)
+      expect(runner).to receive(:test_file_paths).with(can_initialize_queue: can_initialize_queue, executed_test_files: []).and_return(test_file_paths)
     end
 
     context 'when test files exist' do
@@ -102,7 +102,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
         expect(KnapsackPro::Hooks::Queue).to receive(:call_after_subset_queue)
 
         # second call of run_tests because of recursion
-        expect(runner).to receive(:test_file_paths).with(can_initialize_queue: false).and_return([])
+        expect(runner).to receive(:test_file_paths).with(can_initialize_queue: false, executed_test_files: ['a_spec.rb', 'b_spec.rb']).and_return([])
       end
 
       context 'when exit code is zero' do


### PR DESCRIPTION

* When Knapsack Pro API doesn't work then start executing tests based on directory names.
* Guarantee all test files are executed at least once across CI nodes.