### PR TITLE
Track time execution of all tests assigned to CI node in Queue Mode even when they did not run due syntax error or being pending/empty in test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 1.0.2
+
+* Track time execution of all tests assigned to CI node in Queue Mode even when they did not run due syntax error or being pending/empty in test run.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/71
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.0.1...v1.0.2
+
 ### 1.0.1
 
 * Fix bug with not being able to set log level via logger wrapper.

--- a/lib/knapsack_pro/adapters/base_adapter.rb
+++ b/lib/knapsack_pro/adapters/base_adapter.rb
@@ -31,23 +31,13 @@ module KnapsackPro
         raise NotImplementedError
       end
 
-      def bind_save_queue_report
-        raise NotImplementedError
-      end
-
-      def bind_tracker_reset
-        raise NotImplementedError
-      end
-
       def bind_before_queue_hook
         raise NotImplementedError
       end
 
       def bind_queue_mode
-        bind_tracker_reset
         bind_before_queue_hook
         bind_time_tracker
-        bind_save_queue_report
       end
     end
   end

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -62,7 +62,7 @@ module KnapsackPro
       def bind_tracker_reset
         ::RSpec.configure do |config|
           config.before(:suite) do
-            KnapsackPro.tracker.reset!
+            #KnapsackPro.tracker.reset!
           end
         end
       end

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -51,22 +51,6 @@ module KnapsackPro
         end
       end
 
-      def bind_save_queue_report
-        ::RSpec.configure do |config|
-          config.after(:suite) do
-            KnapsackPro::Report.save_subset_queue_to_file
-          end
-        end
-      end
-
-      def bind_tracker_reset
-        ::RSpec.configure do |config|
-          config.before(:suite) do
-            #KnapsackPro.tracker.reset!
-          end
-        end
-      end
-
       def bind_before_queue_hook
         ::RSpec.configure do |config|
           config.before(:suite) do

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -59,6 +59,7 @@ module KnapsackPro
             ENV['KNAPSACK_PRO_SUBSET_QUEUE_ID'] = subset_queue_id
 
             KnapsackPro.tracker.reset!
+            KnapsackPro.tracker.set_prerun_tests(test_file_paths)
 
             all_test_file_paths += test_file_paths
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -48,6 +48,8 @@ module KnapsackPro
             can_initialize_queue: can_initialize_queue,
             executed_test_files: all_test_file_paths
           )
+          KnapsackPro.tracker.reset!
+          KnapsackPro.tracker.set_prerun_tests(test_file_paths)
 
           if test_file_paths.empty?
             unless all_test_file_paths.empty?

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -48,8 +48,6 @@ module KnapsackPro
             can_initialize_queue: can_initialize_queue,
             executed_test_files: all_test_file_paths
           )
-          KnapsackPro.tracker.reset!
-          KnapsackPro.tracker.set_prerun_tests(test_file_paths)
 
           if test_file_paths.empty?
             unless all_test_file_paths.empty?
@@ -71,6 +69,9 @@ module KnapsackPro
             subset_queue_id = KnapsackPro::Config::EnvGenerator.set_subset_queue_id
             ENV['KNAPSACK_PRO_SUBSET_QUEUE_ID'] = subset_queue_id
 
+            KnapsackPro.tracker.reset!
+            KnapsackPro.tracker.set_prerun_tests(test_file_paths)
+
             all_test_file_paths += test_file_paths
             cli_args = args + test_file_paths
 
@@ -83,6 +84,8 @@ module KnapsackPro
             rspec_clear_examples
 
             KnapsackPro::Hooks::Queue.call_after_subset_queue
+
+            KnapsackPro::Report.save_subset_queue_to_file
 
             return {
               status: :next,

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -34,6 +34,10 @@ module KnapsackPro
 
     def set_prerun_tests(test_file_paths)
       test_file_paths.each do |test_file_path|
+        # Set a default time for test file
+        # in case when the test file will not be run
+        # due syntax error or being pending.
+        # The time is required by Knapsack Pro API.
         @test_files_with_time[test_file_path] = 0.1
       end
       puts '@'*50

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -15,7 +15,7 @@ module KnapsackPro
     end
 
     def start_timer
-      puts '@'*50
+      puts 'S'*50
       puts @test_files_with_time.inspect
       @start_time = now_without_mock_time.to_f
     end

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -15,8 +15,6 @@ module KnapsackPro
     end
 
     def start_timer
-      puts 'S'*50
-      puts @test_files_with_time.inspect
       @start_time = now_without_mock_time.to_f
     end
 
@@ -40,8 +38,6 @@ module KnapsackPro
         # The time is required by Knapsack Pro API.
         @test_files_with_time[test_file_path] = 0.1
       end
-      puts '@'*50
-      puts @test_files_with_time.inspect
     end
 
     def to_a

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -15,6 +15,8 @@ module KnapsackPro
     end
 
     def start_timer
+      puts '@'*50
+      puts @test_files_with_time.inspect
       @start_time = now_without_mock_time.to_f
     end
 
@@ -28,6 +30,14 @@ module KnapsackPro
     def current_test_path
       raise("current_test_path needs to be set by Knapsack Pro Adapter's bind method") unless @current_test_path
       @current_test_path.sub(/^\.\//, '')
+    end
+
+    def set_prerun_tests(test_file_paths)
+      test_file_paths.each do |test_file_path|
+        @test_files_with_time[test_file_path] = 0.1
+      end
+      puts '@'*50
+      puts @test_files_with_time.inspect
     end
 
     def to_a

--- a/spec/knapsack_pro/adapters/base_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/base_adapter_spec.rb
@@ -48,10 +48,8 @@ describe KnapsackPro::Adapters::BaseAdapter do
       let(:queue_recording_enabled?) { true }
 
       before do
-        allow(subject).to receive(:bind_tracker_reset)
         allow(subject).to receive(:bind_before_queue_hook)
         allow(subject).to receive(:bind_time_tracker)
-        allow(subject).to receive(:bind_save_queue_report)
       end
 
       it do
@@ -59,17 +57,13 @@ describe KnapsackPro::Adapters::BaseAdapter do
         expect(KnapsackPro).to receive(:logger).and_return(logger)
         expect(logger).to receive(:debug).with('Test suite time execution queue recording enabled.')
       end
-      it { expect(subject).to receive(:bind_tracker_reset) }
       it { expect(subject).to receive(:bind_before_queue_hook) }
       it { expect(subject).to receive(:bind_time_tracker) }
-      it { expect(subject).to receive(:bind_save_queue_report) }
     end
 
     context 'when recording disabled' do
-      it { expect(subject).not_to receive(:bind_tracker_reset) }
       it { expect(subject).not_to receive(:bind_time_tracker) }
       it { expect(subject).not_to receive(:bind_save_report) }
-      it { expect(subject).not_to receive(:bind_save_queue_report) }
       it { expect(subject).not_to receive(:bind_before_queue_hook) }
     end
   end
@@ -86,22 +80,6 @@ describe KnapsackPro::Adapters::BaseAdapter do
     it do
       expect {
         subject.bind_save_report
-      }.to raise_error(NotImplementedError)
-    end
-  end
-
-  describe '#bind_save_queue_report' do
-    it do
-      expect {
-        subject.bind_save_queue_report
-      }.to raise_error(NotImplementedError)
-    end
-  end
-
-  describe '#bind_tracker_reset' do
-    it do
-      expect {
-        subject.bind_tracker_reset
       }.to raise_error(NotImplementedError)
     end
   end

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -115,30 +115,6 @@ describe KnapsackPro::Adapters::RSpecAdapter do
       end
     end
 
-    describe '#bind_save_queue_report' do
-      it do
-        expect(config).to receive(:after).with(:suite).and_yield
-        expect(::RSpec).to receive(:configure).and_yield(config)
-
-        expect(KnapsackPro::Report).to receive(:save_subset_queue_to_file)
-
-        subject.bind_save_queue_report
-      end
-    end
-
-    describe '#bind_tracker_reset' do
-      it do
-        expect(config).to receive(:before).with(:suite).and_yield
-        expect(::RSpec).to receive(:configure).and_yield(config)
-
-        tracker = instance_double(KnapsackPro::Tracker)
-        expect(KnapsackPro).to receive(:tracker).and_return(tracker)
-        expect(tracker).to receive(:reset!)
-
-        subject.bind_tracker_reset
-      end
-    end
-
     describe '#bind_before_queue_hook' do
       it do
         expect(config).to receive(:before).with(:suite).and_yield

--- a/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
@@ -106,7 +106,10 @@ describe KnapsackPro::Runners::Queue::MinitestRunner do
 
         expect(ENV).to receive(:[]=).with('KNAPSACK_PRO_SUBSET_QUEUE_ID', subset_queue_id)
 
-        expect(KnapsackPro).to receive_message_chain(:tracker, :reset!)
+        tracker = instance_double(KnapsackPro::Tracker)
+        expect(KnapsackPro).to receive(:tracker).twice.and_return(tracker)
+        expect(tracker).to receive(:reset!)
+        expect(tracker).to receive(:set_prerun_tests).with(test_file_paths)
 
         # .minitest_run
         expect(described_class).to receive(:require).with('./a_test.rb')

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -138,6 +138,11 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
         expect(ENV).to receive(:[]=).with('KNAPSACK_PRO_SUBSET_QUEUE_ID', subset_queue_id)
 
+        tracker = instance_double(KnapsackPro::Tracker)
+        expect(KnapsackPro).to receive(:tracker).twice.and_return(tracker)
+        expect(tracker).to receive(:reset!)
+        expect(tracker).to receive(:set_prerun_tests).with(test_file_paths)
+
         options = double
         expect(RSpec::Core::ConfigurationOptions).to receive(:new).with([
           '--example-arg', 'example-value',
@@ -152,6 +157,8 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
         expect(described_class).to receive(:rspec_clear_examples)
 
         expect(KnapsackPro::Hooks::Queue).to receive(:call_after_subset_queue)
+
+        expect(KnapsackPro::Report).to receive(:save_subset_queue_to_file)
       end
 
       context 'when exit code is zero' do


### PR DESCRIPTION
This fix allows recording default timing 0.1s for test files like:

# Queue Mode  for RSpec
* test file is empty
* test file has only pending tests
* test file has a syntax error


# Queue Mode  for Minitest
* test file is empty
* test file has only pending tests
* test file has a syntax error (this breaks the runtime, the Knapsack Pro API will run the same set of tests when you retry failed CI node)