### PR TITLE
Retry request 3 times when API returns 5xx HTTP status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.6.0
+
+* Retry request 3 times when API returns 5xx HTTP status
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/78
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.5.0...v1.6.0
+
 ### 1.5.0
 
 * Add support for Semaphore CI 2.0

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -91,7 +91,7 @@ module KnapsackPro
         @http_response = http.post(uri.path, request_body, json_headers)
         @response_body = parse_response_body(http_response.body)
 
-        request_uuid = http_response.header['X-Request-Id']
+        request_uuid = http_response.header['X-Request-Id'] || 'N/A'
 
         logger.debug("API request UUID: #{request_uuid}")
         logger.debug("Test suite split seed: #{seed}") if has_seed?

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -2,6 +2,7 @@ module KnapsackPro
   module Client
     class Connection
       TIMEOUT = 15
+      MAX_RETRY = 3
       REQUEST_RETRY_TIMEBOX = 2
 
       def initialize(action)
@@ -106,7 +107,7 @@ module KnapsackPro
       rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
         logger.warn(e.inspect)
         retries += 1
-        if retries < 3
+        if retries < MAX_RETRY
           wait = retries * REQUEST_RETRY_TIMEBOX
           logger.warn("Wait #{wait}s and retry request to Knapsack Pro API.")
           sleep wait


### PR DESCRIPTION
# Before
When API returns 5xx error we don't retry the request. 
Because of that, we run tests in Fallback Mode right away when nginx returns 502 error when could not connect to unicorn process on API side.

# After this change
Retry request 3 times. If all 3 requests fail then start Fallback Mode.

Thanks to this change during API traffic peak time the Fallback Mode will be started only when it actually needs to.