### PR TITLE
Update RSpec timing adapter to be more resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 0.50.1
+
+* Update RSpec timing adapter to be more resilient.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/52
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.50.0...v0.50.1
+
 ### 0.50.0
 
 * Add support for Codeship environment variables.

--- a/knapsack_pro.gemspec
+++ b/knapsack_pro.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake', '>= 0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rspec', '~> 3.0', '>= 2.0.0'
+  spec.add_development_dependency 'rspec', '~> 3.0', '>= 2.10.0'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'cucumber', '>= 0'
   spec.add_development_dependency 'spinach', '>= 0.8'

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -21,7 +21,7 @@ module KnapsackPro
 
       def bind_time_tracker
         ::RSpec.configure do |config|
-          config.before(:each) do
+          config.prepend_before(:each) do
             current_example_group =
               if ::RSpec.respond_to?(:current_example)
                 ::RSpec.current_example.metadata[:example_group]
@@ -32,7 +32,7 @@ module KnapsackPro
             KnapsackPro.tracker.start_timer
           end
 
-          config.after(:each) do
+          config.append_after(:each) do
             KnapsackPro.tracker.stop_timer
           end
 

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -80,8 +80,8 @@ describe KnapsackPro::Adapters::RSpecAdapter do
       end
 
       it do
-        expect(config).to receive(:before).with(:each).and_yield
-        expect(config).to receive(:after).with(:each).and_yield
+        expect(config).to receive(:prepend_before).with(:each).and_yield
+        expect(config).to receive(:append_after).with(:each).and_yield
         expect(config).to receive(:after).with(:suite).and_yield
         expect(::RSpec).to receive(:configure).and_yield(config)
 


### PR DESCRIPTION
It improves how we track time for tests in RSpec.

This PR is based on fix: https://github.com/ArturT/knapsack/pull/64