### PR TITLE
If KnapsackPro::Hooks::Queue.before_queue hook has block of code that raises an exception then ensure the hook was called only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.18.2
+
+* If `KnapsackPro::Hooks::Queue.before_queue` hook has block of code that raises an exception then ensure the hook was called only once.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/103
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.18.1...v1.18.2
+
 ### 1.18.1
 
 * Pass non zero exit status from Cucumber as exit status for Cucumber executed in Queue Mode

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -55,8 +55,8 @@ module KnapsackPro
         ::RSpec.configure do |config|
           config.before(:suite) do
             unless ENV['KNAPSACK_PRO_BEFORE_QUEUE_HOOK_CALLED']
-              KnapsackPro::Hooks::Queue.call_before_queue
               ENV['KNAPSACK_PRO_BEFORE_QUEUE_HOOK_CALLED'] = 'true'
+              KnapsackPro::Hooks::Queue.call_before_queue
             end
           end
         end


### PR DESCRIPTION
This PR fixes a bug that could lead to running multiple times `before_queue` hook.

# solution
If `KnapsackPro::Hooks::Queue.before_queue` hook has block of code that raises an exception then ensure the hook was called only once.
