### PR TITLE
Allow to use Queue Mode for old RSpec versions that don't have RSpec.configuration.reset_filters method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.16.1
+
+* Allow to use Queue Mode for old RSpec versions that don't have `RSpec.configuration.reset_filters` method
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/96
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.16.0...v1.16.1
+
 ### 1.16.0
 
 * Add test runner name to `KNAPSACK-PRO-CLIENT-NAME` header send to Knapsack Pro API

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -131,7 +131,11 @@ module KnapsackPro
           end
           RSpec.world.example_groups.clear
           RSpec.configuration.start_time = ::RSpec::Core::Time.now
-          RSpec.configuration.reset_filters
+
+          # skip reset filters for old RSpec versions
+          if RSpec.configuration.respond_to?(:reset_filters)
+            RSpec.configuration.reset_filters
+          end
         end
       end
     end


### PR DESCRIPTION
Call `RSpec.configuration.reset_filters` for RSpec only if this method exists. This way we won't call it for old RSpec version like RSpec 3.1.0