### PR TITLE
Use Process.clock_gettime to measure track execution time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.9.0
+
+* Use `Process.clock_gettime` to measure track execution time
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/132
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.8.0...v2.9.0
+
 ### 2.8.0
 
 * More actionable error message when RSpec split by examples is not working due to RSpec dry-run failure

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -90,11 +90,7 @@ module KnapsackPro
     end
 
     def now_without_mock_time
-      if defined?(Timecop)
-        Time.now_without_mock_time
-      else
-        Time.raw_now
-      end
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end


### PR DESCRIPTION
# problem
Using any variation of `Time.now` is not a reliable way of measuring elapsed time. It may be affected by jumps in the local clock.

# solution
Instead, we can use a more reliable `Process.clock_gettime(Process:: CLOCK_MONOTONIC)`.

For a detailed explanation, please read this blog post: https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/

# Related PR
https://github.com/ArturT/knapsack/pull/100