### PR TITLE
Switch to fallback mode when failed to open TCP connection to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 0.55.1
+
+* Switch to fallback mode when failed to open TCP connection to API
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/63
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.55.0...v0.55.1
+
 ### 0.55.0
 
 * Fix to record proper time for around(:each) in RSpec

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -100,7 +100,7 @@ module KnapsackPro
         end
 
         response
-      rescue Errno::ECONNREFUSED, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
         logger.warn(e.inspect)
         retries += 1
         if retries < 3


### PR DESCRIPTION
This way knapsack will handle exception and switch to fallback mode when there will be issue with API availability.

```
Errno::ETIMEDOUT: Failed to open TCP connection to api.knapsackpro.com:443 (Connection timed out - connect(2) for "api.knapsackpro.com" port 443)
/workspace/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.54.0/lib/knapsack_pro/client/connection.rb:88:in `post'
/workspace/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.54.0/lib/knapsack_pro/client/connection.rb:12:in `call'
/workspace/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.54.0/lib/knapsack_pro/queue_allocator.rb:15:in `test_file_paths'
/workspace/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.54.0/lib/knapsack_pro/runners/queue/base_runner.rb:21:in `test_file_paths'
/workspace/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.54.0/lib/knapsack_pro/runners/queue/rspec_runner.rb:28:in `run_tests'
/workspace/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.54.0/lib/knapsack_pro/runners/queue/rspec_runner.rb:24:in `run'
/workspace/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.54.0/lib/tasks/queue/rspec.rake:6:in `block (3 levels) in <main>'
/workspace/vendor/bundle/ruby/2.3.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
```