### PR TITLE
Fix for an auto split of slow RSpec test files by test examples when using parallel_tests gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.22.1
+
+* Fix for an auto split of slow RSpec test files by test examples when using `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true` and `parallel_tests` gem. Save the JSON reports with unique file names with the CI node index in the name to avoid accidentally overriding the files on the same disk.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/113
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.22.0...v1.22.1
+
 ### 1.22.0
 
 * Increase request retry timebox from 4s to 8s to not flood Knapsack Pro API with too many requests in a short period of time and to give time for API server to autoscale and add additional machines to serve traffic

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -2,7 +2,6 @@ module KnapsackPro
   class SlowTestFileDeterminer
     TIME_THRESHOLD_PER_CI_NODE = 0.7 # 70%
     REPORT_DIR = 'tmp/knapsack_pro/slow_test_file_determiner'
-    REPORT_PATH = "#{REPORT_DIR}/slow_test_files.json"
 
     # test_files: { 'path' => 'a_spec.rb', 'time_execution' => 0.0 }
     # time_execution: of build distribution (total time of CI build run)
@@ -16,13 +15,19 @@ module KnapsackPro
 
     def self.save_to_json_report(test_files)
       FileUtils.mkdir_p(REPORT_DIR)
-      File.write(REPORT_PATH, test_files.to_json)
+      File.write(report_path, test_files.to_json)
     end
 
     def self.read_from_json_report
-      raise 'Report with slow test files was not generated yet. If you have enabled split by test cases https://github.com/KnapsackPro/knapsack_pro-ruby#split-test-files-by-test-cases and you see this error it means that your tests accidentally cleaned up tmp/knapsack_pro directory. Please do not remove this directory during tests runtime!' unless File.exists?(REPORT_PATH)
-      slow_test_files_json_report = File.read(REPORT_PATH)
+      raise 'Report with slow test files was not generated yet. If you have enabled split by test cases https://github.com/KnapsackPro/knapsack_pro-ruby#split-test-files-by-test-cases and you see this error it means that your tests accidentally cleaned up tmp/knapsack_pro directory. Please do not remove this directory during tests runtime!' unless File.exists?(report_path)
+      slow_test_files_json_report = File.read(report_path)
       JSON.parse(slow_test_files_json_report)
+    end
+
+    private
+
+    def self.report_path
+      "#{REPORT_DIR}/slow_test_files_node_#{KnapsackPro::Config::Env.ci_node_index}.json"
     end
   end
 end

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -2,7 +2,6 @@ module KnapsackPro
   module TestCaseDetectors
     class RSpecTestExampleDetector
       REPORT_DIR = 'tmp/knapsack_pro/test_case_detectors/rspec'
-      REPORT_PATH = "#{REPORT_DIR}/rspec_dry_run_json_report.json"
 
       def generate_json_report
         require 'rspec/core'
@@ -22,13 +21,13 @@ module KnapsackPro
 
         if test_file_entities.empty?
           no_examples_json = { examples: [] }.to_json
-          File.write(REPORT_PATH, no_examples_json)
+          File.write(report_path, no_examples_json)
           return
         end
 
         cli_args = cli_format + [
           '--dry-run',
-          '--out', REPORT_PATH,
+          '--out', report_path,
           '--default-path', test_dir,
         ] + KnapsackPro::TestFilePresenter.paths(test_file_entities)
         options = RSpec::Core::ConfigurationOptions.new(cli_args)
@@ -39,9 +38,9 @@ module KnapsackPro
       end
 
       def test_file_example_paths
-        raise "No report found at #{REPORT_PATH}" unless File.exists?(REPORT_PATH)
+        raise "No report found at #{report_path}" unless File.exists?(report_path)
 
-        json_report = File.read(REPORT_PATH)
+        json_report = File.read(report_path)
         hash_report = JSON.parse(json_report)
         hash_report
           .fetch('examples')
@@ -61,6 +60,10 @@ module KnapsackPro
 
       private
 
+      def report_path
+        "#{REPORT_DIR}/rspec_dry_run_json_report_node_#{KnapsackPro::Config::Env.ci_node_index}.json"
+      end
+
       def adapter_class
         KnapsackPro::Adapters::RSpecAdapter
       end
@@ -78,7 +81,7 @@ module KnapsackPro
       end
 
       def remove_old_json_report
-        File.delete(REPORT_PATH) if File.exists?(REPORT_PATH)
+        File.delete(report_path) if File.exists?(report_path)
       end
 
       def test_file_hash_for(test_file_path)

--- a/spec/knapsack_pro/slow_test_file_determiner_spec.rb
+++ b/spec/knapsack_pro/slow_test_file_determiner_spec.rb
@@ -27,7 +27,7 @@ describe KnapsackPro::SlowTestFileDeterminer do
   end
 
   describe '.save_to_json_report', :clear_tmp do
-    let(:json_report_path) { 'tmp/knapsack_pro/slow_test_file_determiner/slow_test_files.json' }
+    let(:json_report_path) { 'tmp/knapsack_pro/slow_test_file_determiner/slow_test_files_node_0.json' }
     let(:test_files) do
       [
         { 'path' => 'a_spec.rb', 'time_execution' => 1.0 },

--- a/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
+++ b/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
@@ -1,6 +1,6 @@
 describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
   let(:report_dir) { 'tmp/knapsack_pro/test_case_detectors/rspec' }
-  let(:report_path) { 'tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report.json' }
+  let(:report_path) { 'tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json' }
   let(:rspec_test_example_detector) { described_class.new }
 
   describe '#generate_json_report' do
@@ -116,7 +116,7 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
       it do
         expect(File).to receive(:exists?).with(report_path).and_return(false)
 
-        expect { subject }.to raise_error(RuntimeError, 'No report found at tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report.json')
+        expect { subject }.to raise_error(RuntimeError, 'No report found at tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json')
       end
     end
   end


### PR DESCRIPTION
Fix for an auto split of slow RSpec test files by test examples when using `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true` and `parallel_tests` gem. Save the JSON reports with unique file names with the CI node index in the name to avoid accidentally overriding the files on the same disk.