### PR TITLE
Add KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX to customize prefix for generating test examples report when using RSpec split by test examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.1.0
+
+* Add `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX` to customize prefix for generating test examples report when using RSpec split by test examples
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/118
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.0.0...v2.1.0
+
 ### 2.0.0
 
 * Add support for CI build ID for Github Actions

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ We keep this old FAQ in README to not break old links spread across the web. You
   - [Supported test runners in queue mode](#supported-test-runners-in-queue-mode)
 - [Split test files by test cases](#split-test-files-by-test-cases)
   - [RSpec split test files by test examples (by individual `it`s)](#rspec-split-test-files-by-test-examples-by-individual-its)
+    - [Why I see error: Don't know how to build task 'knapsack_pro:rspec_test_example_detector'?](#why-i-see-error-dont-know-how-to-build-task-knapsack_prorspec_test_example_detector)
   - [How to manually define a list of slow test files to be split by test cases](#how-to-manually-define-a-list-of-slow-test-files-to-be-split-by-test-cases)
 - [Extra configuration for CI server](#extra-configuration-for-ci-server)
   - [Info about ENV variables](#info-about-env-variables)
@@ -617,6 +618,16 @@ KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
 ```
 
 Thanks to that your CI build speed can be faster. We recommend using this feature with [Queue Mode](https://youtu.be/hUEB1XDKEFY) to ensure parallel CI nodes finish work at a similar time which gives you the shortest CI build time.
+
+#### Why I see error: Don't know how to build task 'knapsack_pro:rspec_test_example_detector'?
+
+If you will see error like:
+
+```
+Don't know how to build task 'knapsack_pro:rspec_test_example_detector' (See the list of available tasks with `rake --tasks`)
+```
+
+It probably means bundler can't find the rake task. You can try remove default prefix `bundle exec` used by knapsack_pro gem by setting `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX=""`.
 
 ### How to manually define a list of slow test files to be split by test cases
 

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -43,7 +43,12 @@ module KnapsackPro
         KnapsackPro.logger.info("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual 'it's. Thanks to that a single slow test file can be split across parallel CI nodes). Analyzing #{slow_test_files.size} slow test files.")
 
         # generate RSpec JSON report in separate process to not pollute RSpec state
-        cmd = 'RACK_ENV=test RAILS_ENV=test bundle exec rake knapsack_pro:rspec_test_example_detector'
+        cmd = [
+          'RACK_ENV=test',
+          'RAILS_ENV=test',
+          KnapsackPro::Config::Env.rspec_test_example_detector_prefix,
+          'rake knapsack_pro:rspec_test_example_detector',
+        ].join(' ')
         unless Kernel.system(cmd)
           raise "Could not generate JSON report for RSpec. Rake task failed when running #{cmd}"
         end

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -179,6 +179,10 @@ module KnapsackPro
           rspec_split_by_test_examples.to_s == 'true'
         end
 
+        def rspec_test_example_detector_prefix
+          ENV.fetch('KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX', 'bundle exec')
+        end
+
         def test_suite_token
           env_name = 'KNAPSACK_PRO_TEST_SUITE_TOKEN'
           ENV[env_name] || raise("Missing environment variable #{env_name}. You should set environment variable like #{env_name}_RSPEC (note there is suffix _RSPEC at the end). knapsack_pro gem will set #{env_name} based on #{env_name}_RSPEC value. If you use other test runner than RSpec then use proper suffix.")

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -658,6 +658,20 @@ describe KnapsackPro::Config::Env do
     end
   end
 
+  describe '.rspec_test_example_detector_prefix' do
+    subject { described_class.rspec_test_example_detector_prefix }
+
+    context 'when ENV exists' do
+      before { stub_const("ENV", { 'KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX' => '' }) }
+      it { should eq '' }
+    end
+
+    context "when ENV doesn't exist" do
+      before { stub_const("ENV", {}) }
+      it { should eq 'bundle exec' }
+    end
+  end
+
   describe '.test_suite_token' do
     subject { described_class.test_suite_token }
 


### PR DESCRIPTION
# problem

When you use RSpec split by test examples 

```
KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
```

https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it

and you saw error like:

```
Don't know how to build task 'knapsack_pro:rspec_test_example_detector' (See the list of available tasks with `rake --tasks`)
```

# context

knapsack_pro by default adds prefix `bundle exec` before the rake task (knapsack_pro:rspec_test_example_detector).
You can try run it without `bundle exec` prefix.

# solution

Set `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX=""` to empty string to remove default prefix `bundle exec`. This should help run the task task properly.

