### PR TITLE
Support for non-delimited formatting params of rspec

### DIFF
--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -16,7 +16,7 @@ module KnapsackPro
           cli_args = (args || '').split
           # if user didn't provide the format then use explicitly default progress formatter
           # in order to avoid KnapsackPro::Formatters::RSpecQueueSummaryFormatter being the only default formatter
-          if !cli_args.include?('--format') && !cli_args.include?('-f')
+          if !cli_args.any?{|arg| arg.start_with?('-f') || arg.start_with?('--format')}
             cli_args += ['--format', 'progress']
           end
           cli_args += [

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -104,6 +104,31 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
           subject
         end
       end
+
+      context 'when format param is provided without a delimiter' do
+        let(:args) { '-fMyCustomFormatter' }
+
+        it 'uses provided format param instead of default formatter progress' do
+          expected_exitstatus = 0
+          expected_accumulator = {
+            status: :completed,
+            exitstatus: expected_exitstatus
+          }
+          accumulator = {
+            status: :next,
+            runner: runner,
+            can_initialize_queue: true,
+            args: ['-fMyCustomFormatter', '--format', 'KnapsackPro::Formatters::RSpecQueueSummaryFormatter', '--default-path', 'fake-test-dir'],
+            exitstatus: 0,
+            all_test_file_paths: [],
+          }
+          expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
+
+          expect(Kernel).to receive(:exit).with(expected_exitstatus)
+
+          subject
+        end
+      end
     end
 
     context 'when args not provided' do


### PR DESCRIPTION
###  Bug
Passing formatting params to rspec without delimiter results in redundantly added `progress` formatter.

### Fix
Check for rspec params prefix instead of inclusion check.