### PR TITLE
Increase request retry timebox from 4s to 8s and when Fallback Mode is disabled then retry request 6 times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 1.22.0
 
-* Increase request retry timebox from 4s to 8s to not flood Knapsack Pro API with too many requests and to give time for API server to autoscale and add additional machines to serve traffic
+* Increase request retry timebox from 4s to 8s to not flood Knapsack Pro API with too many requests in a short period of time and to give time for API server to autoscale and add additional machines to serve traffic
 * When Fallback Mode is disabled with env `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false` then retry the request to Knapsack Pro API for 6 times instead of only 3 times.
 
   Here is related [info why some users want to disable Fallback Mode](https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ### 1.22.0
 
 * Increase request retry timebox from 4s to 8s to not flood Knapsack Pro API with too many requests and to give time for API server to autoscale and add additional machines to serve traffic
+* When Fallback Mode is disabled with env `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false` then retry the request to Knapsack Pro API for 6 times instead of only 3 times.
+
+  Here is related [info why some users want to disable Fallback Mode](https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode).
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/112
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.21.0...v1.22.0
 
 ### 1.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 1.22.0
+
+* Increase request retry timebox from 4s to 8s to not flood Knapsack Pro API with too many requests and to give time for API server to autoscale and add additional machines to serve traffic
+
 ### 1.21.0
 
 * Automatically detect slow test files for RSpec and split them by test examples when `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true`

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -4,7 +4,7 @@ module KnapsackPro
       class ServerError < StandardError; end
 
       TIMEOUT = 15
-      MAX_RETRY = 3
+      MAX_RETRY = -> { KnapsackPro::Config::Env.fallback_mode_enabled? ? 3 : 6 }
       REQUEST_RETRY_TIMEBOX = 8
 
       def initialize(action)
@@ -118,7 +118,7 @@ module KnapsackPro
       rescue ServerError, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
         logger.warn(e.inspect)
         retries += 1
-        if retries < MAX_RETRY
+        if retries < MAX_RETRY.call
           wait = retries * REQUEST_RETRY_TIMEBOX
           logger.warn("Wait #{wait}s and retry request to Knapsack Pro API.")
           Kernel.sleep(wait)

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -5,7 +5,7 @@ module KnapsackPro
 
       TIMEOUT = 15
       MAX_RETRY = 3
-      REQUEST_RETRY_TIMEBOX = 4
+      REQUEST_RETRY_TIMEBOX = 8
 
       def initialize(action)
         @action = action

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -85,10 +85,10 @@ shared_examples 'when retry request' do
       server_error = described_class::ServerError.new(parsed_response)
       expect(logger).to receive(:warn).exactly(3).with(server_error.inspect)
 
-      expect(logger).to receive(:warn).with("Wait 4s and retry request to Knapsack Pro API.")
       expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
-      expect(Kernel).to receive(:sleep).with(4)
+      expect(logger).to receive(:warn).with("Wait 16s and retry request to Knapsack Pro API.")
       expect(Kernel).to receive(:sleep).with(8)
+      expect(Kernel).to receive(:sleep).with(16)
 
       expect(subject).to eq(parsed_response)
 


### PR DESCRIPTION
# general change

* Increase request retry timebox from 4s to 8s to not flood Knapsack Pro API with too many requests in a short period of time and to give time for API server to autoscale and add additional machines to serve traffic

# 1. when Fallback Mode is enabled (default behavior)
This is the default behavior of knapsack_pro to start running tests in Fallback Mode when 3 times request to API fails.

## example when Fallback Mode is enabled

8+16 = 24s wait time - knapsack_pro will try to connect with API within 24s before starting running tests in Fallback Mode


# 2. when Fallback Mode is disabled
* When Fallback Mode is disabled with env `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false` then retry the request to Knapsack Pro API for 6 times instead of only 3 times.

Here is related info when some users want to disable Fallback Mode: https://github.com/KnapsackPro/knapsack_pro-ruby#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode

Related to PR: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/100

## example when Fallback Mode is disabled

8+16+24+32+40 = 120s = 2 minutes wait time (6 attempts to make a request to API)  - knapsack_pro will try to connect with API within 2 minutes before exiting with failure. 