### PR TITLE
When you use Regular Mode then try 6 attempts to connect to the API instead of 3 attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.2.2
+
+* When you use Regular Mode then try 6 attempts to connect to the API instead of 3 attempts
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/124
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.2.1...v2.2.2
+
 ### 2.2.1
 
 * Improve detection of test file path in test-unit runner for test files with shared examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * When you use Regular Mode then try 6 attempts to connect to the API instead of 3 attempts
 
+    Add `KNAPSACK_PRO_MAX_REQUEST_RETRIES` environment variable to let user define their own number of request retries to the API. It is useful to set it to `0` for [forked repos](https://knapsackpro.com/faq/question/how-to-make-knapsack_pro-works-for-forked-repositories-of-my-project) when you want to relay on Fallback Mode.
+
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/124
 
 https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.2.1...v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Change Log
 
-### 2.2.2
+### 2.3.0
 
 * When you use Regular Mode then try 6 attempts to connect to the API instead of 3 attempts
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/124
 
-https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.2.1...v2.2.2
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.2.1...v2.3.0
 
 ### 2.2.1
 

--- a/README.md
+++ b/README.md
@@ -2320,11 +2320,19 @@ There are a few ways to reproduce tests executed on CI node in your development 
 
 ##### for knapsack_pro regular mode
 
-knapsack_pro gem will retry requests to Knapsack Pro API multiple times every few seconds til it switch to fallback behavior and it will split test files across CI nodes based on popular test directory names. When knapsack_pro starts fallback mode then you will see a warning in the output.
+knapsack_pro gem will retry requests to Knapsack Pro API multiple times every few seconds till it switchs to fallback behavior (Fallback Mode) and it will split test files across CI nodes based on popular test directory names. When knapsack_pro starts Fallback Mode then you will see a warning in the output.
+
+Note there is an unlikely scenario when some of the CI nodes may start in Fallback Mode but others don't and then it could happen that some of test files might be skipped. You should [read this to learn more](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/124) and decide if you like to use Fallback Mode when running tests with knapsack_pro Regular Mode.
+
+If your CI provider allows to retry only one of parallel CI nodes then please [read about this edge case as well](#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode).
 
 ##### for knapsack_pro queue mode
 
-knapsack_pro gem will retry requests to Knapsack Pro API multiple times every few seconds till it switches to fallback behavior and it will split test files across CI nodes based on popular test directory names. Note that if one of CI nodes will lose connection to Knapsack Pro API but other not then you may see that some of the test files will be executed on multiple CI nodes. Fallback mode guarantees each of test files is run at least once across CI nodes. Thanks to that we know if the whole test suite is green or not. When knapsack_pro starts fallback mode then you will see a warning in the output.
+knapsack_pro gem will retry requests to Knapsack Pro API multiple times every few seconds till it switches to fallback behavior (Fallback Mode) and it will split test files across CI nodes based on popular test directory names.
+
+Note that if one of the CI nodes will lose connection to Knapsack Pro API but other not then you may see that some of the test files will be executed on multiple CI nodes. **Fallback Mode guarantees each of the test files is run at least once across CI nodes when you use knapsack_pro in Queue Mode.** Thanks to that we know if the whole test suite is green or not. When knapsack_pro starts Fallback Mode then you will see a warning in the output.
+
+If your CI provider allows to retry only one of parallel CI nodes then please [read about this edge case as well](#required-ci-configuration-if-you-use-retry-single-failed-ci-node-feature-on-your-ci-server-when-knapsack_pro_fixed_queue_splittrue-in-queue-mode-or-knapsack_pro_fixed_test_suite_splittrue-in-regular-mode).
 
 #### How can I change log level?
 

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -157,6 +157,9 @@ module KnapsackPro
       end
 
       def max_request_retries
+        # when user defined max request retries
+        return KnapsackPro::Config::Env.max_request_retries if KnapsackPro::Config::Env.max_request_retries
+
         # when Fallback Mode is disabled then try more attempts to connect to the API
         return 6 unless KnapsackPro::Config::Env.fallback_mode_enabled?
 

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -4,7 +4,6 @@ module KnapsackPro
       class ServerError < StandardError; end
 
       TIMEOUT = 15
-      MAX_RETRY = -> { KnapsackPro::Config::Env.fallback_mode_enabled? ? 3 : 6 }
       REQUEST_RETRY_TIMEBOX = 8
 
       def initialize(action)
@@ -118,7 +117,7 @@ module KnapsackPro
       rescue ServerError, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
         logger.warn(e.inspect)
         retries += 1
-        if retries < MAX_RETRY.call
+        if retries < max_request_retries
           wait = retries * REQUEST_RETRY_TIMEBOX
           logger.warn("Wait #{wait}s and retry request to Knapsack Pro API.")
           print_every = 2 # seconds
@@ -155,6 +154,18 @@ module KnapsackPro
         make_request do
           http.get(uri, json_headers)
         end
+      end
+
+      def max_request_retries
+        # when Fallback Mode is disabled then try more attempts to connect to the API
+        return 6 unless KnapsackPro::Config::Env.fallback_mode_enabled?
+
+        # when Regular Mode then try more attempts to connect to the API
+        # because if only one CI node starts Fallback Mode instead of all then we can't guarantee all test files will be run
+        return 6 if KnapsackPro::Config::Env.regular_mode?
+
+        # default number of attempts
+        3
       end
     end
   end

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -161,7 +161,8 @@ module KnapsackPro
         return 6 unless KnapsackPro::Config::Env.fallback_mode_enabled?
 
         # when Regular Mode then try more attempts to connect to the API
-        # because if only one CI node starts Fallback Mode instead of all then we can't guarantee all test files will be run
+        # if only one CI node starts Fallback Mode instead of all then we can't guarantee all test files will be run
+        # https://github.com/KnapsackPro/knapsack_pro-ruby/pull/124
         return 6 if KnapsackPro::Config::Env.regular_mode?
 
         # default number of attempts

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -83,6 +83,10 @@ module KnapsackPro
           recording_enabled == 'true'
         end
 
+        def regular_mode?
+          recording_enabled?
+        end
+
         def queue_recording_enabled
           ENV['KNAPSACK_PRO_QUEUE_RECORDING_ENABLED']
         end

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -36,6 +36,13 @@ module KnapsackPro
           ).to_i
         end
 
+        def max_request_retries
+          number = ENV['KNAPSACK_PRO_MAX_REQUEST_RETRIES']
+          if number
+            number.to_i
+          end
+        end
+
         def commit_hash
           ENV['KNAPSACK_PRO_COMMIT_HASH'] ||
             ci_env_for(:commit_hash)

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -108,6 +108,53 @@ shared_examples 'when retry request' do
       expect(connection.errors?).to be true
     end
 
+    context 'when max request retries defined' do
+      before do
+        expect(KnapsackPro::Config::Env).to receive(:max_request_retries).at_least(1).and_return(4)
+      end
+
+      it do
+        expect(logger).to receive(:debug).exactly(4).with("#{expected_http_method} http://api.knapsackpro.test:3000/v1/fake_endpoint")
+        expect(logger).to receive(:debug).exactly(4).with('API request UUID: fake-uuid')
+        expect(logger).to receive(:debug).exactly(4).with('API response:')
+
+        parsed_response = { 'error' => 'Internal Server Error' }
+
+        expect(logger).to receive(:error).exactly(4).with(parsed_response)
+
+        server_error = described_class::ServerError.new(parsed_response)
+        expect(logger).to receive(:warn).exactly(4).with(server_error.inspect)
+
+        expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("Next request in 8s...")
+        expect(logger).to receive(:warn).with("Next request in 6s...")
+        expect(logger).to receive(:warn).with("Next request in 4s...")
+        expect(logger).to receive(:warn).with("Next request in 2s...")
+
+        expect(logger).to receive(:warn).with("Wait 16s and retry request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("Next request in 16s...")
+        expect(logger).to receive(:warn).with("Next request in 14s...")
+        expect(logger).to receive(:warn).with("Next request in 12s...")
+        expect(logger).to receive(:warn).with("Next request in 10s...")
+        expect(logger).to receive(:warn).with("Next request in 8s...")
+        expect(logger).to receive(:warn).with("Next request in 6s...")
+        expect(logger).to receive(:warn).with("Next request in 4s...")
+        expect(logger).to receive(:warn).with("Next request in 2s...")
+
+        expect(logger).to receive(:warn).with("Wait 24s and retry request to Knapsack Pro API.")
+        12.times do |i|
+          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        end
+
+        expect(Kernel).to receive(:sleep).exactly(4+8+12).with(2)
+
+        expect(subject).to eq(parsed_response)
+
+        expect(connection.success?).to be false
+        expect(connection.errors?).to be true
+      end
+    end
+
     context 'when Fallback Mode is disabled' do
       before do
         expect(KnapsackPro::Config::Env).to receive(:fallback_mode_enabled?).at_least(1).and_return(false)

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -100,6 +100,19 @@ describe KnapsackPro::Config::Env do
     end
   end
 
+  describe '.max_request_retries' do
+    subject { described_class.max_request_retries }
+
+    context 'when ENV exists' do
+      before { stub_const("ENV", { 'KNAPSACK_PRO_MAX_REQUEST_RETRIES' => '2' }) }
+      it { should eq 2 }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should be_nil }
+    end
+  end
+
   describe '.commit_hash' do
     subject { described_class.commit_hash }
 

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -267,6 +267,25 @@ describe KnapsackPro::Config::Env do
     end
   end
 
+
+  describe '.regular_mode?' do
+    subject { described_class.regular_mode? }
+
+    before do
+      expect(described_class).to receive(:recording_enabled?).and_return(recording_enabled)
+    end
+
+    context 'when recording is enabled' do
+      let(:recording_enabled) { true }
+      it { should be true }
+    end
+
+    context 'when recording is not enabled' do
+      let(:recording_enabled) { false }
+      it { should be false }
+    end
+  end
+
   describe '.recording_enabled?' do
     subject { described_class.recording_enabled? }
 


### PR DESCRIPTION
# problem

Before this PR the knapsack_pro gem does 3 attempts to connect to Knapsack Pro API before starting running tests in [Fallback Mode](https://github.com/KnapsackPro/knapsack_pro-ruby#what-happens-when-knapsack-pro-api-is-not-availablenot-reachable-temporarily).

The described problem below is relevant only for running knapsack_pro in Regular Mode.

## Example scenarios

Assume:
* there are 2 parallel CI nodes. 
* the user uses knapsack_pro gem in Regular Mode.

Here you can learn about the [difference between Regular Mode and Queue Mode](https://docs.knapsackpro.com/2020/how-to-speed-up-ruby-and-javascript-tests-with-ci-parallelisation)

## Scenario when Knapsack Pro API is not available at all (no bug - successful scenario)

* CI node index 0 can't connect to the API so it starts running tests in Fallback Mode.
* CI node index 1 can't connect to the API so it starts running tests in Fallback Mode.

The whole test suite is executed across parallel CI nodes. Everything works fine.

## Scenario when Knapsack Pro API was not available only for one of the parallel CI nodes (bug exists - buggy scenario)

* CI node index 0 can't connect to the API so it starts running tests in Fallback Mode
* CI node index 1 can connect to the API so it starts running tests based on list of tests from the API

There is a risk that tests that supposed to be run on CI node index 0 and were never fetched from API won't run at all because Fallback Mode can run a different set of tests on CI node index 0. 
CI node index 1 instead of running tests in Fallback Mode was able to connect to the API so it got a different set of tests then it would get if it was also running Fallback Mode.

Problem: 

* A) This can lead to the scenario that not all test files from test suite will be run as part of CI build. This is a problem.
* B) Some of test files run in Fallback Mode on CI node index 0 can be the same as test files fetched from API on CI node index 1. This is not an issue that we run some tests at least once. The biggest issue is that we can skip some test files (issue A).

**Important:** knapsack_pro gem in Regular Mode can guarantee each test file from the test suite will be executed only when Fallback Mode starts on all parallel CI nodes.

# what we aim for

* We should aim to the scenario that all parallel CI nodes can connect to Knapsack Pro API.
* Or we should aim to the scenario that all parallel CI nodes should run Fallback Mode.

Only those 2 scenarios guarantee that all test files from the test suite will be run as part of the CI build.

* We should avoid scenario that some of CI nodes connect to Knapsack Pro API and other CI nodes use Fallback Mode. This can lead to skipping some tests as part of CI build.

# solution

We can increase max request retries attempts to the Knapsack Pro API. 

knapsack_pro gem in Regular Mode will do 6 attempts to connect to the API before starting Fallback Mode.
6 attempts will be spread across 2 minutes. This should be plenty of time for the Knapsack Pro API to auto-scale up the new available servers to serve increased traffic to the API.

If in 2 minutes knapsack_pro gem can't connect to the API then it is more likely a serious problem with the API availability so API should rather be not available at all to all parallel CI nodes (then all CI nodes should start in Fallback Mode). 

Of course, there is still a risk that edge case can happen and across all parallel CI nodes some of them connected to API and some of them did 6 requests attempts and started Fallback Mode. 

## recommendations

* If you would like to be 100% sure you never have this edge case then you can completely disable Fallback Mode with the env variable `KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false`.

* If you want to define on your own how many request attempts can be made you can do it with the env variable  `KNAPSACK_PRO_MAX_REQUEST_RETRIES=7`.




