### PR TITLE
Do not allow Fallback Mode when the CI node was retried to avoid running the wrong set of tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Change Log
 
-### Unreleased
+### 1.18.0
+
+* __IMPORTANT__ Do not allow Fallback Mode when the CI node was retried to avoid running the wrong set of tests
+
+    Please read the PR description if you are using retry failed CI node feature on your CI (for instance you use Buildkite).
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100
 
 * Increase delay between request retry to Knapsack Pro API from 2s to 4s for 2nd request and from 4s to 8s for 3rd request
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/99
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.17.0...v1.18.0
 
 ### 1.17.0
 

--- a/README.md
+++ b/README.md
@@ -565,18 +565,6 @@ There might be some cached test suite splits for git commits you have run in pas
     [knapsack_pro] {"queue_name"=>"retry-dead-ci-node:queue-id", "test_files"=>[{"path"=>"spec/foo_spec.rb", "time_execution"=>1.23}]}
     ```
 
-  * __IMPORTANT:__ If you use __the feature to retry only a single failed CI node__ on your CI server (for instance you use Buildkite and you use [auto-retry](https://buildkite.com/docs/pipelines/command-step#retry-attributes) for the failed job) then you need to be aware of [a race condition that could happen](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100). knapsack_pro should not allow running tests in Fallback Mode in the case when the failed CI node was retried to prevent running the wrong set of tests.
-
-    knapsack_pro has built-in support for retries of failed parallel CI nodes for listed CI servers:
-
-    * Buildkite (knapsack_pro reads `BUILDKITE_RETRY_COUNT`)
-
-    knapsack_pro reads ENV vars for above CI servers and it disables Fallback Mode when failed parallel CI node can't connect with Knapsack Pro API. This way we prevent running the wrong set of tests by Fallback Mode on retried CI node.
-
-    If you use other CI server you need to manually configure your CI server to set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT=1` only during retry CI node attempt. If `KNAPSACK_PRO_CI_NODE_RETRY_COUNT > 0` then knapsack_pro won't allow starting running tests in Fallback Mode and instead will raise error so a user can manually retry CI node later when a connection to Knapsack Pro API can be established.
-
-    If you cannot set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT` only for retried CI node or it is not possible for your CI server then you can disable Fallback Mode completely `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false`.
-
   * To [reproduce tests executed on CI node](#for-knapsack_pro-queue-mode) in development environment please see FAQ.
 
 #### KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS (hide duplicated summary of pending and failed tests)
@@ -655,6 +643,22 @@ This is only for maintainer of knapsack_pro gem. Not for the end users.
 * `KNAPSACK_PRO_MODE` - Default value is `production` and then endpoint is `https://api.knapsackpro.com`.
   * When mode is `development` then endpoint is `http://api.knapsackpro.test:3000`.
   * When mode is `test` then endpoint is `https://api-staging.knapsackpro.com`.
+
+### Required CI configuration if you use retry single failed CI node feature on your CI server when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true (in Queue Mode) or KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true (in Regular Mode)
+
+Read below required configuration step if you use Queue Mode and you set [`KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true`](#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node) or you use Regular Mode which has by default [`KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true`](#knapsack_pro_fixed_test_suite_splite-test-suite-splite-based-on-seed).
+
+* __IMPORTANT:__ If you use __the feature to retry only a single failed CI node__ on your CI server (for instance you use Buildkite and you use [auto-retry](https://buildkite.com/docs/pipelines/command-step#retry-attributes) for the failed job) then you need to be aware of [a race condition that could happen](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100). knapsack_pro should not allow running tests in Fallback Mode in the case when the failed CI node was retried to prevent running the wrong set of tests.
+
+  knapsack_pro has built-in support for retries of failed parallel CI nodes for listed CI servers:
+
+  * Buildkite (knapsack_pro reads `BUILDKITE_RETRY_COUNT`)
+
+  knapsack_pro reads ENV vars for above CI servers and it disables Fallback Mode when failed parallel CI node can't connect with Knapsack Pro API. This way we prevent running the wrong set of tests by Fallback Mode on retried CI node.
+
+  If you use other CI server you need to manually configure your CI server to set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT=1` only during retry CI node attempt. If `KNAPSACK_PRO_CI_NODE_RETRY_COUNT > 0` then knapsack_pro won't allow starting running tests in Fallback Mode and instead will raise error so a user can manually retry CI node later when a connection to Knapsack Pro API can be established.
+
+  If you cannot set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT` only for retried CI node or it is not possible for your CI server then you can disable Fallback Mode completely `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false`.
 
 ### Passing arguments to rake task
 

--- a/README.md
+++ b/README.md
@@ -621,13 +621,15 @@ Note this is for knapsack_pro regular mode only.
 
     Thanks to that when tests on one of your node failed you can retry the node with exactly the same subset of tests that were run on the node in the first place.
 
-    There is one edge case. When you run tests for the first time and there is no data collected about time execution of your tests then
-    we need to collect data to prepare the first test suite split. The second run of your tests will have fixed test suite split.
+    * There is one edge case. When you run tests for the first time and there is no data collected about time execution of your tests then
+      we need to collect data to prepare the first test suite split. The second run of your tests will have fixed test suite split.
 
-    To compare if all your CI nodes are running based on the same test suite split seed you can check the value for seed in knapsack logging message
-    before your test starts. The message looks like:
+      To compare if all your CI nodes are running based on the same test suite split seed you can check the value for seed in knapsack logging message
+      before your test starts. The message looks like:
 
-        [knapsack_pro] Test suite split seed: 8a606431-02a1-4766-9878-0ea42a07ad21
+      ```
+      [knapsack_pro] Test suite split seed: 8a606431-02a1-4766-9878-0ea42a07ad21
+      ```
 
 * `KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=false`
 

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ There might be some cached test suite splits for git commits you have run in pas
     ```
 
   * __IMPORTANT:__ If you use __feature to retry only single failed CI node__ on your CI server (for instance you use Buildkite and you use [auto-retry](https://buildkite.com/docs/pipelines/command-step#retry-attributes) for failed job) then you need to be aware of [race condition that could happen](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100). knapsack_pro should not allow running tests in Fallback Mode in the case when failed CI node was retried to prevent running wrong set of tests.
-  
+
     knapsack_pro has built in support for retries of failed parallel CI nodes for listed CI servers:
 
     * Buildkite (knapsack_pro reads `BUILDKITE_RETRY_COUNT`)
@@ -574,6 +574,7 @@ There might be some cached test suite splits for git commits you have run in pas
     knapsack_pro reads ENV vars for above CI servers and it disables Fallback Mode when failed parallel CI node can't connect with Knapsack Pro API. This way we prevent running wrong set of tests by Fallback Mode on retried CI node.
 
     If you use other CI server you need to manually configure your CI server to set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT=1` only during retry CI node attempt. If `KNAPSACK_PRO_CI_NODE_RETRY_COUNT > 0` then knapsack_pro won't allow to start running tests in Fallback Mode and instead will raise error so user can manually retry CI node later when connection to Knapsack Pro API can be established.
+
     If you cannot set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT` only for retried CI node or it is not possible for your CI server then you can disable Fallback Mode completely `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false`.
 
   * To [reproduce tests executed on CI node](#for-knapsack_pro-queue-mode) in development environment please see FAQ.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We keep this old FAQ in README to not break old links spread across the web. You
   - [Supported test runners in queue mode](#supported-test-runners-in-queue-mode)
 - [Extra configuration for CI server](#extra-configuration-for-ci-server)
   - [Info about ENV variables](#info-about-env-variables)
-    - [KNAPSACK_PRO_FIXED_TEST_SUITE_SPLITE (test suite split based on seed)](#knapsack_pro_fixed_test_suite_splite-test-suite-split-based-on-seed)
+    - [KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT (test suite split based on seed)](#knapsack_pro_fixed_test_suite_split-test-suite-split-based-on-seed)
     - [Environment variables for debugging gem](#environment-variables-for-debugging-gem)
   - [Required CI configuration if you use retry single failed CI node feature on your CI server when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true (in Queue Mode) or KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true (in Regular Mode)](#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode)
   - [Passing arguments to rake task](#passing-arguments-to-rake-task)
@@ -603,7 +603,7 @@ In case when you use other CI provider for instance [Jenkins](https://jenkins-ci
 
 `KNAPSACK_PRO_CI_NODE_INDEX` - index of current CI node starts from 0. Second CI node should have `KNAPSACK_PRO_CI_NODE_INDEX=1`.
 
-#### KNAPSACK_PRO_FIXED_TEST_SUITE_SPLITE (test suite split based on seed)
+#### KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT (test suite split based on seed)
 
 Note this is for knapsack_pro regular mode only.
 
@@ -655,7 +655,7 @@ This is only for maintainer of knapsack_pro gem. Not for the end users.
 
 ### Required CI configuration if you use retry single failed CI node feature on your CI server when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true (in Queue Mode) or KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true (in Regular Mode)
 
-Read below required configuration step if you use Queue Mode and you set [`KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true`](#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node) or you use Regular Mode which has by default [`KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true`](#knapsack_pro_fixed_test_suite_splite-test-suite-splite-based-on-seed).
+Read below required configuration step if you use Queue Mode and you set [`KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true`](#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node) or you use Regular Mode which has by default [`KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true`](#knapsack_pro_fixed_test_suite_splite-test-suite-split-based-on-seed).
 
 * __IMPORTANT:__ If you use __the feature to retry only a single failed CI node__ on your CI server (for instance you use Buildkite and you use [auto-retry](https://buildkite.com/docs/pipelines/command-step#retry-attributes) for the failed job) then you need to be aware of [a race condition that could happen](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100). knapsack_pro should not allow running tests in Fallback Mode in the case when the failed CI node was retried to prevent running the wrong set of tests.
 

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ There might be some cached test suite splits for git commits you have run in pas
     [knapsack_pro] {"queue_name"=>"retry-dead-ci-node:queue-id", "test_files"=>[{"path"=>"spec/foo_spec.rb", "time_execution"=>1.23}]}
     ```
 
-  * __IMPORTANT:__ If you use __the feature to retry only a single failed CI node__ on your CI server (for instance you use Buildkite and you use [auto-retry](https://buildkite.com/docs/pipelines/command-step#retry-attributes) for the failed job) then you need to be aware of [a race condition that could happen](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100). knapsack_pro should not allow running tests in Fallback Mode in the case when failed CI node was retried to prevent running the wrong set of tests.
+  * __IMPORTANT:__ If you use __the feature to retry only a single failed CI node__ on your CI server (for instance you use Buildkite and you use [auto-retry](https://buildkite.com/docs/pipelines/command-step#retry-attributes) for the failed job) then you need to be aware of [a race condition that could happen](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100). knapsack_pro should not allow running tests in Fallback Mode in the case when the failed CI node was retried to prevent running the wrong set of tests.
 
     knapsack_pro has built-in support for retries of failed parallel CI nodes for listed CI servers:
 

--- a/README.md
+++ b/README.md
@@ -554,6 +554,8 @@ There might be some cached test suite splits for git commits you have run in pas
 
   __IMPORTANT__: [Required CI configuration if you use retry single failed CI node feature on your CI server when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true (in Queue Mode) or KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true (in Regular Mode)](#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode)
 
+  Other useful info:
+
   * Note when fixed queue split is enabled then you can run tests in a dynamic way only once for particular commit hash and a total number of nodes and for the same branch.
 
   * When Knapsack Pro API server has already information about previous queue split then the information will be used. You will see at the beginning of the knapsack command the log with info that queue name is nil because it was not generated this time. You will get the list of all test files that were executed on the particular CI node in the past.
@@ -612,6 +614,10 @@ Note this is for knapsack_pro regular mode only.
 
     Thanks to that when tests on one of your node failed you can retry the node with exactly the same subset of tests that were run on the node in the first place.
 
+    __IMPORTANT__: [Required CI configuration if you use retry single failed CI node feature on your CI server when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true (in Queue Mode) or KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true (in Regular Mode)](#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode)
+
+    Other useful info:
+
     * There is one edge case. When you run tests for the first time and there is no data collected about time execution of your tests then
       we need to collect data to prepare the first test suite split. The second run of your tests will have fixed test suite split.
 
@@ -621,8 +627,6 @@ Note this is for knapsack_pro regular mode only.
       ```
       [knapsack_pro] Test suite split seed: 8a606431-02a1-4766-9878-0ea42a07ad21
       ```
-
-    __IMPORTANT__: [Required CI configuration if you use retry single failed CI node feature on your CI server when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true (in Queue Mode) or KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true (in Regular Mode)](#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode)
 
 * `KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=false`
 

--- a/README.md
+++ b/README.md
@@ -552,6 +552,8 @@ There might be some cached test suite splits for git commits you have run in pas
 
   Thanks to that when tests on one of your node failed you can retry the node with exactly the same subset of tests that were run on the node in the first place.
 
+  __IMPORTANT__: [Required CI configuration if you use retry single failed CI node feature on your CI server when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true (in Queue Mode) or KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true (in Regular Mode)](#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode)
+
   * Note when fixed queue split is enabled then you can run tests in a dynamic way only once for particular commit hash and a total number of nodes and for the same branch.
 
   * When Knapsack Pro API server has already information about previous queue split then the information will be used. You will see at the beginning of the knapsack command the log with info that queue name is nil because it was not generated this time. You will get the list of all test files that were executed on the particular CI node in the past.
@@ -619,6 +621,8 @@ Note this is for knapsack_pro regular mode only.
       ```
       [knapsack_pro] Test suite split seed: 8a606431-02a1-4766-9878-0ea42a07ad21
       ```
+
+    __IMPORTANT__: [Required CI configuration if you use retry single failed CI node feature on your CI server when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true (in Queue Mode) or KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true (in Regular Mode)](#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode)
 
 * `KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=false`
 

--- a/README.md
+++ b/README.md
@@ -565,15 +565,15 @@ There might be some cached test suite splits for git commits you have run in pas
     [knapsack_pro] {"queue_name"=>"retry-dead-ci-node:queue-id", "test_files"=>[{"path"=>"spec/foo_spec.rb", "time_execution"=>1.23}]}
     ```
 
-  * __IMPORTANT:__ If you use __feature to retry only single failed CI node__ on your CI server (for instance you use Buildkite and you use [auto-retry](https://buildkite.com/docs/pipelines/command-step#retry-attributes) for failed job) then you need to be aware of [race condition that could happen](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100). knapsack_pro should not allow running tests in Fallback Mode in the case when failed CI node was retried to prevent running wrong set of tests.
+  * __IMPORTANT:__ If you use __the feature to retry only a single failed CI node__ on your CI server (for instance you use Buildkite and you use [auto-retry](https://buildkite.com/docs/pipelines/command-step#retry-attributes) for the failed job) then you need to be aware of [a race condition that could happen](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100). knapsack_pro should not allow running tests in Fallback Mode in the case when failed CI node was retried to prevent running the wrong set of tests.
 
-    knapsack_pro has built in support for retries of failed parallel CI nodes for listed CI servers:
+    knapsack_pro has built-in support for retries of failed parallel CI nodes for listed CI servers:
 
     * Buildkite (knapsack_pro reads `BUILDKITE_RETRY_COUNT`)
 
-    knapsack_pro reads ENV vars for above CI servers and it disables Fallback Mode when failed parallel CI node can't connect with Knapsack Pro API. This way we prevent running wrong set of tests by Fallback Mode on retried CI node.
+    knapsack_pro reads ENV vars for above CI servers and it disables Fallback Mode when failed parallel CI node can't connect with Knapsack Pro API. This way we prevent running the wrong set of tests by Fallback Mode on retried CI node.
 
-    If you use other CI server you need to manually configure your CI server to set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT=1` only during retry CI node attempt. If `KNAPSACK_PRO_CI_NODE_RETRY_COUNT > 0` then knapsack_pro won't allow to start running tests in Fallback Mode and instead will raise error so user can manually retry CI node later when connection to Knapsack Pro API can be established.
+    If you use other CI server you need to manually configure your CI server to set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT=1` only during retry CI node attempt. If `KNAPSACK_PRO_CI_NODE_RETRY_COUNT > 0` then knapsack_pro won't allow starting running tests in Fallback Mode and instead will raise error so a user can manually retry CI node later when a connection to Knapsack Pro API can be established.
 
     If you cannot set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT` only for retried CI node or it is not possible for your CI server then you can disable Fallback Mode completely `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false`.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ We keep this old FAQ in README to not break old links spread across the web. You
   - [Info about ENV variables](#info-about-env-variables)
     - [KNAPSACK_PRO_FIXED_TEST_SUITE_SPLITE (test suite split based on seed)](#knapsack_pro_fixed_test_suite_splite-test-suite-split-based-on-seed)
     - [Environment variables for debugging gem](#environment-variables-for-debugging-gem)
+  - [Required CI configuration if you use retry single failed CI node feature on your CI server when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true (in Queue Mode) or KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true (in Regular Mode)](#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode)
   - [Passing arguments to rake task](#passing-arguments-to-rake-task)
     - [Passing arguments to rspec](#passing-arguments-to-rspec)
     - [Passing arguments to cucumber](#passing-arguments-to-cucumber)

--- a/README.md
+++ b/README.md
@@ -565,6 +565,17 @@ There might be some cached test suite splits for git commits you have run in pas
     [knapsack_pro] {"queue_name"=>"retry-dead-ci-node:queue-id", "test_files"=>[{"path"=>"spec/foo_spec.rb", "time_execution"=>1.23}]}
     ```
 
+  * __IMPORTANT:__ If you use __feature to retry only single failed CI node__ on your CI server (for instance you use Buildkite and you use [auto-retry](https://buildkite.com/docs/pipelines/command-step#retry-attributes) for failed job) then you need to be aware of [race condition that could happen](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100). knapsack_pro should not allow running tests in Fallback Mode in the case when failed CI node was retried to prevent running wrong set of tests.
+  
+    knapsack_pro has built in support for retries of failed parallel CI nodes for listed CI servers:
+
+    * Buildkite (knapsack_pro reads `BUILDKITE_RETRY_COUNT`)
+
+    knapsack_pro reads ENV vars for above CI servers and it disables Fallback Mode when failed parallel CI node can't connect with Knapsack Pro API. This way we prevent running wrong set of tests by Fallback Mode on retried CI node.
+
+    If you use other CI server you need to manually configure your CI server to set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT=1` only during retry CI node attempt. If `KNAPSACK_PRO_CI_NODE_RETRY_COUNT > 0` then knapsack_pro won't allow to start running tests in Fallback Mode and instead will raise error so user can manually retry CI node later when connection to Knapsack Pro API can be established.
+    If you cannot set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT` only for retried CI node or it is not possible for your CI server then you can disable Fallback Mode completely `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false`.
+
   * To [reproduce tests executed on CI node](#for-knapsack_pro-queue-mode) in development environment please see FAQ.
 
 #### KNAPSACK_PRO_MODIFY_DEFAULT_RSPEC_FORMATTERS (hide duplicated summary of pending and failed tests)

--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -18,7 +18,7 @@ module KnapsackPro
         KnapsackPro.logger.error(message)
         raise message
       elsif KnapsackPro::Config::Env.ci_node_retry_count > 0
-        message = 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node.'
+        message = 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode'
         unless KnapsackPro::Config::Env.fixed_test_suite_split?
           message += ' Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_test_suite_split-test-suite-split-based-on-seed'
         end

--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -13,6 +13,17 @@ module KnapsackPro
       if connection.success?
         raise ArgumentError.new(response) if connection.errors?
         prepare_test_files(response)
+      elsif !KnapsackPro::Config::Env.fallback_mode_enabled?
+        message = 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100'
+        KnapsackPro.logger.error(message)
+        raise message
+      elsif KnapsackPro::Config::Env.ci_node_retry_count > 0
+        message = 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node.'
+        unless KnapsackPro::Config::Env.fixed_test_suite_split?
+          message += ' Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_test_suite_splite-test-suite-split-based-on-seed'
+        end
+        KnapsackPro.logger.error(message)
+        raise message
       else
         KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby#what-happens-when-knapsack-pro-api-is-not-availablenot-reachable-temporarily")
         fallback_test_files

--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -20,7 +20,7 @@ module KnapsackPro
       elsif KnapsackPro::Config::Env.ci_node_retry_count > 0
         message = 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node.'
         unless KnapsackPro::Config::Env.fixed_test_suite_split?
-          message += ' Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_test_suite_splite-test-suite-split-based-on-seed'
+          message += ' Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_test_suite_split-test-suite-split-based-on-seed'
         end
         KnapsackPro.logger.error(message)
         raise message

--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -14,7 +14,7 @@ module KnapsackPro
         raise ArgumentError.new(response) if connection.errors?
         prepare_test_files(response)
       elsif !KnapsackPro::Config::Env.fallback_mode_enabled?
-        message = 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100'
+        message = 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode'
         KnapsackPro.logger.error(message)
         raise message
       elsif KnapsackPro::Config::Env.ci_node_retry_count > 0

--- a/lib/knapsack_pro/config/ci/base.rb
+++ b/lib/knapsack_pro/config/ci/base.rb
@@ -11,6 +11,9 @@ module KnapsackPro
         def node_build_id
         end
 
+        def node_retry_count
+        end
+
         def commit_hash
         end
 

--- a/lib/knapsack_pro/config/ci/buildkite.rb
+++ b/lib/knapsack_pro/config/ci/buildkite.rb
@@ -14,6 +14,10 @@ module KnapsackPro
           ENV['BUILDKITE_BUILD_NUMBER']
         end
 
+        def node_retry_count
+          ENV['BUILDKITE_RETRY_COUNT']
+        end
+
         def commit_hash
           ENV['BUILDKITE_COMMIT']
         end

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -36,10 +36,6 @@ module KnapsackPro
           ).to_i
         end
 
-        def can_run_fallback_mode?
-          ci_node_retry_count == 0
-        end
-
         def commit_hash
           ENV['KNAPSACK_PRO_COMMIT_HASH'] ||
             ci_env_for(:commit_hash)
@@ -97,6 +93,14 @@ module KnapsackPro
 
         def subset_queue_id
           ENV['KNAPSACK_PRO_SUBSET_QUEUE_ID'] || raise('Missing Subset Queue ID')
+        end
+
+        def fallback_mode_enabled
+          ENV.fetch('KNAPSACK_PRO_FALLBACK_MODE_ENABLED', true)
+        end
+
+        def fallback_mode_enabled?
+          fallback_mode_enabled.to_s == 'true'
         end
 
         def test_files_encrypted

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -28,6 +28,18 @@ module KnapsackPro
             'missing-build-id'
         end
 
+        def ci_node_retry_count
+          (
+            ENV['KNAPSACK_PRO_CI_NODE_RETRY_COUNT'] ||
+            ci_env_for(:node_retry_count) ||
+            0
+          ).to_i
+        end
+
+        def can_run_fallback_mode?
+          ci_node_retry_count == 0
+        end
+
         def commit_hash
           ENV['KNAPSACK_PRO_COMMIT_HASH'] ||
             ci_env_for(:commit_hash)
@@ -135,8 +147,16 @@ module KnapsackPro
           ENV.fetch('KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT', true)
         end
 
+        def fixed_test_suite_split?
+          fixed_test_suite_split.to_s == 'true'
+        end
+
         def fixed_queue_split
           ENV.fetch('KNAPSACK_PRO_FIXED_QUEUE_SPLIT', false)
+        end
+
+        def fixed_queue_split?
+          fixed_queue_split.to_s == 'true'
         end
 
         def cucumber_queue_prefix

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -21,7 +21,7 @@ module KnapsackPro
         KnapsackPro.logger.error(message)
         raise message
       elsif KnapsackPro::Config::Env.ci_node_retry_count > 0
-        message = 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node.'
+        message = 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode'
         unless KnapsackPro::Config::Env.fixed_queue_split?
           message += ' Please ensure you have set KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node'
         end

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -17,7 +17,7 @@ module KnapsackPro
         raise ArgumentError.new(response) if connection.errors?
         prepare_test_files(response)
       elsif !KnapsackPro::Config::Env.fallback_mode_enabled?
-        message = 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100'
+        message = 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode'
         KnapsackPro.logger.error(message)
         raise message
       elsif KnapsackPro::Config::Env.ci_node_retry_count > 0

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -16,6 +16,17 @@ module KnapsackPro
       if connection.success?
         raise ArgumentError.new(response) if connection.errors?
         prepare_test_files(response)
+      elsif !KnapsackPro::Config::Env.fallback_mode_enabled?
+        message = 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100'
+        KnapsackPro.logger.error(message)
+        raise message
+      elsif KnapsackPro::Config::Env.ci_node_retry_count > 0
+        message = 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node.'
+        unless KnapsackPro::Config::Env.fixed_queue_split?
+          message += ' Please ensure you have set KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node'
+        end
+        KnapsackPro.logger.error(message)
+        raise message
       else
         @fallback_activated = true
         KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. If other CI nodes were able to connect with Knapsack Pro API then you may notice that some of the test files will be executed twice across CI nodes. The most important thing is to guarantee each of test files is run at least once! Read more about fallback mode at https://github.com/KnapsackPro/knapsack_pro-ruby#what-happens-when-knapsack-pro-api-is-not-availablenot-reachable-temporarily")

--- a/spec/knapsack_pro/allocator_spec.rb
+++ b/spec/knapsack_pro/allocator_spec.rb
@@ -96,7 +96,7 @@ describe KnapsackPro::Allocator do
           end
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node.')
+            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode')
           end
         end
 
@@ -106,7 +106,7 @@ describe KnapsackPro::Allocator do
           end
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_test_suite_split-test-suite-split-based-on-seed')
+            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_test_suite_split-test-suite-split-based-on-seed')
           end
         end
       end

--- a/spec/knapsack_pro/allocator_spec.rb
+++ b/spec/knapsack_pro/allocator_spec.rb
@@ -75,16 +75,54 @@ describe KnapsackPro::Allocator do
       let(:success?) { false }
       let(:errors?) { false }
 
-      before do
-        test_flat_distributor = instance_double(KnapsackPro::TestFlatDistributor)
-        expect(KnapsackPro::TestFlatDistributor).to receive(:new).with(test_files, ci_node_total).and_return(test_flat_distributor)
-        expect(test_flat_distributor).to receive(:test_files_for_node).with(ci_node_index).and_return([
-          { 'path' => 'c_spec.rb' },
-          { 'path' => 'd_spec.rb' },
-        ])
+      context 'when fallback mode is disabled' do
+        before do
+          expect(KnapsackPro::Config::Env).to receive(:fallback_mode_enabled?).and_return(false)
+        end
+
+        it do
+          expect { subject }.to raise_error(RuntimeError, 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100')
+        end
       end
 
-      it { should eq ['c_spec.rb', 'd_spec.rb'] }
+      context 'when CI node retry count > 0' do
+        before do
+          expect(KnapsackPro::Config::Env).to receive(:ci_node_retry_count).and_return(1)
+        end
+
+        context 'when fixed_test_suite_split=true' do
+          before do
+            expect(KnapsackPro::Config::Env).to receive(:fixed_test_suite_split).and_return(true)
+          end
+
+          it do
+            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node.')
+          end
+        end
+
+        context 'when fixed_test_suite_split=false' do
+          before do
+            expect(KnapsackPro::Config::Env).to receive(:fixed_test_suite_split).and_return(false)
+          end
+
+          it do
+            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_test_suite_splite-test-suite-split-based-on-seed')
+          end
+        end
+      end
+
+      context 'when fallback mode started' do
+        before do
+          test_flat_distributor = instance_double(KnapsackPro::TestFlatDistributor)
+          expect(KnapsackPro::TestFlatDistributor).to receive(:new).with(test_files, ci_node_total).and_return(test_flat_distributor)
+          expect(test_flat_distributor).to receive(:test_files_for_node).with(ci_node_index).and_return([
+            { 'path' => 'c_spec.rb' },
+            { 'path' => 'd_spec.rb' },
+          ])
+        end
+
+        it { should eq ['c_spec.rb', 'd_spec.rb'] }
+      end
     end
   end
 end

--- a/spec/knapsack_pro/allocator_spec.rb
+++ b/spec/knapsack_pro/allocator_spec.rb
@@ -106,7 +106,7 @@ describe KnapsackPro::Allocator do
           end
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_test_suite_splite-test-suite-split-based-on-seed')
+            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_test_suite_split-test-suite-split-based-on-seed')
           end
         end
       end

--- a/spec/knapsack_pro/allocator_spec.rb
+++ b/spec/knapsack_pro/allocator_spec.rb
@@ -81,7 +81,7 @@ describe KnapsackPro::Allocator do
         end
 
         it do
-          expect { subject }.to raise_error(RuntimeError, 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100')
+          expect { subject }.to raise_error(RuntimeError, 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode')
         end
       end
 

--- a/spec/knapsack_pro/config/ci/base_spec.rb
+++ b/spec/knapsack_pro/config/ci/base_spec.rb
@@ -2,6 +2,7 @@ describe KnapsackPro::Config::CI::Base do
   its(:node_total) { should be nil }
   its(:node_index) { should be nil }
   its(:node_build_id) { should be nil }
+  its(:node_retry_count) { should be nil }
   its(:commit_hash) { should be nil }
   its(:branch) { should be nil }
   its(:project_dir) { should be nil }

--- a/spec/knapsack_pro/config/ci/buildkite_spec.rb
+++ b/spec/knapsack_pro/config/ci/buildkite_spec.rb
@@ -46,6 +46,19 @@ describe KnapsackPro::Config::CI::Buildkite do
     end
   end
 
+  describe '#node_retry_count' do
+    subject { described_class.new.node_retry_count }
+
+    context 'when environment exists' do
+      let(:env) { { 'BUILDKITE_RETRY_COUNT' => '1' } }
+      it { should eql '1' }
+    end
+
+    context "when environment doesn't exist" do
+      it { should be nil }
+    end
+  end
+
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -77,6 +77,45 @@ describe KnapsackPro::Config::Env do
     end
   end
 
+  describe '.ci_node_retry_count' do
+    subject { described_class.ci_node_retry_count }
+
+    context 'when ENV exists' do
+      context 'when KNAPSACK_PRO_CI_NODE_RETRY_COUNT has value' do
+        before { stub_const("ENV", { 'KNAPSACK_PRO_CI_NODE_RETRY_COUNT' => '1' }) }
+        it { should eq 1 }
+      end
+
+      context 'when CI environment has value' do
+        before do
+          expect(described_class).to receive(:ci_env_for).with(:node_retry_count).and_return('2')
+        end
+
+        it { should eq 2 }
+      end
+    end
+
+    context "when ENV doesn't exist" do
+      it { should eq 0 }
+    end
+  end
+
+  describe '.can_run_fallback_mode?' do
+    subject { described_class.can_run_fallback_mode? }
+
+    context 'when ENV exists (stub #ci_node_retry_count)' do
+      before do
+        expect(described_class).to receive(:ci_node_retry_count).and_return(1)
+      end
+
+      it { should be false }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should be true }
+    end
+  end
+
   describe '.commit_hash' do
     subject { described_class.commit_hash }
 
@@ -490,12 +529,54 @@ describe KnapsackPro::Config::Env do
     end
   end
 
+  describe '.fixed_test_suite_split?' do
+    subject { described_class.fixed_test_suite_split? }
+
+    context 'when ENV exists' do
+      context 'when KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true' do
+        before { stub_const("ENV", { 'KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT' => 'true' }) }
+        it { should be true }
+      end
+
+      context 'when KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=false' do
+        before { stub_const("ENV", { 'KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT' => 'false' }) }
+        it { should be false }
+      end
+    end
+
+    context "when ENV doesn't exist" do
+      before { stub_const("ENV", {}) }
+      it { should be true }
+    end
+  end
+
   describe '.fixed_queue_split' do
     subject { described_class.fixed_queue_split }
 
     context 'when ENV exists' do
       before { stub_const("ENV", { 'KNAPSACK_PRO_FIXED_QUEUE_SPLIT' => true }) }
       it { should eq true }
+    end
+
+    context "when ENV doesn't exist" do
+      before { stub_const("ENV", {}) }
+      it { should be false }
+    end
+  end
+
+  describe '.fixed_queue_split?' do
+    subject { described_class.fixed_queue_split? }
+
+    context 'when ENV exists' do
+      context 'when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true' do
+        before { stub_const("ENV", { 'KNAPSACK_PRO_FIXED_QUEUE_SPLIT' => 'true' }) }
+        it { should be true }
+      end
+
+      context 'when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=false' do
+        before { stub_const("ENV", { 'KNAPSACK_PRO_FIXED_QUEUE_SPLIT' => 'false' }) }
+        it { should be false }
+      end
     end
 
     context "when ENV doesn't exist" do

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -100,22 +100,6 @@ describe KnapsackPro::Config::Env do
     end
   end
 
-  describe '.can_run_fallback_mode?' do
-    subject { described_class.can_run_fallback_mode? }
-
-    context 'when ENV exists (stub #ci_node_retry_count)' do
-      before do
-        expect(described_class).to receive(:ci_node_retry_count).and_return(1)
-      end
-
-      it { should be false }
-    end
-
-    context "when ENV doesn't exist" do
-      it { should be true }
-    end
-  end
-
   describe '.commit_hash' do
     subject { described_class.commit_hash }
 
@@ -353,6 +337,32 @@ describe KnapsackPro::Config::Env do
       it do
         expect { subject }.to raise_error('Missing Subset Queue ID')
       end
+    end
+  end
+
+  describe '.fallback_mode_enabled' do
+    subject { described_class.fallback_mode_enabled }
+
+    context 'when ENV exists' do
+      before { stub_const("ENV", { 'KNAPSACK_PRO_FALLBACK_MODE_ENABLED' => 'false' }) }
+      it { should eq 'false' }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should be true }
+    end
+  end
+
+  describe '.fallback_mode_enabled?' do
+    subject { described_class.fallback_mode_enabled? }
+
+    context 'when ENV exists' do
+      before { stub_const("ENV", { 'KNAPSACK_PRO_FALLBACK_MODE_ENABLED' => 'false' }) }
+      it { should be false }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should be true }
     end
   end
 

--- a/spec/knapsack_pro/queue_allocator_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_spec.rb
@@ -81,29 +81,66 @@ describe KnapsackPro::QueueAllocator do
       let(:success?) { false }
       let(:errors?) { false }
 
+      context 'when fallback mode is disabled' do
+        before do
+          expect(KnapsackPro::Config::Env).to receive(:fallback_mode_enabled?).and_return(false)
+        end
 
-      before do
-        test_flat_distributor = instance_double(KnapsackPro::TestFlatDistributor)
-        expect(KnapsackPro::TestFlatDistributor).to receive(:new).with(test_files, ci_node_total).and_return(test_flat_distributor)
-        expect(test_flat_distributor).to receive(:test_files_for_node).with(ci_node_index).and_return([
-          { 'path' => 'c_spec.rb' },
-          { 'path' => 'd_spec.rb' },
-        ])
-      end
-
-      context 'when no test files were executed yet' do
-        let(:executed_test_files) { [] }
-
-        it 'enables fallback mode and returns fallback test files' do
-          expect(subject).to eq ['c_spec.rb', 'd_spec.rb']
+        it do
+          expect { subject }.to raise_error(RuntimeError, 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100')
         end
       end
 
-      context 'when test files were already executed' do
-        let(:executed_test_files) { ['c_spec.rb', 'additional_executed_spec.rb'] }
+      context 'when CI node retry count > 0' do
+        before do
+          expect(KnapsackPro::Config::Env).to receive(:ci_node_retry_count).and_return(1)
+        end
 
-        it 'enables fallback mode and returns fallback test files' do
-          expect(subject).to eq ['d_spec.rb']
+        context 'when fixed_queue_split=true' do
+          before do
+            expect(KnapsackPro::Config::Env).to receive(:fixed_queue_split).and_return(true)
+          end
+
+          it do
+            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node.')
+          end
+        end
+
+        context 'when fixed_queue_split=false' do
+          before do
+            expect(KnapsackPro::Config::Env).to receive(:fixed_queue_split).and_return(false)
+          end
+
+          it do
+            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Please ensure you have set KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node')
+          end
+        end
+      end
+
+      context 'when fallback mode started' do
+        before do
+          test_flat_distributor = instance_double(KnapsackPro::TestFlatDistributor)
+          expect(KnapsackPro::TestFlatDistributor).to receive(:new).with(test_files, ci_node_total).and_return(test_flat_distributor)
+          expect(test_flat_distributor).to receive(:test_files_for_node).with(ci_node_index).and_return([
+            { 'path' => 'c_spec.rb' },
+            { 'path' => 'd_spec.rb' },
+          ])
+        end
+
+        context 'when no test files were executed yet' do
+          let(:executed_test_files) { [] }
+
+          it 'enables fallback mode and returns fallback test files' do
+            expect(subject).to eq ['c_spec.rb', 'd_spec.rb']
+          end
+        end
+
+        context 'when test files were already executed' do
+          let(:executed_test_files) { ['c_spec.rb', 'additional_executed_spec.rb'] }
+
+          it 'enables fallback mode and returns fallback test files' do
+            expect(subject).to eq ['d_spec.rb']
+          end
         end
       end
     end

--- a/spec/knapsack_pro/queue_allocator_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_spec.rb
@@ -87,7 +87,7 @@ describe KnapsackPro::QueueAllocator do
         end
 
         it do
-          expect { subject }.to raise_error(RuntimeError, 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100')
+          expect { subject }.to raise_error(RuntimeError, 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode')
         end
       end
 

--- a/spec/knapsack_pro/queue_allocator_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_spec.rb
@@ -102,7 +102,7 @@ describe KnapsackPro::QueueAllocator do
           end
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node.')
+            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode')
           end
         end
 
@@ -112,7 +112,7 @@ describe KnapsackPro::QueueAllocator do
           end
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Please ensure you have set KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node')
+            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode Please ensure you have set KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node')
           end
         end
       end


### PR DESCRIPTION
# Problem

You run tests in Queue Mode with flag `KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true` or Regular Mode with the flag `KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true` (default).

How to reproduce race condition:

* You run 1st CI build and one of parallel CI nodes tests failed.
* You retry failed CI node. We expect knapsack_pro will run the same set of tests on the CI node during retry as it was recorded for the first CI node run. Let's assume knapsack_pro could not connect to Knapsack Pro API. In such a case, the Fallback Mode is started and a different set of tests are run on the CI node. This can lead to false-positive because different tests can be green and the retried CI node did not run failing tests at all.

# Solution

knapsack_pro should not allow running tests in Fallback Mode in the case when CI node was retried. 

Some of CI providers expose ENV variable that knapsack_pro can read so it will know that Fallback Mode is not allowed. 

This PR adds support for [Buildkite CI env var](https://buildkite.com/docs/pipelines/environment-variables) `BUILDKITE_RETRY_COUNT` that has value `1` when CI node was retried.

# How to fix your CI config

* If you use Buildkite CI then knapsack_pro won't allow for Fallback Mode when the parallel job was restarted. No action required on your side.
* If you use other CI provider that allows retrying failed CI node you should set `KNAPSACK_PRO_CI_NODE_RETRY_COUNT=1` when failed CI node is restarted. 

If you can't do it then please don't use retrying single failed CI node. Instead, you should retry the whole CI build to be sure that the whole test suite is passing green. In the case of Fallback Mode starting on any parallel CI nodes the knapsack_pro ensures each test file is executed at least once so you can be sure the whole test suite is green (passing). 

If you really need to use retry failed CI node then you can disable fallback mode completely `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false`. Thanks to that tests won't run when a connection with Knapsack Pro API is lost. Instead, exception will be raised.