### PR TITLE
Fix to record proper time for around(:each) in RSpec 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 0.55.0
+
+* Fix to record proper time for around(:each) in RSpec
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/62
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.54.0...v0.55.0
+
 ### 0.54.0
 
 * Add Queue Mode for Minitest

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -21,18 +21,19 @@ module KnapsackPro
 
       def bind_time_tracker
         ::RSpec.configure do |config|
-          config.prepend_before(:each) do
+          config.around(:each) do |example|
             current_example_group =
               if ::RSpec.respond_to?(:current_example)
                 ::RSpec.current_example.metadata[:example_group]
               else
                 example.metadata
               end
+
             KnapsackPro.tracker.current_test_path = KnapsackPro::Adapters::RSpecAdapter.test_path(current_example_group)
             KnapsackPro.tracker.start_timer
-          end
 
-          config.append_after(:each) do
+            example.run
+
             KnapsackPro.tracker.stop_timer
           end
 

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -78,10 +78,10 @@ describe KnapsackPro::Adapters::RSpecAdapter do
           example_group: example_group
         })
       end
+      let(:example) { double }
 
       it do
-        expect(config).to receive(:prepend_before).with(:each).and_yield
-        expect(config).to receive(:append_after).with(:each).and_yield
+        expect(config).to receive(:around).with(:each).and_yield(example)
         expect(config).to receive(:after).with(:suite).and_yield
         expect(::RSpec).to receive(:configure).and_yield(config)
 
@@ -91,6 +91,8 @@ describe KnapsackPro::Adapters::RSpecAdapter do
         allow(KnapsackPro).to receive(:tracker).and_return(tracker)
         expect(tracker).to receive(:current_test_path=).with(test_path)
         expect(tracker).to receive(:start_timer)
+
+        expect(example).to receive(:run)
 
         expect(tracker).to receive(:stop_timer)
 


### PR DESCRIPTION
Use around :each so thanks to that we can track time for around :each defined by user in spec_helper or rails_helper