### PR TITLE
More actionable error message when RSpec split by examples is not working due to RSpec dry-run failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.8.0
+
+* More actionable error message when RSpec split by examples is not working due to RSpec dry-run failure
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/130
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.7.0...v2.8.0
+
 ### 2.7.0
 
 * Add support for env var `KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE` to allow accepting file containing test files to run

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -36,9 +36,13 @@ module KnapsackPro
           debug_cmd = ([
             'bundle exec rspec',
           ] + cli_args).join(' ')
-          KnapsackPro.logger.error('-'*100)
-          KnapsackPro.logger.error('Please read an exception message below:')
-          raise "There was a problem while generating test examples for the test suite using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run this command (this way, you can find out what is causing the error): #{debug_cmd}"
+
+          KnapsackPro.logger.error('-'*10 + ' START of actionable error message ' + '-'*50)
+          KnapsackPro.logger.error('There was a problem while generating test examples for the test suite using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run below command (this way, you can find out what is causing the error):')
+          KnapsackPro.logger.error(debug_cmd)
+          KnapsackPro.logger.error('-'*10 + ' END of actionable error message ' + '-'*50)
+
+          raise 'There was a problem while generating test examples for the test suite. Please read actionable error message above.'
         end
       end
 

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -36,7 +36,7 @@ module KnapsackPro
           debug_cmd = ([
             'bundle exec rspec',
           ] + cli_args).join(' ')
-          raise "There was a problem while generating test examples for the test suite. To reproduce the error triggered by RSpec please try to run this command. (this way, you can find out what is causing the error): #{debug_cmd}"
+          raise "There was a problem while generating test examples for the test suite using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run this command (this way, you can find out what is causing the error): #{debug_cmd}"
         end
       end
 

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -38,11 +38,11 @@ module KnapsackPro
           ] + cli_args).join(' ')
 
           KnapsackPro.logger.error('-'*10 + ' START of actionable error message ' + '-'*50)
-          KnapsackPro.logger.error('There was a problem while generating test examples for the test suite using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run below command (this way, you can find out what is causing the error):')
+          KnapsackPro.logger.error('There was a problem while generating test examples for the slow test files using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run below command (this way, you can find out what is causing the error):')
           KnapsackPro.logger.error(debug_cmd)
           KnapsackPro.logger.error('-'*10 + ' END of actionable error message ' + '-'*50)
 
-          raise 'There was a problem while generating test examples for the test suite. Please read actionable error message above.'
+          raise 'There was a problem while generating test examples for the slow test files. Please read actionable error message above.'
         end
       end
 

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -36,6 +36,8 @@ module KnapsackPro
           debug_cmd = ([
             'bundle exec rspec',
           ] + cli_args).join(' ')
+          KnapsackPro.logger.error('-'*100)
+          KnapsackPro.logger.error('Please read an exception message below:')
           raise "There was a problem while generating test examples for the test suite using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run this command (this way, you can find out what is causing the error): #{debug_cmd}"
         end
       end

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -33,7 +33,10 @@ module KnapsackPro
         options = ::RSpec::Core::ConfigurationOptions.new(cli_args)
         exit_code = ::RSpec::Core::Runner.new(options).run($stderr, $stdout)
         if exit_code != 0
-          raise 'There was problem to generate test examples for test suite'
+          debug_cmd = ([
+            'bundle exec rspec',
+          ] + cli_args).join(' ')
+          raise "There was a problem while generating test examples for the test suite. To reproduce the error triggered by RSpec please try to run this command. (this way, you can find out what is causing the error): #{debug_cmd}"
         end
       end
 

--- a/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
+++ b/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
@@ -67,7 +67,7 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
           let(:exit_code) { 1 }
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'There was a problem while generating test examples for the test suite. Please read actionable error message above.')
+            expect { subject }.to raise_error(RuntimeError, 'There was a problem while generating test examples for the slow test files. Please read actionable error message above.')
           end
         end
       end

--- a/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
+++ b/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
@@ -67,7 +67,7 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
           let(:exit_code) { 1 }
 
           it do
-            expect { subject }.to raise_error(RuntimeError, expected_exception_message)
+            expect { subject }.to raise_error(RuntimeError, 'There was a problem while generating test examples for the test suite. Please read actionable error message above.')
           end
         end
       end
@@ -75,14 +75,12 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
 
     context 'when RSpec >= 3.6.0' do
       let(:expected_format) { 'json' }
-      let(:expected_exception_message) { 'There was a problem while generating test examples for the test suite using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run this command (this way, you can find out what is causing the error): bundle exec rspec --format json --dry-run --out tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json --default-path spec spec/a_spec.rb spec/b_spec.rb' }
 
       it_behaves_like 'generate_json_report runs RSpec::Core::Runner'
     end
 
     context 'when RSpec < 3.6.0' do
       let(:expected_format) { 'KnapsackPro::Formatters::RSpecJsonFormatter' }
-      let(:expected_exception_message) { 'There was a problem while generating test examples for the test suite using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run this command (this way, you can find out what is causing the error): bundle exec rspec --format KnapsackPro::Formatters::RSpecJsonFormatter --dry-run --out tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json --default-path spec spec/a_spec.rb spec/b_spec.rb' }
 
       before do
         stub_const('RSpec::Core::Version::STRING', '3.5.0')

--- a/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
+++ b/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
@@ -67,7 +67,7 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
           let(:exit_code) { 1 }
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'There was problem to generate test examples for test suite')
+            expect { subject }.to raise_error(RuntimeError, expected_exception_message)
           end
         end
       end
@@ -75,12 +75,14 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
 
     context 'when RSpec >= 3.6.0' do
       let(:expected_format) { 'json' }
+      let(:expected_exception_message) { 'There was a problem while generating test examples for the test suite. To reproduce the error triggered by RSpec please try to run this command. (this way, you can find out what is causing the error): bundle exec rspec --format json --dry-run --out tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json --default-path spec spec/a_spec.rb spec/b_spec.rb' }
 
       it_behaves_like 'generate_json_report runs RSpec::Core::Runner'
     end
 
     context 'when RSpec < 3.6.0' do
       let(:expected_format) { 'KnapsackPro::Formatters::RSpecJsonFormatter' }
+      let(:expected_exception_message) { 'There was a problem while generating test examples for the test suite. To reproduce the error triggered by RSpec please try to run this command. (this way, you can find out what is causing the error): bundle exec rspec --format KnapsackPro::Formatters::RSpecJsonFormatter --dry-run --out tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json --default-path spec spec/a_spec.rb spec/b_spec.rb' }
 
       before do
         stub_const('RSpec::Core::Version::STRING', '3.5.0')

--- a/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
+++ b/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
@@ -75,14 +75,14 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
 
     context 'when RSpec >= 3.6.0' do
       let(:expected_format) { 'json' }
-      let(:expected_exception_message) { 'There was a problem while generating test examples for the test suite. To reproduce the error triggered by RSpec please try to run this command. (this way, you can find out what is causing the error): bundle exec rspec --format json --dry-run --out tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json --default-path spec spec/a_spec.rb spec/b_spec.rb' }
+      let(:expected_exception_message) { 'There was a problem while generating test examples for the test suite using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run this command (this way, you can find out what is causing the error): bundle exec rspec --format json --dry-run --out tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json --default-path spec spec/a_spec.rb spec/b_spec.rb' }
 
       it_behaves_like 'generate_json_report runs RSpec::Core::Runner'
     end
 
     context 'when RSpec < 3.6.0' do
       let(:expected_format) { 'KnapsackPro::Formatters::RSpecJsonFormatter' }
-      let(:expected_exception_message) { 'There was a problem while generating test examples for the test suite. To reproduce the error triggered by RSpec please try to run this command. (this way, you can find out what is causing the error): bundle exec rspec --format KnapsackPro::Formatters::RSpecJsonFormatter --dry-run --out tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json --default-path spec spec/a_spec.rb spec/b_spec.rb' }
+      let(:expected_exception_message) { 'There was a problem while generating test examples for the test suite using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run this command (this way, you can find out what is causing the error): bundle exec rspec --format KnapsackPro::Formatters::RSpecJsonFormatter --dry-run --out tmp/knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json --default-path spec spec/a_spec.rb spec/b_spec.rb' }
 
       before do
         stub_const('RSpec::Core::Version::STRING', '3.5.0')


### PR DESCRIPTION
* Show actionable error - show how to reproduce RSpec dry-run command in development to check what's root problem of the RSpec failure