### PR TITLE
Fix GitLab CI environment variables integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### 1.12.1
+
+* Use `CI_PIPELINE_ID` as build ID for GitLab CI because it is unique across parallel jobs.
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.12.0...v1.12.1
+
 ### 1.12.0
 
 * Add Queue Mode for Cucumber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Use `CI_PIPELINE_ID` as build ID for GitLab CI because it is unique across parallel jobs
 * Load GitLab CI first to avoid edge case with order of loading envs for `CI_NODE_INDEX`
 
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/88
+
 https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.12.0...v1.12.1
 
 ### 1.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 1.12.1
 
-* Use `CI_PIPELINE_ID` as build ID for GitLab CI because it is unique across parallel jobs.
+* Use `CI_PIPELINE_ID` as build ID for GitLab CI because it is unique across parallel jobs
+* Load GitLab CI first to avoid edge case with order of loading envs for `CI_NODE_INDEX`
 
 https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.12.0...v1.12.1
 

--- a/lib/knapsack_pro/config/ci/gitlab_ci.rb
+++ b/lib/knapsack_pro/config/ci/gitlab_ci.rb
@@ -15,7 +15,7 @@ module KnapsackPro
         end
 
         def node_build_id
-          ENV['CI_JOB_ID'] || # Gitlab Release 9.0+
+          ENV['CI_PIPELINE_ID'] || # Gitlab Release 9.0+
           ENV['CI_BUILD_ID']  # Gitlab Release 8.x
         end
 

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -177,7 +177,9 @@ module KnapsackPro
 
         def ci_env_for(env_name)
           value = nil
-          ci_list = KnapsackPro::Config::CI.constants - [:Base]
+          ci_list = KnapsackPro::Config::CI.constants - [:Base, :GitlabCI]
+          # load GitLab CI first to avoid edge case with order of loading envs for CI_NODE_INDEX
+          ci_list = [:GitlabCI] + ci_list
           ci_list.each do |ci_name|
             ci_class = Object.const_get("KnapsackPro::Config::CI::#{ci_name}")
             ci = ci_class.new

--- a/spec/knapsack_pro/config/ci/gitlab_ci_spec.rb
+++ b/spec/knapsack_pro/config/ci/gitlab_ci_spec.rb
@@ -37,7 +37,7 @@ describe KnapsackPro::Config::CI::GitlabCI do
     subject { described_class.new.node_build_id }
 
     context 'when Gitlab Release 9.0+ and environment exists' do
-      let(:env) { { 'CI_JOB_ID' => 7046507 } }
+      let(:env) { { 'CI_PIPELINE_ID' => 7046507 } }
       it { should eql 7046507 }
     end
 

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -40,6 +40,13 @@ describe KnapsackPro::Config::Env do
 
         it { should eq 2 }
       end
+
+      context 'when order of loading envs does matter' do
+        context 'when GitLab CI' do
+          before { stub_const("ENV", { 'CI_NODE_INDEX' => '2', 'GITLAB_CI' => 'true' }) }
+          it { should eq 1 }
+        end
+      end
     end
 
     context "when ENV doesn't exist" do


### PR DESCRIPTION
* Use `CI_PIPELINE_ID` as build ID for GitLab CI because it is unique across parallel jobs
* Load GitLab CI envs first to avoid edge case with an order of loading envs for `CI_NODE_INDEX`. Gitlab CI starts from 1 instead of index 0 for `CI_NODE_INDEX`. We should first check if CI is Gitlab CI then do `CI_NODE_INDEX - 1`. Otherwise, assume it's other CI provider and just use `CI_NODE_INDEX`.