### PR TITLE
Allow defining Queue Mode hooks multiple times (before_queue, after_subset_queue, after_queue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.2.0
+
+* Allow defining Queue Mode hooks multiple times (`KnapsackPro::Hooks::Queue.before_queue`, `KnapsackPro::Hooks::Queue.after_subset_queue`, `KnapsackPro::Hooks::Queue.after_queue`)
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/122
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.1.1...v2.2.0
+
 ### 2.1.1
 
 * Explicitly call root test runner class to avoid a confusing error when test runner gem is not loaded

--- a/README.md
+++ b/README.md
@@ -2737,6 +2737,8 @@ end
 
 #### What hooks are supported in Queue Mode?
 
+Note: Each hook type can be defined multiple times. For instance, if you define `KnapsackPro::Hooks::Queue.before_queue` twice then both block of code will be called when running your tests.
+
 * RSpec in knapsack_pro Queue Mode supports hooks:
 
 ```ruby

--- a/lib/knapsack_pro/hooks/queue.rb
+++ b/lib/knapsack_pro/hooks/queue.rb
@@ -4,7 +4,7 @@ module KnapsackPro
       class << self
         attr_reader :before_queue_store,
           :after_subset_queue,
-          :after_queue
+          :after_queue_store
 
         def reset_before_queue
           @before_queue_store = nil
@@ -15,7 +15,7 @@ module KnapsackPro
         end
 
         def reset_after_queue
-          @after_queue = nil
+          @after_queue_store = nil
         end
 
         def before_queue(&block)
@@ -28,7 +28,8 @@ module KnapsackPro
         end
 
         def after_queue(&block)
-          @after_queue ||= block
+          @after_queue_store ||= []
+          @after_queue_store << block
         end
 
         def call_before_queue
@@ -49,10 +50,12 @@ module KnapsackPro
         end
 
         def call_after_queue
-          return unless after_queue
-          after_queue.call(
-            KnapsackPro::Config::Env.queue_id
-          )
+          return unless after_queue_store
+          after_queue_store.each do |block|
+            block.call(
+              KnapsackPro::Config::Env.queue_id
+            )
+          end
         end
       end
     end

--- a/lib/knapsack_pro/hooks/queue.rb
+++ b/lib/knapsack_pro/hooks/queue.rb
@@ -3,7 +3,7 @@ module KnapsackPro
     class Queue
       class << self
         attr_reader :before_queue_store,
-          :after_subset_queue,
+          :after_subset_queue_store,
           :after_queue_store
 
         def reset_before_queue
@@ -11,7 +11,7 @@ module KnapsackPro
         end
 
         def reset_after_subset_queue
-          @after_subset_queue = nil
+          @after_subset_queue_store = nil
         end
 
         def reset_after_queue
@@ -24,7 +24,8 @@ module KnapsackPro
         end
 
         def after_subset_queue(&block)
-          @after_subset_queue ||= block
+          @after_subset_queue_store ||= []
+          @after_subset_queue_store << block
         end
 
         def after_queue(&block)
@@ -42,11 +43,13 @@ module KnapsackPro
         end
 
         def call_after_subset_queue
-          return unless after_subset_queue
-          after_subset_queue.call(
-            KnapsackPro::Config::Env.queue_id,
-            KnapsackPro::Config::Env.subset_queue_id
-          )
+          return unless after_subset_queue_store
+          after_subset_queue_store.each do |block|
+            block.call(
+              KnapsackPro::Config::Env.queue_id,
+              KnapsackPro::Config::Env.subset_queue_id
+            )
+          end
         end
 
         def call_after_queue

--- a/lib/knapsack_pro/hooks/queue.rb
+++ b/lib/knapsack_pro/hooks/queue.rb
@@ -2,12 +2,12 @@ module KnapsackPro
   module Hooks
     class Queue
       class << self
-        attr_reader :before_queue,
+        attr_reader :before_queue_store,
           :after_subset_queue,
           :after_queue
 
         def reset_before_queue
-          @before_queue = nil
+          @before_queue_store = nil
         end
 
         def reset_after_subset_queue
@@ -19,7 +19,8 @@ module KnapsackPro
         end
 
         def before_queue(&block)
-          @before_queue ||= block
+          @before_queue_store ||= []
+          @before_queue_store << block
         end
 
         def after_subset_queue(&block)
@@ -31,10 +32,12 @@ module KnapsackPro
         end
 
         def call_before_queue
-          return unless before_queue
-          before_queue.call(
-            KnapsackPro::Config::Env.queue_id
-          )
+          return unless before_queue_store
+          before_queue_store.each do |block|
+            block.call(
+              KnapsackPro::Config::Env.queue_id
+            )
+          end
         end
 
         def call_after_subset_queue

--- a/spec/knapsack_pro/hooks/queue_spec.rb
+++ b/spec/knapsack_pro/hooks/queue_spec.rb
@@ -10,18 +10,30 @@ describe KnapsackPro::Hooks::Queue do
       it { should be_nil }
     end
 
-    context 'when callback is set' do
+    context 'when callback is set multiple times' do
       let(:queue_id) { double }
 
       before do
-        expect(KnapsackPro::Config::Env).to receive(:queue_id).and_return(queue_id)
+        expect(KnapsackPro::Config::Env).to receive(:queue_id).twice.and_return(queue_id)
+
+        $expected_called_blocks = []
 
         described_class.before_queue do |q_id|
-          [:fake_value, q_id]
+          $expected_called_blocks << [:block_1_called, q_id]
+        end
+        described_class.before_queue do |q_id|
+          $expected_called_blocks << [:block_2_called, q_id]
         end
       end
 
-      it { should eq [:fake_value, queue_id] }
+      it 'each block is called' do
+        subject
+
+        expect($expected_called_blocks).to eq([
+          [:block_1_called, queue_id],
+          [:block_2_called, queue_id],
+        ])
+      end
     end
   end
 

--- a/spec/knapsack_pro/hooks/queue_spec.rb
+++ b/spec/knapsack_pro/hooks/queue_spec.rb
@@ -48,20 +48,32 @@ describe KnapsackPro::Hooks::Queue do
       it { should be_nil }
     end
 
-    context 'when callback is set' do
+    context 'when callback is set multiple times' do
       let(:queue_id) { double }
       let(:subset_queue_id) { double }
 
       before do
-        expect(KnapsackPro::Config::Env).to receive(:queue_id).and_return(queue_id)
-        expect(KnapsackPro::Config::Env).to receive(:subset_queue_id).and_return(subset_queue_id)
+        expect(KnapsackPro::Config::Env).to receive(:queue_id).twice.and_return(queue_id)
+        expect(KnapsackPro::Config::Env).to receive(:subset_queue_id).twice.and_return(subset_queue_id)
+
+        $expected_called_blocks = []
 
         described_class.after_subset_queue do |q_id, subset_q_id|
-          [:fake_value, q_id, subset_q_id]
+          $expected_called_blocks << [:block_1_called, q_id, subset_q_id]
+        end
+        described_class.after_subset_queue do |q_id, subset_q_id|
+          $expected_called_blocks << [:block_2_called, q_id, subset_q_id]
         end
       end
 
-      it { should eq [:fake_value, queue_id, subset_queue_id] }
+      it 'each block is called' do
+        subject
+
+        expect($expected_called_blocks).to eq([
+          [:block_1_called, queue_id, subset_queue_id],
+          [:block_2_called, queue_id, subset_queue_id],
+        ])
+      end
     end
   end
 

--- a/spec/knapsack_pro/hooks/queue_spec.rb
+++ b/spec/knapsack_pro/hooks/queue_spec.rb
@@ -76,18 +76,30 @@ describe KnapsackPro::Hooks::Queue do
       it { should be_nil }
     end
 
-    context 'when callback is set' do
+    context 'when callback is set multiple times' do
       let(:queue_id) { double }
 
       before do
-        expect(KnapsackPro::Config::Env).to receive(:queue_id).and_return(queue_id)
+        expect(KnapsackPro::Config::Env).to receive(:queue_id).twice.and_return(queue_id)
+
+        $expected_called_blocks = []
 
         described_class.after_queue do |q_id|
-          [:fake_value, q_id]
+          $expected_called_blocks << [:block_1_called, q_id]
+        end
+        described_class.after_queue do |q_id|
+          $expected_called_blocks << [:block_2_called, q_id]
         end
       end
 
-      it { should eq [:fake_value, queue_id] }
+      it 'each block is called' do
+        subject
+
+        expect($expected_called_blocks).to eq([
+          [:block_1_called, queue_id],
+          [:block_2_called, queue_id],
+        ])
+      end
     end
   end
 end


### PR DESCRIPTION
Allow defining multiple times hooks for Queue Mode like 

* `KnapsackPro::Hooks::Queue.before_queue`
* `KnapsackPro::Hooks::Queue.after_subset_queue`
* `KnapsackPro::Hooks::Queue.after_queue`

# why

So far you could define only once a hook for Queue Mode.  This might be less convenient when you would like to keep hooks related code in a few separate files. 

# change

You can now define multiple times the same hook. Example:

```ruby
KnapsackPro::Hooks::Queue.before_queue do
  puts '1st call'
end

KnapsackPro::Hooks::Queue.before_queue do
  puts '2nd call'
end
```

This works similarly to hooks in RSpec so you can define them many times.

Here are examples of using all hooks in Queue Mode:
https://github.com/KnapsackPro/knapsack_pro-ruby#what-hooks-are-supported-in-queue-mode