### PR TITLE
[BUG] Fallback mode should respect the connection errors

### DIFF
--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -10,8 +10,7 @@ module KnapsackPro
     def test_file_paths
       connection = KnapsackPro::Client::Connection.new(build_action)
       response = connection.call
-      if connection.success?
-        raise ArgumentError.new(response) if connection.errors?
+      if connection.success? && !connection.errors?
         prepare_test_files(response)
       else
         KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby#what-happens-when-knapsack-pro-api-is-not-availablenot-reachable-temporarily")


### PR DESCRIPTION
When builds experience a 500 from the connection, Knapsack should not throw an error, but rather use fallback mode. A successful `connection` should both be successful AND have no errors.
```
ArgumentError: {"status"=>"500", "error"=>"Internal Server Error"}
--
  | /usr/src/app/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.53.0/lib/knapsack_pro/allocator.rb:14:in `test_file_paths'
  | /usr/src/app/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.53.0/lib/knapsack_pro/runners/base_runner.rb:14:in `test_file_paths'
  | /usr/src/app/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.53.0/lib/knapsack_pro/runners/base_runner.rb:26:in `test_files_to_execute_exist?'
  | /usr/src/app/vendor/bundle/ruby/2.3.0/gems/knapsack_pro-0.53.0/lib/knapsack_pro/runners/rspec_runner.rb:10:in `run'
```
Maybe an alternative would be to warn when there are errors but still fall back? Either way this is blocking builds in production for us.