### PR TITLE
Add support for job index and job count for parallelism in Semaphore 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.13.0
+
+* Add support for job index and job count for parallelism in Semaphore 2.0
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/89
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.12.1...v1.13.0
+
 ### 1.12.1
 
 * Use `CI_PIPELINE_ID` as build ID for GitLab CI because it is unique across parallel jobs

--- a/README.md
+++ b/README.md
@@ -905,9 +905,7 @@ More info about global and matrix ENV configuration in [travis docs](https://doc
 knapsack_pro gem supports environment variables provided by Semaphore CI 2.0 to run your tests. You will have to define a few things in `.semaphore/semaphore.yml` config file.
 
 * You need to set `KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC`. If you don't want to commit secrets in yml file then you can [follow this guide](https://docs.semaphoreci.com/article/66-environment-variables-and-secrets).
-* You need to create as many jobs with unique names (Node 0 - Knapsack Pro, Node 1 - Knapsack Pro etc) as many parallel jobs you want to run. If your test suite is long you should use more parallel jobs.
-* If you have 2 parallel jobs you need to set `KNAPSACK_PRO_CI_NODE_TOTAL=2` for each job.
-* You need to set job index starting from 0 like `KNAPSACK_PRO_CI_NODE_INDEX=0` for Node 0.
+* You should create as many parallel jobs as you need with `parallelism` property. If your test suite is long you should use more parallel jobs.
 
 Below you can find full Semaphore CI 2.0 config for Rails project.
 

--- a/README.md
+++ b/README.md
@@ -986,13 +986,10 @@ blocks:
           - bundle exec rake db:setup
 
       jobs:
-      - name: Node 0 - Knapsack Pro
+      - name: Run tests with Knapsack Pro
+        parallelism: 2
         commands:
-          - KNAPSACK_PRO_CI_NODE_TOTAL=2 KNAPSACK_PRO_CI_NODE_INDEX=0 bundle exec rake knapsack_pro:queue:rspec
-
-      - name: Node 1 - Knapsack Pro
-        commands:
-          - KNAPSACK_PRO_CI_NODE_TOTAL=2 KNAPSACK_PRO_CI_NODE_INDEX=1 bundle exec rake knapsack_pro:queue:rspec
+        - bundle exec rake knapsack_pro:queue:rspec
 ```
 
 ##### Semaphore 1.0

--- a/lib/knapsack_pro/config/ci/semaphore2.rb
+++ b/lib/knapsack_pro/config/ci/semaphore2.rb
@@ -4,11 +4,12 @@ module KnapsackPro
     module CI
       class Semaphore2 < Base
         def node_total
-          # not provided
+          ENV['SEMAPHORE_JOB_COUNT']
         end
 
         def node_index
-          # not provided
+          index = ENV['SEMAPHORE_JOB_INDEX']
+          index.to_i - 1 if index
         end
 
         def node_build_id

--- a/spec/knapsack_pro/config/ci/semaphore2_spec.rb
+++ b/spec/knapsack_pro/config/ci/semaphore2_spec.rb
@@ -10,13 +10,27 @@ describe KnapsackPro::Config::CI::Semaphore2 do
   describe '#node_total' do
     subject { described_class.new.node_total }
 
-    it { should be nil }
+    context 'when environment exists' do
+      let(:env) { { 'SEMAPHORE_JOB_COUNT' => 4 } }
+      it { should eql 4 }
+    end
+
+    context "when environment doesn't exist" do
+      it { should be nil }
+    end
   end
 
   describe '#node_index' do
     subject { described_class.new.node_index }
 
-    it { should be nil }
+    context 'when environment exists' do
+      let(:env) { { 'SEMAPHORE_JOB_INDEX' => 4 } }
+      it { should eql 3 }
+    end
+
+    context "when environment doesn't exist" do
+      it { should be nil }
+    end
   end
 
   describe '#node_build_id' do


### PR DESCRIPTION
* `SEMAPHORE_JOB_COUNT` - total number of jobs generated via parallelism property
* `SEMAPHORE_JOB_INDEX` - value in the range from 1 to `SEMAPHORE_JOB_COUNT` which represents the index of a particular job in the list of generated jobs.

https://docs.semaphoreci.com/article/50-pipeline-yaml#parallelism