### PR TITLE
Increase delay between request retry to Knapsack Pro API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### Unreleased
+
+* Increase delay between request retry to Knapsack Pro API from 2s to 4s for 2nd request and from 4s to 8s for 3rd request
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/99
+
 ### 1.17.0
 
 * Add `KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX` to allow run Cucumber with spring gem in Queue Mode

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -5,7 +5,7 @@ module KnapsackPro
 
       TIMEOUT = 15
       MAX_RETRY = 3
-      REQUEST_RETRY_TIMEBOX = 2
+      REQUEST_RETRY_TIMEBOX = 4
 
       def initialize(action)
         @action = action

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -152,10 +152,10 @@ describe KnapsackPro::Client::Connection do
           server_error = described_class::ServerError.new(parsed_response)
           expect(logger).to receive(:warn).exactly(3).with(server_error.inspect)
 
-          expect(logger).to receive(:warn).with("Wait 2s and retry request to Knapsack Pro API.")
           expect(logger).to receive(:warn).with("Wait 4s and retry request to Knapsack Pro API.")
-          expect(Kernel).to receive(:sleep).with(2)
+          expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
           expect(Kernel).to receive(:sleep).with(4)
+          expect(Kernel).to receive(:sleep).with(8)
 
           expect(subject).to eq(parsed_response)
 


### PR DESCRIPTION
Increase delay between request retry to Knapsack Pro API:
* from 2s to 4s for 2nd request 
* from 4s to 8s for 3rd request

This should help with not flooding Knapsack Pro API with too fast request retries. 