### PR TITLE
Improve detection of test file path in test-unit runner for test files with shared examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.2.1
+
+* Improve detection of test file path in test-unit runner for test files with shared examples
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/123
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.2.0...v2.2.1
+
 ### 2.2.0
 
 * Allow defining Queue Mode hooks multiple times (`KnapsackPro::Hooks::Queue.before_queue`, `KnapsackPro::Hooks::Queue.after_subset_queue`, `KnapsackPro::Hooks::Queue.after_queue`)

--- a/lib/knapsack_pro/adapters/test_unit_adapter.rb
+++ b/lib/knapsack_pro/adapters/test_unit_adapter.rb
@@ -6,6 +6,7 @@ module KnapsackPro
 
       def self.test_path(obj)
         full_test_path = nil
+        found_valid_test_file_path = false
 
         obj.tests.each do |test_obj|
           method = test_obj.method_name
@@ -16,7 +17,15 @@ module KnapsackPro
           # For instance if test file contains only shared examples then it's not possible to properly detect test file path
           # so the wrong path can be returned like:
           # /Users/artur/.rvm/gems/ruby-2.6.5/gems/shared_should-0.10.0/lib/shared_should/shared_context.rb
-          break if full_test_path.include?(@@parent_of_test_dir)
+          if full_test_path.include?(@@parent_of_test_dir)
+            found_valid_test_file_path = true
+            break
+          end
+        end
+
+        unless found_valid_test_file_path
+          KnapsackPro.logger.warn('cannot detect a valid test file path. Probably the test file contains only shared examples. Please add test cases to your test file. Read more at https://github.com/KnapsackPro/knapsack_pro-ruby/pull/123')
+          KnapsackPro.logger.warn("See test file for #{obj.inspect}")
         end
 
         parent_of_test_dir_regexp = Regexp.new("^#{@@parent_of_test_dir}")

--- a/lib/knapsack_pro/adapters/test_unit_adapter.rb
+++ b/lib/knapsack_pro/adapters/test_unit_adapter.rb
@@ -5,9 +5,20 @@ module KnapsackPro
       @@parent_of_test_dir = nil
 
       def self.test_path(obj)
-        first_test = obj.tests.first
-        method = first_test.method_name
-        full_test_path = first_test.method(method).source_location.first
+        full_test_path = nil
+
+        obj.tests.each do |test_obj|
+          method = test_obj.method_name
+          full_test_path = test_obj.method(method).source_location.first
+          # if we find a test file path that is a valid test file path within test suite directory
+          # then break to stop looking further.
+          # If we won't find a valid test file path then the last found path will be used as full_test_path
+          # For instance if test file contains only shared examples then it's not possible to properly detect test file path
+          # so the wrong path can be returned like:
+          # /Users/artur/.rvm/gems/ruby-2.6.5/gems/shared_should-0.10.0/lib/shared_should/shared_context.rb
+          break if full_test_path.include?(@@parent_of_test_dir)
+        end
+
         parent_of_test_dir_regexp = Regexp.new("^#{@@parent_of_test_dir}")
         test_path = full_test_path.gsub(parent_of_test_dir_regexp, '.')
         # test_path will look like ./test/dir/unit_test.rb

--- a/lib/knapsack_pro/adapters/test_unit_adapter.rb
+++ b/lib/knapsack_pro/adapters/test_unit_adapter.rb
@@ -15,7 +15,7 @@ module KnapsackPro
           # then break to stop looking further.
           # If we won't find a valid test file path then the last found path will be used as full_test_path
           # For instance if test file contains only shared examples then it's not possible to properly detect test file path
-          # so the wrong path can be returned like:
+          # so the wrong path can be used like:
           # /Users/artur/.rvm/gems/ruby-2.6.5/gems/shared_should-0.10.0/lib/shared_should/shared_context.rb
           if full_test_path.include?(@@parent_of_test_dir)
             found_valid_test_file_path = true

--- a/spec/knapsack_pro/adapters/test_unit_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/test_unit_adapter_spec.rb
@@ -10,8 +10,7 @@ describe KnapsackPro::Adapters::TestUnitAdapter do
 
     before do
       parent_of_test_dir = File.expand_path('../../../', File.dirname(__FILE__))
-      parent_of_test_dir_regexp = Regexp.new("^#{parent_of_test_dir}")
-      described_class.class_variable_set(:@@parent_of_test_dir, parent_of_test_dir_regexp)
+      described_class.class_variable_set(:@@parent_of_test_dir, parent_of_test_dir)
     end
 
     context 'when regular test' do


### PR DESCRIPTION
# problem
When you use test runner `test-unit` https://test-unit.github.io and your test file has shared examples (`share_should` method) and regular test cases then when tests are executed in random order for this file then it could lead to knapsack_pro detecting wrong test file path for executed test if first test case is shared example for a test file.

Bug also happens when test file contains only shared examples.

Example test file with shared examples https://github.com/KnapsackPro/rails-app-with-knapsack_pro/blob/383cb917755f6d34bd3cacd8261226cc769e49a1/test-unit/models/shared_should_test.rb#L33


Root problem is that detecting test file path based on shared examples method returns wrong test file path.

```ruby
module KnapsackPro
  module Adapters
    class TestUnitAdapter < BaseAdapter
      TEST_DIR_PATTERN = 'test/**{,/*/**}/*_test.rb'
      @@parent_of_test_dir = nil

      def self.test_path(obj)
        first_test = obj.tests.first
        method = first_test.method_name
        full_test_path = first_test.method(method).source_location.first
        parent_of_test_dir_regexp = Regexp.new("^#{@@parent_of_test_dir}")
        test_path = full_test_path.gsub(parent_of_test_dir_regexp, '.')
        # test_path will look like ./test/dir/unit_test.rb
        test_path
      end
```

test_path method returned wrong path `/Users/artur/.rvm/gems/ruby-2.6.5/gems/shared_should-0.10.0/lib/shared_should/shared_context.rb` for shared example instead of `test-unit/models/shared_should_test.rb`

# fix

* knapsack_pro will try to detect the proper test file path. If the test file contains only shared examples then it's not possible to detect test file properly so the old behavior stays - the wrong path will be used because we don't have any other path.
* when wrong test file path is detected then show warning in logs 