### PR TITLE
Add KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX to allow run Cucumber with spring gem in Queue Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.17.0
+
+* Add `KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX` to allow run Cucumber with spring gem in Queue Mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/98
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.16.1...v1.17.0
+
 ### 1.16.1
 
 * Allow to use Queue Mode for old RSpec versions that don't have `RSpec.configuration.reset_filters` method

--- a/README.md
+++ b/README.md
@@ -482,6 +482,11 @@ bundle exec rake knapsack_pro:queue:rspec
 bundle exec rake knapsack_pro:queue:minitest
 
 # Cucumber
+# If you use spring gem and spring-commands-cucumber gem to start Cucumber tests faster please set
+# export KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX=bundle exec spring
+# or you can use spring binstub
+# export KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX=bin/spring
+# Thanks to that Cucumber will start tests faster for each batch of tests fetched from Knapsack Pro Queue API
 bundle exec rake knapsack_pro:queue:cucumber
 ```
 

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -139,6 +139,10 @@ module KnapsackPro
           ENV.fetch('KNAPSACK_PRO_FIXED_QUEUE_SPLIT', false)
         end
 
+        def cucumber_queue_prefix
+          ENV.fetch('KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX', 'bundle exec')
+        end
+
         def test_suite_token
           env_name = 'KNAPSACK_PRO_TEST_SUITE_TOKEN'
           ENV[env_name] || raise("Missing environment variable #{env_name}. You should set environment variable like #{env_name}_RSPEC (note there is suffix _RSPEC at the end). knapsack_pro gem will set #{env_name} based on #{env_name}_RSPEC value. If you use other test runner than RSpec then use proper suffix.")

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -79,7 +79,10 @@ module KnapsackPro
         def self.cucumber_run(runner, test_file_paths, args)
           stringify_test_file_paths = KnapsackPro::TestFilePresenter.stringify_paths(test_file_paths)
 
-          cmd = %Q[bundle exec cucumber #{args} --require #{runner.test_dir} -- #{stringify_test_file_paths}]
+          cmd = [
+            KnapsackPro::Config::Env.cucumber_queue_prefix,
+            %Q[cucumber #{args} --require #{runner.test_dir} -- #{stringify_test_file_paths}]
+          ].join(' ')
 
           Kernel.system(cmd)
 

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -504,6 +504,20 @@ describe KnapsackPro::Config::Env do
     end
   end
 
+  describe '.cucumber_queue_prefix' do
+    subject { described_class.cucumber_queue_prefix }
+
+    context 'when ENV exists' do
+      before { stub_const("ENV", { 'KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX' => 'bundle exec spring' }) }
+      it { should eq 'bundle exec spring' }
+    end
+
+    context "when ENV doesn't exist" do
+      before { stub_const("ENV", {}) }
+      it { should eq 'bundle exec' }
+    end
+  end
+
   describe '.test_suite_token' do
     subject { described_class.test_suite_token }
 


### PR DESCRIPTION
This solves issue https://github.com/KnapsackPro/knapsack_pro-ruby/issues/97

# How to use it

```bash
KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX='bundle exec spring'
or
KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX='bin/spring'
```

It would add this prefix to Cucumber command to run it faster in Knapsack Pro Queue Mode thanks to spring gem.