### PR TITLE
Add custom formatter KnapsackPro::Formatters::RSpecJsonFormatter to add support for RSpec example.id in JSON report to be able to split test files by test examples in RSpec older than 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.20.0
+
+* Add support for tests split by test examples to RSpec older than 3.6.0
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/104
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.19.0...v1.20.0
+
 ### 1.19.0
 
 * RSpec split test files by test examples (by individual `it`s)

--- a/lib/knapsack_pro/formatters/rspec_json_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_json_formatter.rb
@@ -1,0 +1,20 @@
+RSpec::Support.require_rspec_core('formatters/json_formatter')
+
+# based on https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/formatters/json_formatter.rb
+module KnapsackPro
+  module Formatters
+    class RSpecJsonFormatter < RSpec::Core::Formatters::JsonFormatter
+      RSpec::Core::Formatters.register self, :message, :dump_summary, :dump_profile, :stop, :seed, :close
+
+      private
+
+      # add example.id to json report to support < RSpec 3.6.0
+      # based on https://github.com/rspec/rspec-core/pull/2369/files
+      def format_example(example)
+        super.merge({
+          :id => example.id,
+        })
+      end
+    end
+  end
+end

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -7,14 +7,21 @@ module KnapsackPro
       def generate_json_report
         require 'rspec/core'
 
+        cli_format =
+          if Gem::Version.new(RSpec::Core::Version::STRING) < Gem::Version.new('3.6.0')
+            require_relative '../formatters/rspec_json_formatter'
+            ['--format', KnapsackPro::Formatters::RSpecJsonFormatter.to_s]
+          else
+            ['--format', 'json']
+          end
+
         ensure_report_dir_exists
         remove_old_json_report
 
         test_file_paths = KnapsackPro::TestFileFinder.call(test_file_pattern)
 
-        cli_args = [
+        cli_args = cli_format + [
           '--dry-run',
-          '--format', 'json',
           '--out', REPORT_PATH,
           '--default-path', test_dir,
         ] + test_file_paths.map { |t| t.fetch('path') }


### PR DESCRIPTION
Add custom formatter `KnapsackPro::Formatters::RSpecJsonFormatter` to add support for RSpec `example.id` in JSON report to be able to split test files by test examples in RSpec older than 3.6.0

# problem

RSpec >= 3.6.0 introduced `example.id` in JSON report
https://github.com/rspec/rspec-core/blob/master/Changelog.md#360--2017-05-04

Related PR https://github.com/rspec/rspec-core/pull/2369

We need `example.id` to split test files by test examples.

# solution

We created custom formatter `KnapsackPro::Formatters::RSpecJsonFormatter` to add `example.id` to JSON report. The custom formatter is used only for RSpec < 3.6.0.