### PR TITLE
Add support for an attempt to connect to existing Queue on API side to reduce slow requests number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.10.0
+
+* Add support for an attempt to connect to existing Queue on API side to reduce slow requests number
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/133
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.9.0...v2.10.0
+
 ### 2.9.0
 
 * Use `Process.clock_gettime` to measure track execution time

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -63,6 +63,10 @@ module KnapsackPro
       end
     end
 
+    def lazy_fast_and_slow_test_files_to_run
+      lambda { fast_and_slow_test_files_to_run }
+    end
+
     private
 
     attr_reader :adapter_class

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -28,6 +28,10 @@ module KnapsackPro
       all_test_files_to_run
     end
 
+    def lazy_fallback_mode_test_files
+      lambda { fallback_mode_test_files }
+    end
+
     # detect test files present on the disk that should be run
     # this may include some fast test files + slow test files split by test cases
     def fast_and_slow_test_files_to_run

--- a/lib/knapsack_pro/client/api/v1/queues.rb
+++ b/lib/knapsack_pro/client/api/v1/queues.rb
@@ -8,6 +8,7 @@ module KnapsackPro
               request_hash = {
                 :fixed_queue_split => KnapsackPro::Config::Env.fixed_queue_split,
                 :can_initialize_queue => args.fetch(:can_initialize_queue),
+                :attempt_connect_to_queue => args.fetch(:attempt_connect_to_queue),
                 :commit_hash => args.fetch(:commit_hash),
                 :branch => args.fetch(:branch),
                 :node_total => args.fetch(:node_total),
@@ -15,7 +16,7 @@ module KnapsackPro
                 :node_build_id => KnapsackPro::Config::Env.ci_node_build_id,
               }
 
-              if request_hash[:can_initialize_queue]
+              if request_hash[:can_initialize_queue] && !request_hash[:attempt_connect_to_queue]
                 request_hash.merge!({
                   :test_files => args.fetch(:test_files)
                 })

--- a/lib/knapsack_pro/client/api/v1/queues.rb
+++ b/lib/knapsack_pro/client/api/v1/queues.rb
@@ -3,6 +3,8 @@ module KnapsackPro
     module API
       module V1
         class Queues < Base
+          CODE_ATTEMPT_CONNECT_TO_QUEUE_FAILED = 'ATTEMPT_CONNECT_TO_QUEUE_FAILED'
+
           class << self
             def queue(args)
               request_hash = {

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -25,6 +25,11 @@ module KnapsackPro
         !!(response_body && (response_body['errors'] || response_body['error']))
       end
 
+      def error_code
+        return unless response_body
+        response_body['error_code']
+      end
+
       def server_error?
         status = http_response.code.to_i
         status >= 500 && status < 600

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -25,9 +25,9 @@ module KnapsackPro
         !!(response_body && (response_body['errors'] || response_body['error']))
       end
 
-      def error_code
+      def api_code
         return unless response_body
-        response_body['error_code']
+        response_body['code']
       end
 
       def server_error?

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -15,7 +15,9 @@ module KnapsackPro
       connection = KnapsackPro::Client::Connection.new(action)
       response = connection.call
 
+      # when attempt to connect to existing queue on API side failed because queue does not exist yet
       if can_initialize_queue && connection.success? && connection.api_code == KnapsackPro::Client::API::V1::Queues::CODE_ATTEMPT_CONNECT_TO_QUEUE_FAILED
+        # make attempt to initalize a new queue on API side
         action = build_action(can_initialize_queue, attempt_connect_to_queue: false)
         connection = KnapsackPro::Client::Connection.new(action)
         response = connection.call

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -2,7 +2,7 @@ module KnapsackPro
   class QueueAllocator
     def initialize(args)
       @lazy_fast_and_slow_test_files_to_run = args.fetch(:lazy_fast_and_slow_test_files_to_run)
-      @fallback_mode_test_files = args.fetch(:fallback_mode_test_files)
+      @lazy_fallback_mode_test_files = args.fetch(:lazy_fallback_mode_test_files)
       @ci_node_total = args.fetch(:ci_node_total)
       @ci_node_index = args.fetch(:ci_node_index)
       @ci_node_build_id = args.fetch(:ci_node_build_id)
@@ -47,7 +47,7 @@ module KnapsackPro
     private
 
     attr_reader :lazy_fast_and_slow_test_files_to_run,
-      :fallback_mode_test_files,
+      :lazy_fallback_mode_test_files,
       :ci_node_total,
       :ci_node_index,
       :ci_node_build_id,
@@ -97,7 +97,7 @@ module KnapsackPro
     end
 
     def fallback_test_files(executed_test_files)
-      test_flat_distributor = KnapsackPro::TestFlatDistributor.new(fallback_mode_test_files, ci_node_total)
+      test_flat_distributor = KnapsackPro::TestFlatDistributor.new(lazy_fallback_mode_test_files.call, ci_node_total)
       test_files_for_node_index = test_flat_distributor.test_files_for_node(ci_node_index)
       KnapsackPro::TestFilePresenter.paths(test_files_for_node_index) - executed_test_files
     end

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -53,7 +53,7 @@ module KnapsackPro
       :ci_node_build_id,
       :repository_adapter
 
-    # This method might be slow because reads test files from disk.
+    # This method might be slow because it reads test files from disk.
     # This method can be very slow (a few seconds or more) when you use RSpec split by test examples feature because RSpec needs to generate JSON report with test examples ids
     def lazy_loaded_fast_and_slow_test_files_to_run
       @lazy_loaded_fast_and_slow_test_files_to_run ||= lazy_fast_and_slow_test_files_to_run.call

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -15,7 +15,7 @@ module KnapsackPro
       connection = KnapsackPro::Client::Connection.new(action)
       response = connection.call
 
-      if can_initialize_queue && connection.success? && connection.error_code == 'attempt_connect_to_queue_failed'
+      if can_initialize_queue && connection.success? && connection.api_code == KnapsackPro::Client::API::V1::Queues::CODE_ATTEMPT_CONNECT_TO_QUEUE_FAILED
         action = build_action(can_initialize_queue, attempt_connect_to_queue: false)
         connection = KnapsackPro::Client::Connection.new(action)
         response = connection.call

--- a/lib/knapsack_pro/queue_allocator_builder.rb
+++ b/lib/knapsack_pro/queue_allocator_builder.rb
@@ -2,7 +2,7 @@ module KnapsackPro
   class QueueAllocatorBuilder < BaseAllocatorBuilder
     def allocator
       KnapsackPro::QueueAllocator.new(
-        fast_and_slow_test_files_to_run: fast_and_slow_test_files_to_run,
+        lazy_fast_and_slow_test_files_to_run: lazy_fast_and_slow_test_files_to_run,
         fallback_mode_test_files: fallback_mode_test_files,
         ci_node_total: env.ci_node_total,
         ci_node_index: env.ci_node_index,

--- a/lib/knapsack_pro/queue_allocator_builder.rb
+++ b/lib/knapsack_pro/queue_allocator_builder.rb
@@ -3,7 +3,7 @@ module KnapsackPro
     def allocator
       KnapsackPro::QueueAllocator.new(
         lazy_fast_and_slow_test_files_to_run: lazy_fast_and_slow_test_files_to_run,
-        fallback_mode_test_files: fallback_mode_test_files,
+        lazy_fallback_mode_test_files: lazy_fallback_mode_test_files,
         ci_node_total: env.ci_node_total,
         ci_node_index: env.ci_node_index,
         ci_node_build_id: env.ci_node_build_id,

--- a/spec/knapsack_pro/client/api/v1/queues_spec.rb
+++ b/spec/knapsack_pro/client/api/v1/queues_spec.rb
@@ -11,6 +11,7 @@ describe KnapsackPro::Client::API::V1::Queues do
     subject do
       described_class.queue(
         can_initialize_queue: can_initialize_queue,
+        attempt_connect_to_queue: attempt_connect_to_queue,
         commit_hash: commit_hash,
         branch: branch,
         node_total: node_total,
@@ -24,8 +25,33 @@ describe KnapsackPro::Client::API::V1::Queues do
       expect(KnapsackPro::Config::Env).to receive(:ci_node_build_id).and_return(node_build_id)
     end
 
-    context 'when can_initialize_queue=true' do
+    context 'when can_initialize_queue=true and attempt_connect_to_queue=true' do
       let(:can_initialize_queue) { true }
+      let(:attempt_connect_to_queue) { true }
+
+      it 'does not send test_files among other params' do
+        action = double
+        expect(KnapsackPro::Client::API::Action).to receive(:new).with({
+          endpoint_path: '/v1/queues/queue',
+          http_method: :post,
+          request_hash: {
+            fixed_queue_split: fixed_queue_split,
+            can_initialize_queue: can_initialize_queue,
+            attempt_connect_to_queue: attempt_connect_to_queue,
+            commit_hash: commit_hash,
+            branch: branch,
+            node_total: node_total,
+            node_index: node_index,
+            node_build_id: node_build_id,
+          }
+        }).and_return(action)
+        expect(subject).to eq action
+      end
+    end
+
+    context 'when can_initialize_queue=true and attempt_connect_to_queue=false' do
+      let(:can_initialize_queue) { true }
+      let(:attempt_connect_to_queue) { false }
 
       it 'sends test_files among other params' do
         action = double
@@ -35,6 +61,7 @@ describe KnapsackPro::Client::API::V1::Queues do
           request_hash: {
             fixed_queue_split: fixed_queue_split,
             can_initialize_queue: can_initialize_queue,
+            attempt_connect_to_queue: attempt_connect_to_queue,
             commit_hash: commit_hash,
             branch: branch,
             node_total: node_total,
@@ -47,8 +74,9 @@ describe KnapsackPro::Client::API::V1::Queues do
       end
     end
 
-    context 'when can_initialize_queue=false' do
+    context 'when can_initialize_queue=false and attempt_connect_to_queue=false' do
       let(:can_initialize_queue) { false }
+      let(:attempt_connect_to_queue) { false }
 
       it 'does not send test_files among other params' do
         action = double
@@ -58,6 +86,7 @@ describe KnapsackPro::Client::API::V1::Queues do
           request_hash: {
             fixed_queue_split: fixed_queue_split,
             can_initialize_queue: can_initialize_queue,
+            attempt_connect_to_queue: attempt_connect_to_queue,
             commit_hash: commit_hash,
             branch: branch,
             node_total: node_total,

--- a/spec/knapsack_pro/queue_allocator_builder_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_builder_spec.rb
@@ -8,11 +8,11 @@ describe KnapsackPro::QueueAllocatorBuilder do
     subject { allocator_builder.allocator }
 
     before do
-      fast_and_slow_test_files_to_run = double
-      expect(allocator_builder).to receive(:fast_and_slow_test_files_to_run).and_return(fast_and_slow_test_files_to_run)
+      lazy_fast_and_slow_test_files_to_run = double
+      expect(allocator_builder).to receive(:lazy_fast_and_slow_test_files_to_run).and_return(lazy_fast_and_slow_test_files_to_run)
 
-      fallback_mode_test_files = double
-      expect(allocator_builder).to receive(:fallback_mode_test_files).and_return(fallback_mode_test_files)
+      lazy_fallback_mode_test_files = double
+      expect(allocator_builder).to receive(:lazy_fallback_mode_test_files).and_return(lazy_fallback_mode_test_files)
 
       repository_adapter = double
       expect(KnapsackPro::RepositoryAdapterInitiator).to receive(:call).and_return(repository_adapter)
@@ -25,8 +25,8 @@ describe KnapsackPro::QueueAllocatorBuilder do
       expect(KnapsackPro::Config::Env).to receive(:ci_node_build_id).and_return(ci_node_build_id)
 
       expect(KnapsackPro::QueueAllocator).to receive(:new).with(
-        fast_and_slow_test_files_to_run: fast_and_slow_test_files_to_run,
-        fallback_mode_test_files: fallback_mode_test_files,
+        lazy_fast_and_slow_test_files_to_run: lazy_fast_and_slow_test_files_to_run,
+        lazy_fallback_mode_test_files: lazy_fallback_mode_test_files,
         ci_node_total: ci_node_total,
         ci_node_index: ci_node_index,
         ci_node_build_id: ci_node_build_id,

--- a/spec/knapsack_pro/queue_allocator_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_spec.rb
@@ -196,47 +196,49 @@ describe KnapsackPro::QueueAllocator do
               expect(KnapsackPro::Client::Connection).to receive(:new).with(action).and_return(connection)
             end
 
-
-            context 'when 2nd response has errors' do
-              let(:response2_errors?) { true }
+            context 'when successful 2nd request to API' do
               let(:response2_success?) { true }
-              let(:response2) { nil }
 
-              it do
-                expect { subject }.to raise_error(ArgumentError)
+              context 'when 2nd response has errors' do
+                let(:response2_errors?) { true }
+                let(:response2) { nil }
+
+                it do
+                  expect { subject }.to raise_error(ArgumentError)
+                end
               end
-            end
 
-            context 'when 2nd response has no errors' do
-              let(:response2_errors?) { false }
-              let(:response2_success?) { true }
+              context 'when 2nd response has no errors' do
+                let(:response2_errors?) { false }
+                let(:response2_success?) { true }
 
-              context 'when 2nd response returns test files (successful attempt to connect to queue already existing on the API side)' do
-                let(:test_files) do
-                  [
-                    { 'path' => 'a_spec.rb' },
-                    { 'path' => 'b_spec.rb' },
-                  ]
-                end
-                let(:response2) do
-                  { 'test_files' => test_files }
-                end
-
-                context 'when test files encryption is enabled' do
-                  before do
-                    expect(KnapsackPro::Config::Env).to receive(:test_files_encrypted?).and_return(true)
-                    expect(KnapsackPro::Crypto::Decryptor).to receive(:call).with(lazy_loaded_fast_and_slow_test_files_to_run, response2['test_files']).and_return(test_files)
+                context 'when 2nd response returns test files (successful attempt to connect to queue already existing on the API side)' do
+                  let(:test_files) do
+                    [
+                      { 'path' => 'a_spec.rb' },
+                      { 'path' => 'b_spec.rb' },
+                    ]
+                  end
+                  let(:response2) do
+                    { 'test_files' => test_files }
                   end
 
-                  it { should eq ['a_spec.rb', 'b_spec.rb'] }
-                end
+                  context 'when test files encryption is enabled' do
+                    before do
+                      expect(KnapsackPro::Config::Env).to receive(:test_files_encrypted?).and_return(true)
+                      expect(KnapsackPro::Crypto::Decryptor).to receive(:call).with(lazy_loaded_fast_and_slow_test_files_to_run, response2['test_files']).and_return(test_files)
+                    end
 
-                context 'when test files encryption is disabled' do
-                  before do
-                    expect(KnapsackPro::Config::Env).to receive(:test_files_encrypted?).and_return(false)
+                    it { should eq ['a_spec.rb', 'b_spec.rb'] }
                   end
 
-                  it { should eq ['a_spec.rb', 'b_spec.rb'] }
+                  context 'when test files encryption is disabled' do
+                    before do
+                      expect(KnapsackPro::Config::Env).to receive(:test_files_encrypted?).and_return(false)
+                    end
+
+                    it { should eq ['a_spec.rb', 'b_spec.rb'] }
+                  end
                 end
               end
             end

--- a/spec/knapsack_pro/queue_allocator_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_spec.rb
@@ -210,7 +210,6 @@ describe KnapsackPro::QueueAllocator do
 
               context 'when 2nd response has no errors' do
                 let(:response2_errors?) { false }
-                let(:response2_success?) { true }
 
                 context 'when 2nd response returns test files (successful attempt to connect to queue already existing on the API side)' do
                   let(:test_files) do

--- a/spec/knapsack_pro/queue_allocator_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_spec.rb
@@ -197,7 +197,7 @@ describe KnapsackPro::QueueAllocator do
             end
 
 
-            context 'when response has errors' do
+            context 'when 2nd response has errors' do
               let(:response2_errors?) { true }
               let(:response2_success?) { true }
               let(:response2) { nil }
@@ -207,11 +207,11 @@ describe KnapsackPro::QueueAllocator do
               end
             end
 
-            context 'when response has no errors' do
+            context 'when 2nd response has no errors' do
               let(:response2_errors?) { false }
               let(:response2_success?) { true }
 
-              context 'when response returns test files (successful attempt to connect to queue already existing on the API side)' do
+              context 'when 2nd response returns test files (successful attempt to connect to queue already existing on the API side)' do
                 let(:test_files) do
                   [
                     { 'path' => 'a_spec.rb' },
@@ -241,7 +241,7 @@ describe KnapsackPro::QueueAllocator do
               end
             end
 
-            context 'when not successful request to API' do
+            context 'when not successful 2nd request to API' do
               let(:response2_success?) { false }
               let(:response2_errors?) { false }
               let(:response2) { nil }


### PR DESCRIPTION
# problem

The very first request to Queue API is slow due to sending a list of test files from the disk. The bigger the test files list the slower is request. For a few thousand test files it can take 1+ second.

When a lot of requests from parallel CI nodes starting at the same time hit the Knapsack Pro API this can lead to slower performance of the API because requests with a list of test files can be slow. This leads to compound effect and degradation of API performance for very large projects using ~100+ parallel CI nodes.

When you use [RSpec split by test examples feature](https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it) then each parallel CI node must generate a JSON report with test example ids in order to prepare a list of test files that must be sent to API. This can be slow. By introducing an attempt to connect to the existing Queue on the API side we can avoid this slow operation of reading test files from disk or from JSON report for RSpec test examples.

Only the very first request (or a few concurrent requests from parallel CI nodes that hit API at the same time) will start 2nd request responsible for initializing the Queue on the API side based on a list of test files from disk (reading test files is slow operation especially for RSpec split by examples feature). 

# solution

* make attempt to connect to the existing Queue on the API side and don't' send a list of test files from the disk
* if the above attempt failed then send a list of test files from the disk to initialize a new Queue on API side

Thanks to the above we can significantly reduce the number of slow requests and make the overall API more stable.

We can also start running tests faster for most parallel CI nodes that will start work after the queue was already initialized on the API side. This reduces start time by a few seconds or even more for the large test suites that use RSpec split by test examples feature.