### PR TITLE
Fix RSpec split by test examples feature broken by lazy generating of JSON report with test example ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.10.1
+
+* Fix RSpec split by test examples feature broken by lazy generating of JSON report with test example ids
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/135
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.10.0...v2.10.1
+
 ### 2.10.0
 
 * Add support for an attempt to connect to existing Queue on API side to reduce slow requests number

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -28,10 +28,6 @@ module KnapsackPro
       all_test_files_to_run
     end
 
-    def lazy_fallback_mode_test_files
-      lambda { fallback_mode_test_files }
-    end
-
     # detect test files present on the disk that should be run
     # this may include some fast test files + slow test files split by test cases
     def fast_and_slow_test_files_to_run
@@ -65,10 +61,6 @@ module KnapsackPro
       else
         test_files_to_run
       end
-    end
-
-    def lazy_fast_and_slow_test_files_to_run
-      lambda { fast_and_slow_test_files_to_run }
     end
 
     private

--- a/lib/knapsack_pro/queue_allocator_builder.rb
+++ b/lib/knapsack_pro/queue_allocator_builder.rb
@@ -2,8 +2,8 @@ module KnapsackPro
   class QueueAllocatorBuilder < BaseAllocatorBuilder
     def allocator
       KnapsackPro::QueueAllocator.new(
-        lazy_fast_and_slow_test_files_to_run: lazy_fast_and_slow_test_files_to_run,
-        lazy_fallback_mode_test_files: lazy_fallback_mode_test_files,
+        fast_and_slow_test_files_to_run: fast_and_slow_test_files_to_run,
+        fallback_mode_test_files: fallback_mode_test_files,
         ci_node_total: env.ci_node_total,
         ci_node_index: env.ci_node_index,
         ci_node_build_id: env.ci_node_build_id,

--- a/spec/knapsack_pro/queue_allocator_builder_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_builder_spec.rb
@@ -8,11 +8,11 @@ describe KnapsackPro::QueueAllocatorBuilder do
     subject { allocator_builder.allocator }
 
     before do
-      lazy_fast_and_slow_test_files_to_run = double
-      expect(allocator_builder).to receive(:lazy_fast_and_slow_test_files_to_run).and_return(lazy_fast_and_slow_test_files_to_run)
+      fast_and_slow_test_files_to_run = double
+      expect(allocator_builder).to receive(:fast_and_slow_test_files_to_run).and_return(fast_and_slow_test_files_to_run)
 
-      lazy_fallback_mode_test_files = double
-      expect(allocator_builder).to receive(:lazy_fallback_mode_test_files).and_return(lazy_fallback_mode_test_files)
+      fallback_mode_test_files = double
+      expect(allocator_builder).to receive(:fallback_mode_test_files).and_return(fallback_mode_test_files)
 
       repository_adapter = double
       expect(KnapsackPro::RepositoryAdapterInitiator).to receive(:call).and_return(repository_adapter)
@@ -25,8 +25,8 @@ describe KnapsackPro::QueueAllocatorBuilder do
       expect(KnapsackPro::Config::Env).to receive(:ci_node_build_id).and_return(ci_node_build_id)
 
       expect(KnapsackPro::QueueAllocator).to receive(:new).with(
-        lazy_fast_and_slow_test_files_to_run: lazy_fast_and_slow_test_files_to_run,
-        lazy_fallback_mode_test_files: lazy_fallback_mode_test_files,
+        fast_and_slow_test_files_to_run: fast_and_slow_test_files_to_run,
+        fallback_mode_test_files: fallback_mode_test_files,
         ci_node_total: ci_node_total,
         ci_node_index: ci_node_index,
         ci_node_build_id: ci_node_build_id,


### PR DESCRIPTION
# Fix bug

remove lazy loading of test files from disk and lazy generating of RSpec split by examples JSON report because the JSON report is needed on all parallel CI nodes to run tests properly when you use [RSpec split by test examples feature](https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it).

# About the bug

The bug was revealed in this CI build
https://app.circleci.com/pipelines/github/KnapsackPro/rails-app-with-knapsack_pro/83/workflows/ccfc0b61-65ca-4e8f-87d5-4e2f0ebcda90/jobs/1377/parallel-runs/0?filterBy=ALL

When CI node did not generate JSON report with test example ids for slow test files (because it connected to existing Queue on API side) then you can't run tests. 

```
Failures:

  1) Example of slow shared examples 
     Failure/Error: raise 'Report with slow test files was not generated yet. If you have enabled split by test cases https://github.com/KnapsackPro/knapsack_pro-ruby#split-test-files-by-test-cases and you see this error it means that your tests accidentally cleaned up tmp/knapsack_pro directory. Please do not remove this directory during tests runtime!' unless File.exists?(report_path)
     
     RuntimeError:
       Report with slow test files was not generated yet. If you have enabled split by test cases https://github.com/KnapsackPro/knapsack_pro-ruby#split-test-files-by-test-cases and you see this error it means that your tests accidentally cleaned up tmp/knapsack_pro directory. Please do not remove this directory during tests runtime!
     # /home/circleci/gems/knapsack_pro-ruby/lib/knapsack_pro/slow_test_file_determiner.rb:22:in `read_from_json_report'
     # /home/circleci/gems/knapsack_pro-ruby/lib/knapsack_pro/adapters/base_adapter.rb:15:in `slow_test_file?'
     # /home/circleci/gems/knapsack_pro-ruby/lib/knapsack_pro/adapters/rspec_adapter.rb:35:in `block (2 levels) in bind_time_tracker'
     # /home/circleci/gems/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:83:in `run_tests'
     # /home/circleci/gems/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:36:in `run'
     # /home/circleci/gems/knapsack_pro-ruby/lib/tasks/queue/rspec.rake:6:in `block (3 levels) in <top (required)>'
```

# Related PR

This PR introduced bug: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/133