### PR TITLE
Use 0 seconds as a default test file time execution instead of 0.1s because Knapsack Pro API already accepts 0 seconds value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.12.0
+
+* Use 0 seconds as a default test file time execution instead of 0.1s because Knapsack Pro API already accepts 0 seconds value
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/140
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.11.0...v2.12.0
+
 ### 2.11.0
 
 * Verify test runner adapter bind method is called to track test files time execution and ensure `tmp/knapsack_pro` directory is not removed accidentally

--- a/README.md
+++ b/README.md
@@ -2065,20 +2065,7 @@ If you go to [user dashboard](https://knapsackpro.com/dashboard) and open `Build
 
 ##### Why all test files have 0.1s time execution for my CI build in user dashboard?
 
-If you go to [user dashboard](https://knapsackpro.com/dashboard) and open `Build metrics` for your API token and you open CI build for your last git commit you should see there info about collected time execution data from all CI nodes. If you see all test files have 0.1s time execution then please ensure:
-
-* you should not clean up `tmp` directory in your tests (for instance in RSpec hooks like `before` or `after`) so knapsack_pro can publish measured time execution data to Knapsack Pro API server. knapsack_pro Queue Mode saves temporary files with collected time execution data in `your_rails_project/tmp/knapsack_pro/queue/`.
-* please ensure you have in your `rails_helper.rb` or `spec_helper.rb` line that allows to measure tests:
-
-```ruby
-require 'knapsack_pro'
-
-# CUSTOM_CONFIG_GOES_HERE
-
-KnapsackPro::Adapters::RSpecAdapter.bind
-```
-
-The 0.1s is a default time execution used when test file is an empty file or its content are all pending tests.
+https://knapsackpro.com/faq/question/why-all-test-files-have-01s-time-execution-for-my-ci-build-in-user-dashboard
 
 ##### Why when I use Queue Mode for RSpec and test fails then I see multiple times info about failed test in RSpec result?
 

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -4,7 +4,7 @@ module KnapsackPro
 
     # when test file is pending, empty with no tests or has syntax error then assume time execution
     # to better allocate it in Queue Mode for future CI build runs
-    DEFAULT_TEST_FILE_TIME = 0.1 # seconds
+    DEFAULT_TEST_FILE_TIME = 0.0 # seconds
 
     attr_reader :global_time_since_beginning, :global_time, :test_files_with_time
     attr_writer :current_test_path


### PR DESCRIPTION
There is no need to keep this workaround with a fake default test file execution time 0.1s for test files that were not executed on CI because API already allows saving test files with 0 seconds.

# related old PR

https://github.com/KnapsackPro/knapsack_pro-ruby/pull/71