### PR TITLE
Raise error from Cucumber Queue Mode runner when system process doesn't finish execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.20.2
+
+* Raise an error when running Cucumber in Queue Mode and Cucumber system process doesn't finish execution correctly (for instance Cucumber process was killed by CI server due to lack of memory)
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/111
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.20.1...v1.20.2
+
 ### 1.20.1
 
 * Fix bug in RSpec split by test examples in < RSpec 3.6.0 (related to custom json formatter)

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -91,7 +91,16 @@ module KnapsackPro
           # which is defined in lib/knapsack_pro/adapters/cucumber_adapter.rb
           ENV['KNAPSACK_PRO_BEFORE_QUEUE_HOOK_CALLED'] = 'true'
 
-          $?.exitstatus
+          process_status = $?
+
+          unless process_status.exited?
+            raise "Cucumber process execution failed. It's likely that your CI server has exceeded"\
+                    " its available memory. Please try changing CI config or retrying the CI build.\n"\
+                    "Failed command: #{cmd}\n"\
+                    "Process status: #{process_status.inspect}"
+          end
+
+          process_status.exitstatus
         end
       end
     end


### PR DESCRIPTION
# Problem

Sometimes Cucumber in Queue Mode could be killed by CI server for some reason (like exceeding the memory).
We want to make sure the user gets meaningful error as to what happened (and be double sure that killing the process never results in a false positive).

# Fix

We raise exception when Cucumber process in Queue Mode failed to execute properly (never exited on its own).