### PR TITLE
Reduce data transfer and speed up usage of Knapsack Pro API for Queue Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.9.0
+
+* Reduce data transfer and speed up usage of Knapsack Pro API for Queue Mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/81
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.8.0...v1.9.0
+
 ### 1.8.0
 
 * Run Fallback Mode when `OpenSSL::SSL::SSLError` certificate verify failed for API

--- a/lib/knapsack_pro/client/api/v1/queues.rb
+++ b/lib/knapsack_pro/client/api/v1/queues.rb
@@ -5,19 +5,26 @@ module KnapsackPro
         class Queues < Base
           class << self
             def queue(args)
+              request_hash = {
+                :fixed_queue_split => KnapsackPro::Config::Env.fixed_queue_split,
+                :can_initialize_queue => args.fetch(:can_initialize_queue),
+                :commit_hash => args.fetch(:commit_hash),
+                :branch => args.fetch(:branch),
+                :node_total => args.fetch(:node_total),
+                :node_index => args.fetch(:node_index),
+                :node_build_id => KnapsackPro::Config::Env.ci_node_build_id,
+              }
+
+              if request_hash[:can_initialize_queue]
+                request_hash.merge!({
+                  :test_files => args.fetch(:test_files)
+                })
+              end
+
               action_class.new(
                 endpoint_path: '/v1/queues/queue',
                 http_method: :post,
-                request_hash: {
-                  :fixed_queue_split => KnapsackPro::Config::Env.fixed_queue_split,
-                  :can_initialize_queue => args.fetch(:can_initialize_queue),
-                  :commit_hash => args.fetch(:commit_hash),
-                  :branch => args.fetch(:branch),
-                  :node_total => args.fetch(:node_total),
-                  :node_index => args.fetch(:node_index),
-                  :node_build_id => KnapsackPro::Config::Env.ci_node_build_id,
-                  :test_files => args.fetch(:test_files)
-                }
+                request_hash: request_hash
               )
             end
           end

--- a/spec/knapsack_pro/client/api/v1/queues_spec.rb
+++ b/spec/knapsack_pro/client/api/v1/queues_spec.rb
@@ -1,12 +1,12 @@
 describe KnapsackPro::Client::API::V1::Queues do
   describe '.queue' do
     let(:fixed_queue_split) { double }
-    let(:can_initialize_queue) { double }
     let(:commit_hash) { double }
     let(:branch) { double }
     let(:node_total) { double }
     let(:node_index) { double }
     let(:test_files) { double }
+    let(:node_build_id) { double }
 
     subject do
       described_class.queue(
@@ -21,28 +21,52 @@ describe KnapsackPro::Client::API::V1::Queues do
 
     before do
       expect(KnapsackPro::Config::Env).to receive(:fixed_queue_split).and_return(fixed_queue_split)
+      expect(KnapsackPro::Config::Env).to receive(:ci_node_build_id).and_return(node_build_id)
     end
 
-    it do
-      node_build_id = double
-      expect(KnapsackPro::Config::Env).to receive(:ci_node_build_id).and_return(node_build_id)
+    context 'when can_initialize_queue=true' do
+      let(:can_initialize_queue) { true }
 
-      action = double
-      expect(KnapsackPro::Client::API::Action).to receive(:new).with({
-        endpoint_path: '/v1/queues/queue',
-        http_method: :post,
-        request_hash: {
-          fixed_queue_split: fixed_queue_split,
-          can_initialize_queue: can_initialize_queue,
-          commit_hash: commit_hash,
-          branch: branch,
-          node_total: node_total,
-          node_index: node_index,
-          node_build_id: node_build_id,
-          test_files: test_files
-        }
-      }).and_return(action)
-      expect(subject).to eq action
+      it 'sends test_files among other params' do
+        action = double
+        expect(KnapsackPro::Client::API::Action).to receive(:new).with({
+          endpoint_path: '/v1/queues/queue',
+          http_method: :post,
+          request_hash: {
+            fixed_queue_split: fixed_queue_split,
+            can_initialize_queue: can_initialize_queue,
+            commit_hash: commit_hash,
+            branch: branch,
+            node_total: node_total,
+            node_index: node_index,
+            node_build_id: node_build_id,
+            test_files: test_files
+          }
+        }).and_return(action)
+        expect(subject).to eq action
+      end
+    end
+
+    context 'when can_initialize_queue=false' do
+      let(:can_initialize_queue) { false }
+
+      it 'does not send test_files among other params' do
+        action = double
+        expect(KnapsackPro::Client::API::Action).to receive(:new).with({
+          endpoint_path: '/v1/queues/queue',
+          http_method: :post,
+          request_hash: {
+            fixed_queue_split: fixed_queue_split,
+            can_initialize_queue: can_initialize_queue,
+            commit_hash: commit_hash,
+            branch: branch,
+            node_total: node_total,
+            node_index: node_index,
+            node_build_id: node_build_id,
+          }
+        }).and_return(action)
+        expect(subject).to eq action
+      end
     end
   end
 end


### PR DESCRIPTION
Don’t send test_files for already initialized Queue. Thanks to that we reduce data transfer. This also makes requests much faster (even 10 times faster for test suite with 5000 test files).