### PR TITLE
Use .test domain for development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.4.0
+
+* Use .test domain for development mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/76
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.3.0...v1.4.0
+
 ### 1.3.0
 
 * Add metadata to the gemspec

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ This is only for maintainer of knapsack_pro gem. Not for the end users.
 
 `KNAPSACK_PRO_ENDPOINT` - Default value is `https://api.knapsackpro.com` which is endpoint for [Knapsack Pro API](http://docs.knapsackpro.com).
 
-`KNAPSACK_PRO_MODE` - Default value is `production`. When mode is `development` then endpoint is `http://api.knapsackpro.dev:3000`. When mode is `test` then endpoint is `http://api-staging.knapsackpro.com`.
+`KNAPSACK_PRO_MODE` - Default value is `production`. When mode is `development` then endpoint is `http://api.knapsackpro.test:3000`. When mode is `test` then endpoint is `http://api-staging.knapsackpro.com`.
 
 ### Passing arguments to rake task
 

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -117,7 +117,7 @@ module KnapsackPro
 
           case mode
           when :development
-            'http://api.knapsackpro.dev:3000'
+            'http://api.knapsackpro.test:3000'
           when :test
             'https://api-staging.knapsackpro.com'
           when :production

--- a/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/invalid_test_suite_token.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/invalid_test_suite_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.knapsackpro.dev:3000/v1/build_distributions/subset
+    uri: http://api.knapsackpro.test:3000/v1/build_distributions/subset
     body:
       encoding: UTF-8
       string: '{"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb"},{"path":"b_spec.rb"}],"test_suite_token":"fake"}'

--- a/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/success.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.knapsackpro.dev:3000/v1/build_distributions/subset
+    uri: http://api.knapsackpro.test:3000/v1/build_distributions/subset
     body:
       encoding: UTF-8
       string: '{"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb"},{"path":"b_spec.rb"}],"test_suite_token":"3fa64859337f6e56409d49f865d13fd7"}'

--- a/spec/fixtures/vcr_cassettes/api/v1/build_subsets/create/invalid_test_suite_token.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_subsets/create/invalid_test_suite_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.knapsackpro.dev:3000/v1/build_subsets
+    uri: http://api.knapsackpro.test:3000/v1/build_subsets
     body:
       encoding: UTF-8
       string: '{"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb","time_execution":1.2},{"path":"b_spec.rb","time_execution":0.3}],"test_suite_token":"fake"}'

--- a/spec/fixtures/vcr_cassettes/api/v1/build_subsets/create/success.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_subsets/create/success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.knapsackpro.dev:3000/v1/build_subsets
+    uri: http://api.knapsackpro.test:3000/v1/build_subsets
     body:
       encoding: UTF-8
       string: '{"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb","time_execution":1.2},{"path":"b_spec.rb","time_execution":0.3}],"test_suite_token":"3fa64859337f6e56409d49f865d13fd7"}'

--- a/spec/integration/api/build_distributions_subset_spec.rb
+++ b/spec/integration/api/build_distributions_subset_spec.rb
@@ -1,6 +1,6 @@
 describe 'Request API /v1/build_distributions/subset' do
-  let(:valid_endpoint) { 'http://api.knapsackpro.dev:3000' }
-  let(:invalid_endpoint) { 'http://api.fake-knapsackpro.dev:3000' }
+  let(:valid_endpoint) { 'http://api.knapsackpro.test:3000' }
+  let(:invalid_endpoint) { 'http://api.fake-knapsackpro.test:3000' }
   let(:valid_test_suite_token) { '3fa64859337f6e56409d49f865d13fd7' }
   let(:invalid_test_suite_token) { 'fake' }
 

--- a/spec/integration/api/build_subsets_create_spec.rb
+++ b/spec/integration/api/build_subsets_create_spec.rb
@@ -1,6 +1,6 @@
 describe 'Request API /v1/build_subsets' do
-  let(:valid_endpoint) { 'http://api.knapsackpro.dev:3000' }
-  let(:invalid_endpoint) { 'http://api.fake-knapsackpro.dev:3000' }
+  let(:valid_endpoint) { 'http://api.knapsackpro.test:3000' }
+  let(:invalid_endpoint) { 'http://api.fake-knapsackpro.test:3000' }
   let(:valid_test_suite_token) { '3fa64859337f6e56409d49f865d13fd7' }
   let(:invalid_test_suite_token) { 'fake' }
 

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -13,7 +13,7 @@ describe KnapsackPro::Client::Connection do
 
   before do
     stub_const('ENV', {
-      'KNAPSACK_PRO_ENDPOINT' => 'http://api.knapsackpro.dev:3000',
+      'KNAPSACK_PRO_ENDPOINT' => 'http://api.knapsackpro.test:3000',
       'KNAPSACK_PRO_TEST_SUITE_TOKEN' => '3fa64859337f6e56409d49f865d13fd7',
     })
   end
@@ -27,7 +27,7 @@ describe KnapsackPro::Client::Connection do
       before do
         http = instance_double(Net::HTTP)
 
-        expect(Net::HTTP).to receive(:new).with('api.knapsackpro.dev', 3000).and_return(http)
+        expect(Net::HTTP).to receive(:new).with('api.knapsackpro.test', 3000).and_return(http)
 
         expect(http).to receive(:use_ssl=).with(false)
         expect(http).to receive(:open_timeout=).with(15)

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -430,7 +430,7 @@ describe KnapsackPro::Config::Env do
 
       context 'when development mode' do
         before { stub_const("ENV", { 'KNAPSACK_PRO_MODE' => 'development' }) }
-        it { should eq 'http://api.knapsackpro.dev:3000' }
+        it { should eq 'http://api.knapsackpro.test:3000' }
       end
 
       context 'when test mode' do


### PR DESCRIPTION
This change is only for the maintainer of this repository.

`.dev` domain does not work anymore due Google acquired it. We should use `.test` domain.
https://medium.engineering/use-a-dev-domain-not-anymore-95219778e6fd