### PR TITLE
Update list of non encryptable branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.4.0
+
+* Update list of non encryptable branches
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/125
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.3.0...v2.4.0
+
 ### 2.3.0
 
 * When you use Regular Mode then try 6 attempts to connect to the API instead of 3 attempts

--- a/lib/knapsack_pro/crypto/branch_encryptor.rb
+++ b/lib/knapsack_pro/crypto/branch_encryptor.rb
@@ -1,7 +1,21 @@
 module KnapsackPro
   module Crypto
     class BranchEncryptor
-      NON_ENCRYPTABLE_BRANCHES = %w(develop development dev master staging)
+      NON_ENCRYPTABLE_BRANCHES = [
+        'master',
+        'main',
+        'develop',
+        'development',
+        'dev',
+        'staging',
+        # GitHub Actions has branch names starting with refs/heads/
+        'refs/heads/master',
+        'refs/heads/main',
+        'refs/heads/develop',
+        'refs/heads/development',
+        'refs/heads/dev',
+        'refs/heads/staging',
+      ]
 
       def self.call(branch)
         if KnapsackPro::Config::Env.branch_encrypted?


### PR DESCRIPTION
Add new branch names like main, development etc. There is no need to encrypt them. Thanks to that Knapsack Pro API can use them as default branches to get from them recorded tests timing data that could be used for a fresh new branch CI build.

Add branches with prefix refs/heads/ that are used on Github Actions.