### PR TITLE
Explicitly call root test runner class to avoid a confusing error when test runner gem is not loaded 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.1.1
+
+* Explicitly call root test runner class to avoid a confusing error when test runner gem is not loaded
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/120
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.1.0...v2.1.1
+
 ### 2.1.0
 
 * Add `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX` to customize prefix for generating test examples report when using RSpec split by test examples

--- a/lib/knapsack_pro/adapters/cucumber_adapter.rb
+++ b/lib/knapsack_pro/adapters/cucumber_adapter.rb
@@ -4,7 +4,7 @@ module KnapsackPro
       TEST_DIR_PATTERN = 'features/**{,/*/**}/*.feature'
 
       def self.test_path(object)
-        if Cucumber::VERSION.to_i >= 2
+        if ::Cucumber::VERSION.to_i >= 2
           test_case = object
           test_case.location.file
         else

--- a/lib/knapsack_pro/adapters/minitest_adapter.rb
+++ b/lib/knapsack_pro/adapters/minitest_adapter.rb
@@ -85,10 +85,10 @@ module KnapsackPro
       private
 
       def add_post_run_callback(&block)
-        if Minitest.respond_to?(:after_run)
-          Minitest.after_run { block.call }
+        if ::Minitest.respond_to?(:after_run)
+          ::Minitest.after_run { block.call }
         else
-          Minitest::Unit.after_tests { block.call }
+          ::Minitest::Unit.after_tests { block.call }
         end
       end
     end

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -4,7 +4,7 @@ module KnapsackPro
       TEST_DIR_PATTERN = 'spec/**{,/*/**}/*_spec.rb'
 
       def self.test_path(example_group)
-        if defined?(Turnip) && Turnip::VERSION.to_i < 2
+        if defined?(::Turnip) && ::Turnip::VERSION.to_i < 2
           unless example_group[:turnip]
             until example_group[:parent_example_group].nil?
               example_group = example_group[:parent_example_group]

--- a/lib/knapsack_pro/adapters/test_unit_adapter.rb
+++ b/lib/knapsack_pro/adapters/test_unit_adapter.rb
@@ -42,7 +42,7 @@ module KnapsackPro
       end
 
       def bind_time_tracker
-        Test::Unit::TestSuite.send(:prepend, BindTimeTrackerTestUnitPlugin)
+        ::Test::Unit::TestSuite.send(:prepend, BindTimeTrackerTestUnitPlugin)
 
         add_post_run_callback do
           KnapsackPro.logger.debug(KnapsackPro::Presenter.global_time)
@@ -63,7 +63,7 @@ module KnapsackPro
       private
 
       def add_post_run_callback(&block)
-        Test::Unit.at_exit do
+        ::Test::Unit.at_exit do
           block.call
         end
       end

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -34,7 +34,7 @@ module KnapsackPro
       test_files_to_run = all_test_files_to_run
 
       if adapter_class == KnapsackPro::Adapters::RSpecAdapter && KnapsackPro::Config::Env.rspec_split_by_test_examples?
-        unless Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new('3.3.0')
+        unless Gem::Version.new(::RSpec::Core::Version::STRING) >= Gem::Version.new('3.3.0')
           raise 'RSpec >= 3.3.0 is required to split test files by test examples. Learn more: https://github.com/KnapsackPro/knapsack_pro-ruby#split-test-files-by-test-cases'
         end
 

--- a/lib/knapsack_pro/formatters/rspec_json_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_json_formatter.rb
@@ -3,8 +3,8 @@ RSpec::Support.require_rspec_core('formatters/json_formatter')
 # based on https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/formatters/json_formatter.rb
 module KnapsackPro
   module Formatters
-    class RSpecJsonFormatter < RSpec::Core::Formatters::JsonFormatter
-      RSpec::Core::Formatters.register self
+    class RSpecJsonFormatter < ::RSpec::Core::Formatters::JsonFormatter
+      ::RSpec::Core::Formatters.register self
 
       private
 

--- a/lib/knapsack_pro/formatters/rspec_queue_profile_formatter_extension.rb
+++ b/lib/knapsack_pro/formatters/rspec_queue_profile_formatter_extension.rb
@@ -5,7 +5,7 @@ module KnapsackPro
     module RSpecQueueProfileFormatterExtension
       def self.print_summary
         return unless KnapsackPro::Config::Env.modify_default_rspec_formatters?
-        RSpec::Core::Formatters::ProfileFormatter.print_profile_summary
+        ::RSpec::Core::Formatters::ProfileFormatter.print_profile_summary
       end
 
       def initialize(output)

--- a/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
@@ -9,8 +9,8 @@ module KnapsackPro
       def dump_summary(summary); end
     end
 
-    class RSpecQueueSummaryFormatter < RSpec::Core::Formatters::BaseFormatter
-      RSpec::Core::Formatters.register self, :dump_summary, :dump_failures, :dump_pending
+    class RSpecQueueSummaryFormatter < ::RSpec::Core::Formatters::BaseFormatter
+      ::RSpec::Core::Formatters.register self, :dump_summary, :dump_failures, :dump_pending
 
       def self.registered_output=(output)
         @registered_output = {

--- a/lib/knapsack_pro/runners/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/cucumber_runner.rb
@@ -15,7 +15,7 @@ module KnapsackPro
             Rake::Task[task_name].clear
           end
 
-          Cucumber::Rake::Task.new(task_name) do |t|
+          ::Cucumber::Rake::Task.new(task_name) do |t|
             t.cucumber_opts = "#{args} --require #{runner.test_dir} -- #{runner.stringify_test_file_paths}"
           end
           Rake::Task[task_name].invoke

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -89,9 +89,9 @@ module KnapsackPro
           end
 
           # duplicate args because Minitest modifies args
-          result = Minitest.run(args.dup)
+          result = ::Minitest.run(args.dup)
 
-          Minitest::Runnable.reset
+          ::Minitest::Runnable.reset
 
           result
         end

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -79,8 +79,8 @@ module KnapsackPro
 
             log_rspec_command(args, test_file_paths, :subset_queue)
 
-            options = RSpec::Core::ConfigurationOptions.new(cli_args)
-            exit_code = RSpec::Core::Runner.new(options).run($stderr, $stdout)
+            options = ::RSpec::Core::ConfigurationOptions.new(cli_args)
+            exit_code = ::RSpec::Core::Runner.new(options).run($stderr, $stdout)
             exitstatus = exit_code if exit_code != 0
 
             rspec_clear_examples
@@ -124,26 +124,26 @@ module KnapsackPro
         #
         # Keep formatters and report to accumulate info about failed/pending tests
         def self.rspec_clear_examples
-          if RSpec::ExampleGroups.respond_to?(:remove_all_constants)
-            RSpec::ExampleGroups.remove_all_constants
+          if ::RSpec::ExampleGroups.respond_to?(:remove_all_constants)
+            ::RSpec::ExampleGroups.remove_all_constants
           else
-            RSpec::ExampleGroups.constants.each do |constant|
-              RSpec::ExampleGroups.__send__(:remove_const, constant)
+            ::RSpec::ExampleGroups.constants.each do |constant|
+              ::RSpec::ExampleGroups.__send__(:remove_const, constant)
             end
           end
-          RSpec.world.example_groups.clear
-          RSpec.configuration.start_time = ::RSpec::Core::Time.now
+          ::RSpec.world.example_groups.clear
+          ::RSpec.configuration.start_time = ::RSpec::Core::Time.now
 
           if KnapsackPro::Config::Env.rspec_split_by_test_examples?
             # Reset example group counts to ensure scoped example ids in metadata
             # have correct index (not increased by each subsequent run).
             # Solves this problem: https://github.com/rspec/rspec-core/issues/2721
-            RSpec.world.instance_variable_set(:@example_group_counts_by_spec_file, Hash.new(0))
+            ::RSpec.world.instance_variable_set(:@example_group_counts_by_spec_file, Hash.new(0))
           end
 
           # skip reset filters for old RSpec versions
-          if RSpec.configuration.respond_to?(:reset_filters)
-            RSpec.configuration.reset_filters
+          if ::RSpec.configuration.respond_to?(:reset_filters)
+            ::RSpec.configuration.reset_filters
           end
         end
       end

--- a/lib/knapsack_pro/runners/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/rspec_runner.rb
@@ -15,7 +15,7 @@ module KnapsackPro
             Rake::Task[task_name].clear
           end
 
-          RSpec::Core::RakeTask.new(task_name) do |t|
+          ::RSpec::Core::RakeTask.new(task_name) do |t|
             # we cannot pass runner.test_file_paths array to t.pattern
             # because pattern does not accept test example path like spec/a_spec.rb[1:2]
             # instead we pass test files and test example paths to t.rspec_opts

--- a/lib/knapsack_pro/runners/test_unit_runner.rb
+++ b/lib/knapsack_pro/runners/test_unit_runner.rb
@@ -16,7 +16,7 @@ module KnapsackPro
               File.expand_path(f)
             end
 
-          exit Test::Unit::AutoRunner.run(
+          exit ::Test::Unit::AutoRunner.run(
             true,
             runner.test_dir,
             cli_args

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -7,7 +7,7 @@ module KnapsackPro
         require 'rspec/core'
 
         cli_format =
-          if Gem::Version.new(RSpec::Core::Version::STRING) < Gem::Version.new('3.6.0')
+          if Gem::Version.new(::RSpec::Core::Version::STRING) < Gem::Version.new('3.6.0')
             require_relative '../formatters/rspec_json_formatter'
             ['--format', KnapsackPro::Formatters::RSpecJsonFormatter.to_s]
           else
@@ -30,8 +30,8 @@ module KnapsackPro
           '--out', report_path,
           '--default-path', test_dir,
         ] + KnapsackPro::TestFilePresenter.paths(test_file_entities)
-        options = RSpec::Core::ConfigurationOptions.new(cli_args)
-        exit_code = RSpec::Core::Runner.new(options).run($stderr, $stdout)
+        options = ::RSpec::Core::ConfigurationOptions.new(cli_args)
+        exit_code = ::RSpec::Core::Runner.new(options).run($stderr, $stdout)
         if exit_code != 0
           raise 'There was problem to generate test examples for test suite'
         end


### PR DESCRIPTION
Explicitly call root test runner class to avoid a confusing error when test runner gem is not loaded 

# why

These changes will help us see more explicit and clear errors when test runner gem like RSpec is not loaded properly.
For instance, it could help avoid misunderstanding of error like https://github.com/KnapsackPro/knapsack_pro-ruby/issues/119

# changes applied

* Use ::RSpec instead of RSpec to be more explicit about using gem RSpec
* Use ::Cucumber instead of Cucumber
* Use ::Minitest instead of Minitest
* Use ::Test::Unit instead of Test::Unit
* Use ::Turnip instead of Turnip
