### PR TITLE
Run tests in Fallback Mode when API response is 5xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 * TODO
 
+### 1.0.0
+
+* Release 1.0.0 is backward compatible with all previous releases.
+* Run tests in Fallback Mode when API response is 5xx
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/69
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v0.57.0...v1.0.0
+
 ### 0.57.0
 
 * Add support for Solano CI and AppVeyor

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -13,7 +13,10 @@ module KnapsackPro
       end
 
       def success?
-        !!response_body
+        return false if !response_body
+
+        status = http_response.code.to_i
+        status >= 200 && status < 500
       end
 
       def errors?
@@ -22,7 +25,7 @@ module KnapsackPro
 
       private
 
-      attr_reader :action, :response_body
+      attr_reader :action, :http_response, :response_body
 
       def logger
         KnapsackPro.logger
@@ -85,7 +88,7 @@ module KnapsackPro
         http.open_timeout = TIMEOUT
         http.read_timeout = TIMEOUT
 
-        http_response = http.post(uri.path, request_body, json_headers)
+        @http_response = http.post(uri.path, request_body, json_headers)
         @response_body = parse_response_body(http_response.body)
 
         request_uuid = http_response.header['X-Request-Id']

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -13,16 +13,16 @@ module KnapsackPro
       end
 
       def success?
-        !!response
+        !!response_body
       end
 
       def errors?
-        !!(response && (response['errors'] || response['error']))
+        !!(response_body && (response_body['errors'] || response_body['error']))
       end
 
       private
 
-      attr_reader :action, :response
+      attr_reader :action, :response_body
 
       def logger
         KnapsackPro.logger
@@ -61,7 +61,7 @@ module KnapsackPro
         }
       end
 
-      def parse_response(body)
+      def parse_response_body(body)
         return '' if body == '' || body.nil?
         JSON.parse(body)
       rescue JSON::ParserError
@@ -69,8 +69,8 @@ module KnapsackPro
       end
 
       def seed
-        return if @response.nil? || @response == ''
-        response['build_distribution_id']
+        return if @response_body.nil? || @response_body == ''
+        response_body['build_distribution_id']
       end
 
       def has_seed?
@@ -86,7 +86,7 @@ module KnapsackPro
         http.read_timeout = TIMEOUT
 
         http_response = http.post(uri.path, request_body, json_headers)
-        @response = parse_response(http_response.body)
+        @response_body = parse_response_body(http_response.body)
 
         request_uuid = http_response.header['X-Request-Id']
 
@@ -94,12 +94,12 @@ module KnapsackPro
         logger.debug("Test suite split seed: #{seed}") if has_seed?
         logger.debug('API response:')
         if errors?
-          logger.error(response)
+          logger.error(response_body)
         else
-          logger.debug(response)
+          logger.debug(response_body)
         end
 
-        response
+        response_body
       rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
         logger.warn(e.inspect)
         retries += 1

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -112,17 +112,17 @@ describe KnapsackPro::Client::Connection do
     subject { connection.success? }
 
     before do
-      allow(connection).to receive(:response).and_return(response)
+      allow(connection).to receive(:response_body).and_return(response_body)
     end
 
     context 'when response has no value' do
-      let(:response) { nil }
+      let(:response_body) { nil }
 
       it { should be false }
     end
 
     context 'when response has value' do
-      let(:response) do
+      let(:response_body) do
         { 'fake' => 'response' }
       end
 
@@ -134,18 +134,18 @@ describe KnapsackPro::Client::Connection do
     subject { connection.errors? }
 
     before do
-      allow(connection).to receive(:response).and_return(response)
+      allow(connection).to receive(:response_body).and_return(response_body)
     end
 
     context 'when response has no value' do
-      let(:response) { nil }
+      let(:response_body) { nil }
 
       it { should be false }
     end
 
     context 'when response has value' do
       context 'when response has no errors' do
-        let(:response) do
+        let(:response_body) do
           { 'fake' => 'response' }
         end
 
@@ -153,7 +153,7 @@ describe KnapsackPro::Client::Connection do
       end
 
       context 'when response has errors' do
-        let(:response) do
+        let(:response_body) do
           { 'errors' => [{ 'field' => 'is wrong' }] }
         end
 
@@ -161,7 +161,7 @@ describe KnapsackPro::Client::Connection do
       end
 
       context 'when response has error (i.e. internal server error)' do
-        let(:response) do
+        let(:response_body) do
           { 'error' => 'Internal Server Error' }
         end
 

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -49,7 +49,7 @@ describe KnapsackPro::Client::Connection do
 
       context 'when body response is json and API response code is 400' do
         let(:body) { '{"errors": "value"}' }
-        let(:code) { "400" } # it must be string code
+        let(:code) { '400' } # it must be string code
 
         before do
           expect(KnapsackPro).to receive(:logger).exactly(3).and_return(logger)
@@ -70,7 +70,7 @@ describe KnapsackPro::Client::Connection do
 
       context 'when body response is json and API response code is 500' do
         let(:body) { '{"error": "Internal Server Error"}' }
-        let(:code) { "500" } # it must be string code
+        let(:code) { '500' } # it must be string code
 
         before do
           expect(KnapsackPro).to receive(:logger).exactly(3).and_return(logger)
@@ -91,7 +91,7 @@ describe KnapsackPro::Client::Connection do
 
       context 'when body response is json with build_distribution_id' do
         let(:body) { '{"build_distribution_id": "seed-uuid"}' }
-        let(:code) { "200" } # it must be string code
+        let(:code) { '200' } # it must be string code
 
         before do
           expect(KnapsackPro).to receive(:logger).exactly(4).and_return(logger)
@@ -113,7 +113,7 @@ describe KnapsackPro::Client::Connection do
 
       context 'when body response is empty' do
         let(:body) { '' }
-        let(:code) { "200" } # it must be string code
+        let(:code) { '200' } # it must be string code
 
         before do
           expect(KnapsackPro).to receive(:logger).exactly(3).and_return(logger)
@@ -156,25 +156,25 @@ describe KnapsackPro::Client::Connection do
       end
 
       context 'when response code is 200' do
-        let(:code) { "200" } # it must be string code
+        let(:code) { '200' } # it must be string code
 
         it { should be true }
       end
 
       context 'when response code is 300' do
-        let(:code) { "300" } # it must be string code
+        let(:code) { '300' } # it must be string code
 
         it { should be true }
       end
 
       context 'when response code is 400' do
-        let(:code) { "400" } # it must be string code
+        let(:code) { '400' } # it must be string code
 
         it { should be true }
       end
 
       context 'when response code is 500' do
-        let(:code) { "500" } # it must be string code
+        let(:code) { '500' } # it must be string code
 
         it { should be false }
       end


### PR DESCRIPTION
Only Knapsack Pro API response 2xx, 3xx, 4xx should be treated as successful. When API response is 5xx then we use Fallback Mode to run tests.

This should allow to run tests even in case of Knapsack Pro API 500 error.

Related: 
Issue: https://github.com/KnapsackPro/knapsack_pro-ruby/issues/68
First reported problem and PR: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/67