### PR TITLE
Logs error on lost info about recorded timing for test files due to missing json files in Queue Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.10.0
+
+* Logs error on lost info about recorded timing for test files due missing json files in Queue Mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/83
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.9.0...v1.10.0
+
 ### 1.9.0
 
 * Reduce data transfer and speed up usage of Knapsack Pro API for Queue Mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 1.10.0
 
-* Logs error on lost info about recorded timing for test files due missing json files in Queue Mode
+* Logs error on lost info about recorded timing for test files due to missing json files in Queue Mode
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/83
 

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -42,7 +42,7 @@ module KnapsackPro
         end
 
         if executed_test_files_count > 0
-          KnapsackPro.logger.error("#{executed_test_files_count} test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow installation guide again: https://docs.knapsackpro.com/integration/")
+          KnapsackPro.logger.error("#{executed_test_files_count} test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow the installation guide again: https://docs.knapsackpro.com/integration/")
         end
       end
 

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -27,7 +27,7 @@ module KnapsackPro
       end
     end
 
-    def self.save_node_queue_to_api
+    def self.save_node_queue_to_api(executed_test_files_count)
       test_files = []
       Dir.glob("#{queue_path}/*.json").each do |file|
         report = JSON.parse(File.read(file))
@@ -35,9 +35,15 @@ module KnapsackPro
       end
 
       if test_files.empty?
-        KnapsackPro.logger.warn("No test files were executed on this CI node.")
-        KnapsackPro.logger.debug("When you use knapsack_pro queue mode then probably reason might be that CI node was started after the test files from the queue were already executed by other CI nodes. That is why this CI node has no test files to execute.")
-        KnapsackPro.logger.debug("Another reason might be when your CI node failed in a way that prevented knapsack_pro to save time execution data to Knapsack Pro API and you have just tried to retry failed CI node but instead you got no test files to execute. In that case knapsack_pro don't know what testes should be executed here.")
+        if executed_test_files_count == 0
+          KnapsackPro.logger.warn("No test files were executed on this CI node.")
+          KnapsackPro.logger.debug("When you use knapsack_pro queue mode then probably reason might be that CI node was started after the test files from the queue were already executed by other CI nodes. That is why this CI node has no test files to execute.")
+          KnapsackPro.logger.debug("Another reason might be when your CI node failed in a way that prevented knapsack_pro to save time execution data to Knapsack Pro API and you have just tried to retry failed CI node but instead you got no test files to execute. In that case knapsack_pro don't know what testes should be executed here.")
+        end
+
+        if executed_test_files_count > 0
+          KnapsackPro.logger.error("#{executed_test_files_count} test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run.")
+        end
       end
 
       create_build_subset(test_files)

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -42,7 +42,7 @@ module KnapsackPro
         end
 
         if executed_test_files_count > 0
-          KnapsackPro.logger.error("#{executed_test_files_count} test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run.")
+          KnapsackPro.logger.error("#{executed_test_files_count} test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow installation guide again: https://docs.knapsackpro.com/integration/")
         end
       end
 

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -48,7 +48,7 @@ module KnapsackPro
           if test_file_paths.empty?
             KnapsackPro::Hooks::Queue.call_after_queue
 
-            KnapsackPro::Report.save_node_queue_to_api
+            KnapsackPro::Report.save_node_queue_to_api(all_test_file_paths.count)
 
             return {
               status: :completed,

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -59,7 +59,7 @@ module KnapsackPro
 
             KnapsackPro::Hooks::Queue.call_after_queue
 
-            KnapsackPro::Report.save_node_queue_to_api
+            KnapsackPro::Report.save_node_queue_to_api(all_test_file_paths.count)
 
             return {
               status: :completed,

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -91,7 +91,7 @@ describe KnapsackPro::Report do
       it 'logs error on lost info about recorded timing for test files due missing json files AND creates empty build subset' do
         logger = instance_double(Logger)
         expect(KnapsackPro).to receive(:logger).and_return(logger)
-        expect(logger).to receive(:error).with('2 test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run.')
+        expect(logger).to receive(:error).with('2 test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow installation guide again: https://docs.knapsackpro.com/integration/')
 
         expect(described_class).to receive(:create_build_subset).with([])
 

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -91,7 +91,7 @@ describe KnapsackPro::Report do
       it 'logs error on lost info about recorded timing for test files due missing json files AND creates empty build subset' do
         logger = instance_double(Logger)
         expect(KnapsackPro).to receive(:logger).and_return(logger)
-        expect(logger).to receive(:error).with('2 test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow installation guide again: https://docs.knapsackpro.com/integration/')
+        expect(logger).to receive(:error).with('2 test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow the installation guide again: https://docs.knapsackpro.com/integration/')
 
         expect(described_class).to receive(:create_build_subset).with([])
 

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -43,33 +43,85 @@ describe KnapsackPro::Report do
   end
 
   describe '.save_node_queue_to_api' do
-    let(:json_test_file_a_path) { double }
-    let(:json_test_file_a) { [{ 'path' => 'a_spec.rb' }] }
+    context 'when json files with recorded time exist for executed test files' do
+      let(:json_test_file_a_path) { double }
+      let(:json_test_file_a) { [{ 'path' => 'a_spec.rb' }] }
 
-    let(:json_test_file_b_path) { double }
-    let(:json_test_file_b) { [{ 'path' => 'b_spec.rb' }] }
+      let(:json_test_file_b_path) { double }
+      let(:json_test_file_b) { [{ 'path' => 'b_spec.rb' }] }
 
-    subject { described_class.save_node_queue_to_api }
+      let(:executed_test_files_count) { 2 }
 
-    before do
-      queue_id = 'fake-queue-id'
-      expect(KnapsackPro::Config::Env).to receive(:queue_id).and_return(queue_id)
+      subject { described_class.save_node_queue_to_api(executed_test_files_count) }
 
-      expect(Dir).to receive(:glob).with('tmp/knapsack_pro/queue/fake-queue-id/*.json').and_return([
-        json_test_file_a_path,
-        json_test_file_b_path
-      ])
+      before do
+        queue_id = 'fake-queue-id'
+        expect(KnapsackPro::Config::Env).to receive(:queue_id).and_return(queue_id)
 
-      expect(File).to receive(:read).with(json_test_file_a_path).and_return(json_test_file_a.to_json)
-      expect(File).to receive(:read).with(json_test_file_b_path).and_return(json_test_file_b.to_json)
+        expect(Dir).to receive(:glob).with('tmp/knapsack_pro/queue/fake-queue-id/*.json').and_return([
+          json_test_file_a_path,
+          json_test_file_b_path
+        ])
+
+        expect(File).to receive(:read).with(json_test_file_a_path).and_return(json_test_file_a.to_json)
+        expect(File).to receive(:read).with(json_test_file_b_path).and_return(json_test_file_b.to_json)
+      end
+
+      it 'creates build subset for 2 recorded test files timing' do
+        expect(described_class).to receive(:create_build_subset).with(
+          json_test_file_a + json_test_file_b
+        )
+
+        subject
+      end
     end
 
-    it do
-      expect(described_class).to receive(:create_build_subset).with(
-        json_test_file_a + json_test_file_b
-      )
+    context 'when json files with recorded time does not exist for executed test files' do
+      let(:executed_test_files_count) { 2 }
 
-      subject
+      subject { described_class.save_node_queue_to_api(executed_test_files_count) }
+
+      before do
+        queue_id = 'fake-queue-id'
+        expect(KnapsackPro::Config::Env).to receive(:queue_id).and_return(queue_id)
+
+        expect(Dir).to receive(:glob).with('tmp/knapsack_pro/queue/fake-queue-id/*.json').and_return([])
+      end
+
+      it 'logs error on lost info about recorded timing for test files due missing json files AND creates empty build subset' do
+        logger = instance_double(Logger)
+        expect(KnapsackPro).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:error).with('2 test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run.')
+
+        expect(described_class).to receive(:create_build_subset).with([])
+
+        subject
+      end
+    end
+
+    context 'when json files with recorded time does not exist AND no executed test files' do
+      let(:executed_test_files_count) { 0 }
+
+      subject { described_class.save_node_queue_to_api(executed_test_files_count) }
+
+      before do
+        queue_id = 'fake-queue-id'
+        expect(KnapsackPro::Config::Env).to receive(:queue_id).and_return(queue_id)
+
+        expect(Dir).to receive(:glob).with('tmp/knapsack_pro/queue/fake-queue-id/*.json').and_return([])
+      end
+
+      it 'logs warning about reasons why no test files were executed on this CI node' do
+        logger = instance_double(Logger)
+        expect(KnapsackPro).to receive(:logger).exactly(3).and_return(logger)
+        expect(logger).to receive(:warn).with('No test files were executed on this CI node.')
+        expect(logger).to receive(:debug).with('When you use knapsack_pro queue mode then probably reason might be that CI node was started after the test files from the queue were already executed by other CI nodes. That is why this CI node has no test files to execute.')
+        expect(logger).to receive(:debug).with("Another reason might be when your CI node failed in a way that prevented knapsack_pro to save time execution data to Knapsack Pro API and you have just tried to retry failed CI node but instead you got no test files to execute. In that case knapsack_pro don't know what testes should be executed here.")
+
+        expect(described_class).to receive(:create_build_subset).with([])
+
+        subject
+      end
     end
   end
 

--- a/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
@@ -161,7 +161,7 @@ describe KnapsackPro::Runners::Queue::MinitestRunner do
 
       it 'returns exit code 0' do
         expect(KnapsackPro::Hooks::Queue).to receive(:call_after_queue)
-        expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
+        expect(KnapsackPro::Report).to receive(:save_node_queue_to_api).with(0)
 
         expect(subject).to eq({
           status: :completed,

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -203,7 +203,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
           expect(KnapsackPro::Formatters::RSpecQueueProfileFormatterExtension).to receive(:print_summary)
 
           expect(KnapsackPro::Hooks::Queue).to receive(:call_after_queue)
-          expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
+          expect(KnapsackPro::Report).to receive(:save_node_queue_to_api).with(1)
 
           expect(subject).to eq({
             status: :completed,
@@ -217,7 +217,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
         it do
           expect(KnapsackPro::Hooks::Queue).to receive(:call_after_queue)
-          expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
+          expect(KnapsackPro::Report).to receive(:save_node_queue_to_api).with(0)
 
           expect(subject).to eq({
             status: :completed,


### PR DESCRIPTION
# Problem is related to knapsack_pro Queue Mode
Sometimes users have in their tests code that clears `tmp` directory. For instance, user can have RSpec hooks like `after(:each)` or `after(:suite)` that remove the content of `tmp` folder.

knapsack_pro gem uses `tmp/knapsack_pro/queue/` directory to store json files with a recorded time of tests. 

# Introduced change
This pull request adds log error to notify the user when the `tmp/knapsack_pro/queue/` directory is empty even when some test files where executed. It means the user has probably RSpec hook or some other code that clears `tmp` directory which breaks knapsack_pro.

Another reason might be that you forgot to add `Knapsack::Adapters::RspecAdapter.bind` in your `rails_helper.rb` or `spec_helper.rb`. Please follow the installation guide again: https://docs.knapsackpro.com/integration/