### PR TITLE
Improve logger to show failed requests URL and when retry will happen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.6.0
+
+* Improve logger to show failed requests URL and when retry will happen
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/127
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.5.0...v2.6.0
+
 ### 2.5.0
 
 * Add production branch to non encryptable branches names

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -115,6 +115,8 @@ module KnapsackPro
 
         response_body
       rescue ServerError, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE, EOFError, SocketError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
+        logger.warn("#{action.http_method.to_s.upcase} #{endpoint_url}")
+        logger.warn('Request failed due to:')
         logger.warn(e.inspect)
         retries += 1
         if retries < max_request_retries

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -121,10 +121,13 @@ module KnapsackPro
         retries += 1
         if retries < max_request_retries
           wait = retries * REQUEST_RETRY_TIMEBOX
-          logger.warn("Wait #{wait}s and retry request to Knapsack Pro API.")
           print_every = 2 # seconds
           (wait / print_every).ceil.times do |i|
-            logger.warn("Next request in #{wait - i * print_every}s...")
+            if i == 0
+              logger.warn("Wait for #{wait}s before retrying the request to Knapsack Pro API.")
+            else
+              logger.warn("#{wait - i * print_every}s left before retry...")
+            end
             Kernel.sleep(print_every)
           end
           retry

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -84,6 +84,8 @@ shared_examples 'when retry request' do
       expect(logger).to receive(:error).exactly(3).with(parsed_response)
 
       server_error = described_class::ServerError.new(parsed_response)
+      expect(logger).to receive(:warn).exactly(3).with("#{expected_http_method} http://api.knapsackpro.test:3000/v1/fake_endpoint")
+      expect(logger).to receive(:warn).exactly(3).with('Request failed due to:')
       expect(logger).to receive(:warn).exactly(3).with(server_error.inspect)
 
       expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
@@ -123,6 +125,8 @@ shared_examples 'when retry request' do
         expect(logger).to receive(:error).exactly(4).with(parsed_response)
 
         server_error = described_class::ServerError.new(parsed_response)
+        expect(logger).to receive(:warn).exactly(4).with("#{expected_http_method} http://api.knapsackpro.test:3000/v1/fake_endpoint")
+        expect(logger).to receive(:warn).exactly(4).with('Request failed due to:')
         expect(logger).to receive(:warn).exactly(4).with(server_error.inspect)
 
         expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
@@ -170,6 +174,8 @@ shared_examples 'when retry request' do
         expect(logger).to receive(:error).exactly(6).with(parsed_response)
 
         server_error = described_class::ServerError.new(parsed_response)
+        expect(logger).to receive(:warn).exactly(6).with("#{expected_http_method} http://api.knapsackpro.test:3000/v1/fake_endpoint")
+        expect(logger).to receive(:warn).exactly(6).with('Request failed due to:')
         expect(logger).to receive(:warn).exactly(6).with(server_error.inspect)
 
         expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
@@ -227,6 +233,8 @@ shared_examples 'when retry request' do
         expect(logger).to receive(:error).exactly(6).with(parsed_response)
 
         server_error = described_class::ServerError.new(parsed_response)
+        expect(logger).to receive(:warn).exactly(6).with("#{expected_http_method} http://api.knapsackpro.test:3000/v1/fake_endpoint")
+        expect(logger).to receive(:warn).exactly(6).with('Request failed due to:')
         expect(logger).to receive(:warn).exactly(6).with(server_error.inspect)
 
         expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")

--- a/spec/knapsack_pro/client/connection_spec.rb
+++ b/spec/knapsack_pro/client/connection_spec.rb
@@ -88,20 +88,18 @@ shared_examples 'when retry request' do
       expect(logger).to receive(:warn).exactly(3).with('Request failed due to:')
       expect(logger).to receive(:warn).exactly(3).with(server_error.inspect)
 
-      expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
-      expect(logger).to receive(:warn).with("Next request in 8s...")
-      expect(logger).to receive(:warn).with("Next request in 6s...")
-      expect(logger).to receive(:warn).with("Next request in 4s...")
-      expect(logger).to receive(:warn).with("Next request in 2s...")
-      expect(logger).to receive(:warn).with("Wait 16s and retry request to Knapsack Pro API.")
-      expect(logger).to receive(:warn).with("Next request in 16s...")
-      expect(logger).to receive(:warn).with("Next request in 14s...")
-      expect(logger).to receive(:warn).with("Next request in 12s...")
-      expect(logger).to receive(:warn).with("Next request in 10s...")
-      expect(logger).to receive(:warn).with("Next request in 8s...")
-      expect(logger).to receive(:warn).with("Next request in 6s...")
-      expect(logger).to receive(:warn).with("Next request in 4s...")
-      expect(logger).to receive(:warn).with("Next request in 2s...")
+      expect(logger).to receive(:warn).with("Wait for 8s before retrying the request to Knapsack Pro API.")
+      expect(logger).to receive(:warn).with("6s left before retry...")
+      expect(logger).to receive(:warn).with("4s left before retry...")
+      expect(logger).to receive(:warn).with("2s left before retry...")
+      expect(logger).to receive(:warn).with("Wait for 16s before retrying the request to Knapsack Pro API.")
+      expect(logger).to receive(:warn).with("14s left before retry...")
+      expect(logger).to receive(:warn).with("12s left before retry...")
+      expect(logger).to receive(:warn).with("10s left before retry...")
+      expect(logger).to receive(:warn).with("8s left before retry...")
+      expect(logger).to receive(:warn).with("6s left before retry...")
+      expect(logger).to receive(:warn).with("4s left before retry...")
+      expect(logger).to receive(:warn).with("2s left before retry...")
       expect(Kernel).to receive(:sleep).exactly(12).with(2)
 
       expect(subject).to eq(parsed_response)
@@ -129,25 +127,23 @@ shared_examples 'when retry request' do
         expect(logger).to receive(:warn).exactly(4).with('Request failed due to:')
         expect(logger).to receive(:warn).exactly(4).with(server_error.inspect)
 
-        expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
-        expect(logger).to receive(:warn).with("Next request in 8s...")
-        expect(logger).to receive(:warn).with("Next request in 6s...")
-        expect(logger).to receive(:warn).with("Next request in 4s...")
-        expect(logger).to receive(:warn).with("Next request in 2s...")
+        expect(logger).to receive(:warn).with("Wait for 8s before retrying the request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("6s left before retry...")
+        expect(logger).to receive(:warn).with("4s left before retry...")
+        expect(logger).to receive(:warn).with("2s left before retry...")
 
-        expect(logger).to receive(:warn).with("Wait 16s and retry request to Knapsack Pro API.")
-        expect(logger).to receive(:warn).with("Next request in 16s...")
-        expect(logger).to receive(:warn).with("Next request in 14s...")
-        expect(logger).to receive(:warn).with("Next request in 12s...")
-        expect(logger).to receive(:warn).with("Next request in 10s...")
-        expect(logger).to receive(:warn).with("Next request in 8s...")
-        expect(logger).to receive(:warn).with("Next request in 6s...")
-        expect(logger).to receive(:warn).with("Next request in 4s...")
-        expect(logger).to receive(:warn).with("Next request in 2s...")
+        expect(logger).to receive(:warn).with("Wait for 16s before retrying the request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("14s left before retry...")
+        expect(logger).to receive(:warn).with("12s left before retry...")
+        expect(logger).to receive(:warn).with("10s left before retry...")
+        expect(logger).to receive(:warn).with("8s left before retry...")
+        expect(logger).to receive(:warn).with("6s left before retry...")
+        expect(logger).to receive(:warn).with("4s left before retry...")
+        expect(logger).to receive(:warn).with("2s left before retry...")
 
-        expect(logger).to receive(:warn).with("Wait 24s and retry request to Knapsack Pro API.")
-        12.times do |i|
-          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        expect(logger).to receive(:warn).with("Wait for 24s before retrying the request to Knapsack Pro API.")
+        11.times do |i|
+          expect(logger).to receive(:warn).with("#{(i+1)*2}s left before retry...")
         end
 
         expect(Kernel).to receive(:sleep).exactly(4+8+12).with(2)
@@ -178,35 +174,33 @@ shared_examples 'when retry request' do
         expect(logger).to receive(:warn).exactly(6).with('Request failed due to:')
         expect(logger).to receive(:warn).exactly(6).with(server_error.inspect)
 
-        expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
-        expect(logger).to receive(:warn).with("Next request in 8s...")
-        expect(logger).to receive(:warn).with("Next request in 6s...")
-        expect(logger).to receive(:warn).with("Next request in 4s...")
-        expect(logger).to receive(:warn).with("Next request in 2s...")
+        expect(logger).to receive(:warn).with("Wait for 8s before retrying the request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("6s left before retry...")
+        expect(logger).to receive(:warn).with("4s left before retry...")
+        expect(logger).to receive(:warn).with("2s left before retry...")
 
-        expect(logger).to receive(:warn).with("Wait 16s and retry request to Knapsack Pro API.")
-        expect(logger).to receive(:warn).with("Next request in 16s...")
-        expect(logger).to receive(:warn).with("Next request in 14s...")
-        expect(logger).to receive(:warn).with("Next request in 12s...")
-        expect(logger).to receive(:warn).with("Next request in 10s...")
-        expect(logger).to receive(:warn).with("Next request in 8s...")
-        expect(logger).to receive(:warn).with("Next request in 6s...")
-        expect(logger).to receive(:warn).with("Next request in 4s...")
-        expect(logger).to receive(:warn).with("Next request in 2s...")
+        expect(logger).to receive(:warn).with("Wait for 16s before retrying the request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("14s left before retry...")
+        expect(logger).to receive(:warn).with("12s left before retry...")
+        expect(logger).to receive(:warn).with("10s left before retry...")
+        expect(logger).to receive(:warn).with("8s left before retry...")
+        expect(logger).to receive(:warn).with("6s left before retry...")
+        expect(logger).to receive(:warn).with("4s left before retry...")
+        expect(logger).to receive(:warn).with("2s left before retry...")
 
-        expect(logger).to receive(:warn).with("Wait 24s and retry request to Knapsack Pro API.")
-        12.times do |i|
-          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        expect(logger).to receive(:warn).with("Wait for 24s before retrying the request to Knapsack Pro API.")
+        11.times do |i|
+          expect(logger).to receive(:warn).with("#{(i+1)*2}s left before retry...")
         end
 
-        expect(logger).to receive(:warn).with("Wait 32s and retry request to Knapsack Pro API.")
-        16.times do |i|
-          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        expect(logger).to receive(:warn).with("Wait for 32s before retrying the request to Knapsack Pro API.")
+        15.times do |i|
+          expect(logger).to receive(:warn).with("#{(i+1)*2}s left before retry...")
         end
 
-        expect(logger).to receive(:warn).with("Wait 40s and retry request to Knapsack Pro API.")
-        20.times do |i|
-          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        expect(logger).to receive(:warn).with("Wait for 40s before retrying the request to Knapsack Pro API.")
+        19.times do |i|
+          expect(logger).to receive(:warn).with("#{(i+1)*2}s left before retry...")
         end
 
         expect(Kernel).to receive(:sleep).exactly(60).with(2)
@@ -237,35 +231,33 @@ shared_examples 'when retry request' do
         expect(logger).to receive(:warn).exactly(6).with('Request failed due to:')
         expect(logger).to receive(:warn).exactly(6).with(server_error.inspect)
 
-        expect(logger).to receive(:warn).with("Wait 8s and retry request to Knapsack Pro API.")
-        expect(logger).to receive(:warn).with("Next request in 8s...")
-        expect(logger).to receive(:warn).with("Next request in 6s...")
-        expect(logger).to receive(:warn).with("Next request in 4s...")
-        expect(logger).to receive(:warn).with("Next request in 2s...")
+        expect(logger).to receive(:warn).with("Wait for 8s before retrying the request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("6s left before retry...")
+        expect(logger).to receive(:warn).with("4s left before retry...")
+        expect(logger).to receive(:warn).with("2s left before retry...")
 
-        expect(logger).to receive(:warn).with("Wait 16s and retry request to Knapsack Pro API.")
-        expect(logger).to receive(:warn).with("Next request in 16s...")
-        expect(logger).to receive(:warn).with("Next request in 14s...")
-        expect(logger).to receive(:warn).with("Next request in 12s...")
-        expect(logger).to receive(:warn).with("Next request in 10s...")
-        expect(logger).to receive(:warn).with("Next request in 8s...")
-        expect(logger).to receive(:warn).with("Next request in 6s...")
-        expect(logger).to receive(:warn).with("Next request in 4s...")
-        expect(logger).to receive(:warn).with("Next request in 2s...")
+        expect(logger).to receive(:warn).with("Wait for 16s before retrying the request to Knapsack Pro API.")
+        expect(logger).to receive(:warn).with("14s left before retry...")
+        expect(logger).to receive(:warn).with("12s left before retry...")
+        expect(logger).to receive(:warn).with("10s left before retry...")
+        expect(logger).to receive(:warn).with("8s left before retry...")
+        expect(logger).to receive(:warn).with("6s left before retry...")
+        expect(logger).to receive(:warn).with("4s left before retry...")
+        expect(logger).to receive(:warn).with("2s left before retry...")
 
-        expect(logger).to receive(:warn).with("Wait 24s and retry request to Knapsack Pro API.")
-        12.times do |i|
-          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        expect(logger).to receive(:warn).with("Wait for 24s before retrying the request to Knapsack Pro API.")
+        11.times do |i|
+          expect(logger).to receive(:warn).with("#{(i+1)*2}s left before retry...")
         end
 
-        expect(logger).to receive(:warn).with("Wait 32s and retry request to Knapsack Pro API.")
-        16.times do |i|
-          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        expect(logger).to receive(:warn).with("Wait for 32s before retrying the request to Knapsack Pro API.")
+        15.times do |i|
+          expect(logger).to receive(:warn).with("#{(i+1)*2}s left before retry...")
         end
 
-        expect(logger).to receive(:warn).with("Wait 40s and retry request to Knapsack Pro API.")
-        20.times do |i|
-          expect(logger).to receive(:warn).with("Next request in #{(i+1)*2}s...")
+        expect(logger).to receive(:warn).with("Wait for 40s before retrying the request to Knapsack Pro API.")
+        19.times do |i|
+          expect(logger).to receive(:warn).with("#{(i+1)*2}s left before retry...")
         end
 
         expect(Kernel).to receive(:sleep).exactly(60).with(2)


### PR DESCRIPTION
* Improve logger to show failed requests URL
* More clear message when showing info about waiting for next request retry

Example output:

```
W, [2020-09-23T13:04:03.675239 #52494]  WARN -- : [knapsack_pro] POST http://api-fake.knapsackpro.test:3000/v1/queues/queue
W, [2020-09-23T13:04:03.675327 #52494]  WARN -- : [knapsack_pro] Request failed due to:
W, [2020-09-23T13:04:03.675354 #52494]  WARN -- : [knapsack_pro] #<SocketError: Failed to open TCP connection to api-fake.knapsackpro.test:3000 (getaddrinfo: nodename nor servname provided, or not known)>
W, [2020-09-23T13:04:03.675392 #52494]  WARN -- : [knapsack_pro] Wait for 8s before retrying the request to Knapsack Pro API.
W, [2020-09-23T13:04:05.678955 #52494]  WARN -- : [knapsack_pro] 6s left before retry...
W, [2020-09-23T13:04:07.683879 #52494]  WARN -- : [knapsack_pro] 4s left before retry...
W, [2020-09-23T13:04:09.689065 #52494]  WARN -- : [knapsack_pro] 2s left before retry...
W, [2020-09-23T13:04:11.697194 #52494]  WARN -- : [knapsack_pro] POST http://api-fake.knapsackpro.test:3000/v1/queues/queue
W, [2020-09-23T13:04:11.697262 #52494]  WARN -- : [knapsack_pro] Request failed due to:
W, [2020-09-23T13:04:11.697296 #52494]  WARN -- : [knapsack_pro] #<SocketError: Failed to open TCP connection to api-fake.knapsackpro.test:3000 (getaddrinfo: nodename nor servname provided, or not known)>
W, [2020-09-23T13:04:11.697338 #52494]  WARN -- : [knapsack_pro] Wait for 16s before retrying the request to Knapsack Pro API.
W, [2020-09-23T13:04:13.701011 #52494]  WARN -- : [knapsack_pro] 14s left before retry...
W, [2020-09-23T13:04:15.706214 #52494]  WARN -- : [knapsack_pro] 12s left before retry...
W, [2020-09-23T13:04:17.711670 #52494]  WARN -- : [knapsack_pro] 10s left before retry...
W, [2020-09-23T13:04:19.714524 #52494]  WARN -- : [knapsack_pro] 8s left before retry...
W, [2020-09-23T13:04:21.716759 #52494]  WARN -- : [knapsack_pro] 6s left before retry...
W, [2020-09-23T13:04:23.718025 #52494]  WARN -- : [knapsack_pro] 4s left before retry...
W, [2020-09-23T13:04:25.722577 #52494]  WARN -- : [knapsack_pro] 2s left before retry...
W, [2020-09-23T13:04:27.735953 #52494]  WARN -- : [knapsack_pro] POST http://api-fake.knapsackpro.test:3000/v1/queues/queue
W, [2020-09-23T13:04:27.736063 #52494]  WARN -- : [knapsack_pro] Request failed due to:
W, [2020-09-23T13:04:27.736125 #52494]  WARN -- : [knapsack_pro] #<SocketError: Failed to open TCP connection to api-fake.knapsackpro.test:3000 (getaddrinfo: nodename nor servname provided, or not known)>
```