### PR TITLE
Run Fallback Mode when OpenSSL::SSL::SSLError certificate verify failed for API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.8.0
+
+* Run Fallback Mode when `OpenSSL::SSL::SSLError` certificate verify failed for API
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/80
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.7.0...v1.8.0
+
 ### 1.7.0
 
 * Add `KNAPSACK_PRO_LOG_DIR` to set directory where to write logs

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -115,7 +115,7 @@ module KnapsackPro
         end
 
         response_body
-      rescue ServerError, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+      rescue ServerError, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
         logger.warn(e.inspect)
         retries += 1
         if retries < MAX_RETRY


### PR DESCRIPTION
When a request fails 3 times with `OpenSSL::SSL::SSLError` then run tests in Fallback Mode.

Error `OpenSSL::SSL::SSLError` can happen when certificate verify failed for Knapsack Pro API. It could happen during DNS propagation and changed SSL certificate for API.