### PR TITLE
Log when next retry request to Knapsack Pro API happens before starting Fallback Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 1.22.2
+
+* Log when next retry request to Knapsack Pro API happens before starting Fallback Mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/114
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.22.1...v1.22.2
+
 ### 1.22.1
 
 * Fix for an auto split of slow RSpec test files by test examples when using `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true` and `parallel_tests` gem. Save the JSON reports with unique file names with the CI node index in the name to avoid accidentally overriding the files on the same disk.

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -121,7 +121,11 @@ module KnapsackPro
         if retries < MAX_RETRY.call
           wait = retries * REQUEST_RETRY_TIMEBOX
           logger.warn("Wait #{wait}s and retry request to Knapsack Pro API.")
-          Kernel.sleep(wait)
+          print_every = 2 # seconds
+          (wait / print_every).ceil.times do |i|
+            logger.warn("Next request in #{wait - i * print_every}s...")
+            Kernel.sleep(print_every)
+          end
           retry
         else
           response_body

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -87,9 +87,20 @@ shared_examples 'when retry request' do
       expect(logger).to receive(:warn).exactly(3).with(server_error.inspect)
 
       expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
+      expect(logger).to receive(:warn).with("Next request in 8s...")
+      expect(logger).to receive(:warn).with("Next request in 6s...")
+      expect(logger).to receive(:warn).with("Next request in 4s...")
+      expect(logger).to receive(:warn).with("Next request in 2s...")
       expect(logger).to receive(:warn).with("Wait 16s and retry request to Knapsack Pro API.")
-      expect(Kernel).to receive(:sleep).with(8)
-      expect(Kernel).to receive(:sleep).with(16)
+      expect(logger).to receive(:warn).with("Next request in 16s...")
+      expect(logger).to receive(:warn).with("Next request in 14s...")
+      expect(logger).to receive(:warn).with("Next request in 12s...")
+      expect(logger).to receive(:warn).with("Next request in 10s...")
+      expect(logger).to receive(:warn).with("Next request in 8s...")
+      expect(logger).to receive(:warn).with("Next request in 6s...")
+      expect(logger).to receive(:warn).with("Next request in 4s...")
+      expect(logger).to receive(:warn).with("Next request in 2s...")
+      expect(Kernel).to receive(:sleep).exactly(12).with(2)
 
       expect(subject).to eq(parsed_response)
 
@@ -115,15 +126,37 @@ shared_examples 'when retry request' do
         expect(logger).to receive(:warn).exactly(6).with(server_error.inspect)
 
         expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("Next request in 8s...")
+        expect(logger).to receive(:warn).with("Next request in 6s...")
+        expect(logger).to receive(:warn).with("Next request in 4s...")
+        expect(logger).to receive(:warn).with("Next request in 2s...")
+
         expect(logger).to receive(:warn).with("Wait 16s and retry request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("Next request in 16s...")
+        expect(logger).to receive(:warn).with("Next request in 14s...")
+        expect(logger).to receive(:warn).with("Next request in 12s...")
+        expect(logger).to receive(:warn).with("Next request in 10s...")
+        expect(logger).to receive(:warn).with("Next request in 8s...")
+        expect(logger).to receive(:warn).with("Next request in 6s...")
+        expect(logger).to receive(:warn).with("Next request in 4s...")
+        expect(logger).to receive(:warn).with("Next request in 2s...")
+
         expect(logger).to receive(:warn).with("Wait 24s and retry request to Knapsack Pro API.")
+        12.times do |i|
+          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        end
+
         expect(logger).to receive(:warn).with("Wait 32s and retry request to Knapsack Pro API.")
+        16.times do |i|
+          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        end
+
         expect(logger).to receive(:warn).with("Wait 40s and retry request to Knapsack Pro API.")
-        expect(Kernel).to receive(:sleep).with(8)
-        expect(Kernel).to receive(:sleep).with(16)
-        expect(Kernel).to receive(:sleep).with(24)
-        expect(Kernel).to receive(:sleep).with(32)
-        expect(Kernel).to receive(:sleep).with(40)
+        20.times do |i|
+          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        end
+
+        expect(Kernel).to receive(:sleep).exactly(60).with(2)
 
         expect(subject).to eq(parsed_response)
 


### PR DESCRIPTION
# change

This adds log warning message: `Next request in 8s...` etc to knapsack pro logger to notify the user when next retry request to Knapsack Pro API will happen.

# why

CodeShip seems to freeze when no output for a long time so we print some output to show that knapsack_pro process is working.

# Example output

```
4 #50431]  WARN -- : [knapsack_pro] #<SocketError: Failed to open TCP connection to api-fake.knapsackpro.test:3000 (getaddrinfo: nodename nor servname provided, or not known)>
W, [2020-06-02T09:28:04.961195 #50431]  WARN -- : [knapsack_pro] Wait 8s and retry request to Knapsack Pro API.
W, [2020-06-02T09:28:04.961239 #50431]  WARN -- : [knapsack_pro] Next request in 8s...
W, [2020-06-02T09:28:06.961402 #50431]  WARN -- : [knapsack_pro] Next request in 6s...
W, [2020-06-02T09:28:08.966389 #50431]  WARN -- : [knapsack_pro] Next request in 4s...
W, [2020-06-02T09:28:10.969894 #50431]  WARN -- : [knapsack_pro] Next request in 2s...
W, [2020-06-02T09:28:12.973823 #50431]  WARN -- : [knapsack_pro] #<SocketError: Failed to open TCP connection to api-fake.knapsackpro.test:3000 (getaddrinfo: nodename nor servname provided, or not known)>
W, [2020-06-02T09:28:12.973963 #50431]  WARN -- : [knapsack_pro] Wait 16s and retry request to Knapsack Pro API.
W, [2020-06-02T09:28:12.974035 #50431]  WARN -- : [knapsack_pro] Next request in 16s...
W, [2020-06-02T09:28:14.975409 #50431]  WARN -- : [knapsack_pro] Next request in 14s...
W, [2020-06-02T09:28:16.976070 #50431]  WARN -- : [knapsack_pro] Next request in 12s...
W, [2020-06-02T09:28:18.976941 #50431]  WARN -- : [knapsack_pro] Next request in 10s...
W, [2020-06-02T09:28:20.980815 #50431]  WARN -- : [knapsack_pro] Next request in 8s...
W, [2020-06-02T09:28:22.985190 #50431]  WARN -- : [knapsack_pro] Next request in 6s...
W, [2020-06-02T09:28:24.985996 #50431]  WARN -- : [knapsack_pro] Next request in 4s...
W, [2020-06-02T09:28:26.991360 #50431]  WARN -- : [knapsack_pro] Next request in 2s...
```