### PR TITLE
Fix log info when measured time of tests was lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.10.1
+
+* Fix log info when measured time of tests was lost
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/85
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.10.0...v1.10.1
+
 ### 1.10.0
 
 * Logs error on lost info about recorded timing for test files due to missing json files in Queue Mode

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -45,7 +45,10 @@ module KnapsackPro
         .select { |time_execution| time_execution != KnapsackPro::Tracker::DEFAULT_TEST_FILE_TIME }
 
       if test_files.size > 0 && measured_test_files.size == 0
-        KnapsackPro.logger.error("#{test_files.size} test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow the installation guide again: https://docs.knapsackpro.com/integration/")
+        KnapsackPro.logger.warn("#{test_files.size} test files were executed on this CI node but the recorded time was lost due to:")
+        KnapsackPro.logger.warn("1. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run.")
+        KnapsackPro.logger.warn("2. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow the installation guide again: https://docs.knapsackpro.com/integration/")
+        KnapsackPro.logger.warn("3. All your tests are empty test files, are pending tests or have syntax error and could not be executed hence no measured time execution by knapsack_pro.")
       end
 
       create_build_subset(test_files)

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -48,7 +48,7 @@ module KnapsackPro
           if test_file_paths.empty?
             KnapsackPro::Hooks::Queue.call_after_queue
 
-            KnapsackPro::Report.save_node_queue_to_api(all_test_file_paths.count)
+            KnapsackPro::Report.save_node_queue_to_api
 
             return {
               status: :completed,

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -59,7 +59,7 @@ module KnapsackPro
 
             KnapsackPro::Hooks::Queue.call_after_queue
 
-            KnapsackPro::Report.save_node_queue_to_api(all_test_file_paths.count)
+            KnapsackPro::Report.save_node_queue_to_api
 
             return {
               status: :completed,

--- a/spec/knapsack_pro/report_spec.rb
+++ b/spec/knapsack_pro/report_spec.rb
@@ -100,8 +100,11 @@ describe KnapsackPro::Report do
 
       it 'logs error on lost info about recorded timing for test files due missing json files AND creates empty build subset' do
         logger = instance_double(Logger)
-        expect(KnapsackPro).to receive(:logger).and_return(logger)
-        expect(logger).to receive(:error).with('2 test files were executed on this CI node but the recorded time of it was lost. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow the installation guide again: https://docs.knapsackpro.com/integration/')
+        expect(KnapsackPro).to receive(:logger).exactly(4).and_return(logger)
+        expect(logger).to receive(:warn).with('2 test files were executed on this CI node but the recorded time was lost due to:')
+        expect(logger).to receive(:warn).with('1. Probably you have a code (i.e. RSpec hooks) that clears tmp directory in your project. Please ensure you do not remove the content of tmp/knapsack_pro/queue/ directory between tests run.')
+        expect(logger).to receive(:warn).with('2. Another reason might be that you forgot to add Knapsack::Adapters::RspecAdapter.bind in your rails_helper.rb or spec_helper.rb. Please follow the installation guide again: https://docs.knapsackpro.com/integration/')
+        expect(logger).to receive(:warn).with('3. All your tests are empty test files, are pending tests or have syntax error and could not be executed hence no measured time execution by knapsack_pro.')
 
         expect(described_class).to receive(:create_build_subset).with(
           json_test_file_a + json_test_file_b

--- a/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
@@ -161,7 +161,7 @@ describe KnapsackPro::Runners::Queue::MinitestRunner do
 
       it 'returns exit code 0' do
         expect(KnapsackPro::Hooks::Queue).to receive(:call_after_queue)
-        expect(KnapsackPro::Report).to receive(:save_node_queue_to_api).with(0)
+        expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
 
         expect(subject).to eq({
           status: :completed,

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -203,7 +203,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
           expect(KnapsackPro::Formatters::RSpecQueueProfileFormatterExtension).to receive(:print_summary)
 
           expect(KnapsackPro::Hooks::Queue).to receive(:call_after_queue)
-          expect(KnapsackPro::Report).to receive(:save_node_queue_to_api).with(1)
+          expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
 
           expect(subject).to eq({
             status: :completed,
@@ -217,7 +217,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
         it do
           expect(KnapsackPro::Hooks::Queue).to receive(:call_after_queue)
-          expect(KnapsackPro::Report).to receive(:save_node_queue_to_api).with(0)
+          expect(KnapsackPro::Report).to receive(:save_node_queue_to_api)
 
           expect(subject).to eq({
             status: :completed,


### PR DESCRIPTION
Fix bug with not showing in logs info about measured time being lost due to:
* missing Knapsack::Adapters::RspecAdapter.bind
* cleared tmp directory
* all tests being empty, pending or have syntax error

Related: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/83