### PR TITLE
Fix bug: default test file time should not be added to measured time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/83
 
+* Fix bug: default test file time should not be added to measured time
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/84
+
 https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.9.0...v1.10.0
 
 ### 1.9.0

--- a/spec/knapsack_pro/tracker_spec.rb
+++ b/spec/knapsack_pro/tracker_spec.rb
@@ -56,8 +56,8 @@ describe KnapsackPro::Tracker do
 
       it { expect(tracker.global_time).to be_within(delta).of(0.3) }
       it { expect(tracker.test_files_with_time.keys.size).to eql 2 }
-      it { expect(tracker.test_files_with_time['a_spec.rb']).to be_within(delta).of(0.1) }
-      it { expect(tracker.test_files_with_time['b_spec.rb']).to be_within(delta).of(0.2) }
+      it { expect(tracker.test_files_with_time['a_spec.rb'][:time_execution]).to be_within(delta).of(0.1) }
+      it { expect(tracker.test_files_with_time['b_spec.rb'][:time_execution]).to be_within(delta).of(0.2) }
       it_behaves_like '#to_a'
     end
 
@@ -81,8 +81,8 @@ describe KnapsackPro::Tracker do
       it { expect(tracker.global_time).to be > 0 }
       it { expect(tracker.global_time).to be_within(delta).of(0) }
       it { expect(tracker.test_files_with_time.keys.size).to eql 2 }
-      it { expect(tracker.test_files_with_time['a_spec.rb']).to be_within(delta).of(0) }
-      it { expect(tracker.test_files_with_time['b_spec.rb']).to be_within(delta).of(0) }
+      it { expect(tracker.test_files_with_time['a_spec.rb'][:time_execution]).to be_within(delta).of(0) }
+      it { expect(tracker.test_files_with_time['b_spec.rb'][:time_execution]).to be_within(delta).of(0) }
       it_behaves_like '#to_a'
     end
 
@@ -97,8 +97,8 @@ describe KnapsackPro::Tracker do
 
       it { expect(tracker.global_time).to eq 0 }
       it { expect(tracker.test_files_with_time.keys.size).to eql 2 }
-      it { expect(tracker.test_files_with_time['a_spec.rb']).to eq 0 }
-      it { expect(tracker.test_files_with_time['b_spec.rb']).to eq 0 }
+      it { expect(tracker.test_files_with_time['a_spec.rb'][:time_execution]).to eq 0 }
+      it { expect(tracker.test_files_with_time['b_spec.rb'][:time_execution]).to eq 0 }
       it_behaves_like '#to_a'
     end
   end


### PR DESCRIPTION
# Problem
When test file is pending, empty with no tests or has syntax error then we assume default time execution 0.1s for it. This helps to better allocate it in Queue Mode for future CI build runs.

It turned out that when the test file was executed then measured time was added to 0.1 seconds. 

Related to PR: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/71

# Fix
We should not add default 0.1s to measured test file time.