### PR TITLE
Add support for GitLab CI env vars CI_NODE_TOTAL and CI_NODE_INDEX

### DIFF
--- a/lib/knapsack_pro/config/ci/gitlab_ci.rb
+++ b/lib/knapsack_pro/config/ci/gitlab_ci.rb
@@ -4,11 +4,14 @@ module KnapsackPro
     module CI
       class GitlabCI < Base
         def node_total
-          # not provided by Gitlab CI
+          ENV['CI_NODE_TOTAL']
         end
 
         def node_index
-          # not provided by Gitlab CI
+          return unless ENV['GITLAB_CI']
+          # GitLab 11.5
+          index = ENV['CI_NODE_INDEX']
+          index.to_i - 1 if index
         end
 
         def node_build_id

--- a/spec/knapsack_pro/config/ci/gitlab_ci_spec.rb
+++ b/spec/knapsack_pro/config/ci/gitlab_ci_spec.rb
@@ -10,13 +10,27 @@ describe KnapsackPro::Config::CI::GitlabCI do
   describe '#node_total' do
     subject { described_class.new.node_total }
 
-    it { should be nil }
+    context 'when environment exists' do
+      let(:env) { { 'CI_NODE_TOTAL' => 4 } }
+      it { should eql 4 }
+    end
+
+    context "when environment doesn't exist" do
+      it { should be nil }
+    end
   end
 
   describe '#node_index' do
     subject { described_class.new.node_index }
 
-    it { should be nil }
+    context 'when environment exists and is in GitLab CI' do
+      let(:env) { { 'CI_NODE_INDEX' => 4, 'GITLAB_CI' => 'true' } }
+      it { should eql 3 }
+    end
+
+    context "when environment doesn't exist" do
+      it { should be nil }
+    end
   end
 
   describe '#node_build_id' do


### PR DESCRIPTION
Since GitLab 11.5, you can define parallel: x (2 to 50) to a job and have it
run in multiple workers. You no longer need to define all of them
nor define any environmental variable manually.

You can read more from the documentation here:
https://docs.gitlab.com/ee/ci/yaml/#parallel

You can read about pre-defined ENV variables in GitLab CI here:
https://docs.gitlab.com/ee/ci/variables/README.html#predefined-variables-environment-variables

Related: https://github.com/ArturT/knapsack/pull/83