### PR TITLE
Pass non zero exit status from Cucumber as exit status for Cucumber executed in Queue Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.18.1
+
+* Pass non zero exit status from Cucumber as exit status for Cucumber executed in Queue Mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/101
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.18.0...v1.18.1
+
 ### 1.18.0
 
 * __IMPORTANT__ Do not allow Fallback Mode when the CI node was retried to avoid running the wrong set of tests

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -57,7 +57,7 @@ module KnapsackPro
             all_test_file_paths += test_file_paths
 
             result_exitstatus = cucumber_run(runner, test_file_paths, args)
-            exitstatus = 1 if result_exitstatus != 0
+            exitstatus = result_exitstatus if result_exitstatus != 0
 
             # KnapsackPro::Hooks::Queue.call_after_subset_queue
             # KnapsackPro::Report.save_subset_queue_to_file


### PR DESCRIPTION
This is a small improvement to don't assume when tests failed then the exit status is always 1. It can be something else so it's good to pass non zero exit status from Cucumber to knapsack_pro in Queue Mode.