### PR TITLE
Add support for CI build ID for Github Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
     If you use Github Actions and Knapsack Pro Queue Mode then you must set in Github Actions environment variable: `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true`. Thanks to that when you retry CI build then tests will run based on previously recorded tests. This solves problem mentioned in the [PR](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/116).
 
+    __Migration path for other users__ - just update `knapsack_pro` gem. Nothing to change in your code :)
+
 https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.22.3...v2.0.0
 
 ### 1.22.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+### 2.0.0
+
+* Add support for CI build ID for Github Actions
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/116
+
+    __Migration path for Github Actions users - required__
+
+    If you use Github Actions and Knapsack Pro Queue Mode then you must set in Github Actions environment variable: `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true`. Thanks to that when you retry CI build then tests will run based on previously recorded tests. This solves problem mentioned in the [PR](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/116).
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v1.22.3...v2.0.0
+
 ### 1.22.3
 
 * Support for non-delimited formatting params of RSpec like `-fMyCustomFormatter`

--- a/README.md
+++ b/README.md
@@ -1639,6 +1639,9 @@ jobs:
         KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
         KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
         KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+        # if you use Knapsack Pro Queue Mode you must set below env variable
+        # to be able to retry CI build and run previously recorded tests
+        KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
       run: |
         # run tests in Knapsack Pro Regular Mode
         bundle exec rake knapsack_pro:rspec

--- a/lib/knapsack_pro/config/ci/github_actions.rb
+++ b/lib/knapsack_pro/config/ci/github_actions.rb
@@ -1,4 +1,4 @@
-# https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
+# https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
 module KnapsackPro
   module Config
     module CI

--- a/lib/knapsack_pro/config/ci/github_actions.rb
+++ b/lib/knapsack_pro/config/ci/github_actions.rb
@@ -12,7 +12,8 @@ module KnapsackPro
         end
 
         def node_build_id
-          # not provided
+          # A unique number for each run within a repository. This number does not change if you re-run the workflow run.
+          ENV['GITHUB_RUN_ID']
         end
 
         def commit_hash

--- a/spec/knapsack_pro/config/ci/github_actions_spec.rb
+++ b/spec/knapsack_pro/config/ci/github_actions_spec.rb
@@ -22,7 +22,14 @@ describe KnapsackPro::Config::CI::GithubActions do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    it { should be nil }
+    context 'when environment exists' do
+      let(:env) { { 'GITHUB_RUN_ID' => 2706 } }
+      it { should eql 2706 }
+    end
+
+    context "when environment doesn't exist" do
+      it { should be nil }
+    end
   end
 
   describe '#commit_hash' do


### PR DESCRIPTION
# what

This PR adds support for CI build ID for Github Actions. 

# why

* Thanks to that you can run concurrent CI builds for the same commit & branch in Knapsack Pro Queue Mode.
* Parallel jobs that started work after Queue was already consumed won't initialize a new Queue (thanks to that you won't accidentally run tests twice).

# Context

List of [env variables in Github Actions](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables).

`GITHUB_RUN_ID` - A unique number for each run within a repository. __This number does not change if you re-run the workflow run.__

# problem with GITHUB_RUN_ID - breaking change
When you retry parallel jobs in Github Actions then `GITHUB_RUN_ID` stays the same. Because of this in Knapsack Pro Queue Mode the Knapsack Pro API will assume the queue was already consumed for the CI build ID (`GITHUB_RUN_ID`) and no tests will run.

__WARNING__: This could accidentally make CI build green because no tests will run on retried CI build on Github Actions. 

__This is breaking change so we need to update the major release version after merge of this PR.__

# Migration path for Github Actions users - required

If you use Github Actions and Knapsack Pro Queue Mode then you must set in Github Actions environment variable: `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` ([more info](https://github.com/KnapsackPro/knapsack_pro-ruby#knapsack_pro_fixed_queue_split-remember-queue-split-on-retry-ci-node)). Thanks to that when you retry CI build then tests will run based on previously recorded tests. This solves problem mentioned in the previous section.

