### PR TITLE
Run Fallback Mode for exception Errno::EPIPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 1.2.1
+
+* Run Fallback Mode for exception `Errno::EPIPE`
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/75
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.2.0...v1.2.1
+
 ### 1.2.0
 
 * Add support for GitLab CI env vars CI_NODE_TOTAL and CI_NODE_INDEX.

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -103,7 +103,7 @@ module KnapsackPro
         end
 
         response_body
-      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
         logger.warn(e.inspect)
         retries += 1
         if retries < 3


### PR DESCRIPTION
When a request fails 3 times with `Errno::EPIPE` then run tests in Fallback Mode.