### PR TITLE
Use Ruby 3 in development and add small improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     parallelism: 1
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.7.0
+      - image: circleci/ruby:3.0.1
         environment:
           CODECLIMATE_REPO_TOKEN: b6626e682a8e97e0c5978febc92c3526792a2d018b41b8e1b52689da37fb7d92
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.17.0
+
+* Use Ruby 3 in development and add small improvements
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/147
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.16.0...v2.17.0
+
 ### 2.16.0
 
 * Improve test time execution tracking for RSpec

--- a/knapsack_pro.gemspec
+++ b/knapsack_pro.gemspec
@@ -29,14 +29,14 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'rspec', '~> 3.0', '>= 2.10.0'
-  spec.add_development_dependency 'rspec-its', '~> 1.2'
+  spec.add_development_dependency 'rspec-its', '~> 1.3'
   spec.add_development_dependency 'cucumber', '>= 0'
   spec.add_development_dependency 'spinach', '>= 0.8'
   spec.add_development_dependency 'minitest', '>= 5.0.0'
   spec.add_development_dependency 'test-unit', '>= 3.0.0'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0'
   spec.add_development_dependency 'pry', '~> 0'
-  spec.add_development_dependency 'vcr', '~> 2.9'
-  spec.add_development_dependency 'webmock', '~> 1.21'
-  spec.add_development_dependency 'timecop', '>= 0.1.0'
+  spec.add_development_dependency 'vcr', '>= 6.0'
+  spec.add_development_dependency 'webmock', '>= 3.13'
+  spec.add_development_dependency 'timecop', '>= 0.9.4'
 end

--- a/knapsack_pro.gemspec
+++ b/knapsack_pro.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'spinach', '>= 0.8'
   spec.add_development_dependency 'minitest', '>= 5.0.0'
   spec.add_development_dependency 'test-unit', '>= 3.0.0'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 0'
   spec.add_development_dependency 'pry', '~> 0'
   spec.add_development_dependency 'vcr', '>= 6.0'
   spec.add_development_dependency 'webmock', '>= 3.13'

--- a/lib/knapsack_pro/config/ci/circle.rb
+++ b/lib/knapsack_pro/config/ci/circle.rb
@@ -23,8 +23,7 @@ module KnapsackPro
         end
 
         def project_dir
-          working_dir = ENV['CIRCLE_WORKING_DIRECTORY']
-          return working_dir if working_dir
+          ENV['CIRCLE_WORKING_DIRECTORY']
         end
       end
     end

--- a/lib/knapsack_pro/config/ci/circle.rb
+++ b/lib/knapsack_pro/config/ci/circle.rb
@@ -23,6 +23,9 @@ module KnapsackPro
         end
 
         def project_dir
+          working_dir = ENV['CIRCLE_WORKING_DIRECTORY']
+          return working_dir if working_dir
+
           project_repo_name = ENV['CIRCLE_PROJECT_REPONAME']
           "/home/ubuntu/#{project_repo_name}" if project_repo_name
         end

--- a/lib/knapsack_pro/config/ci/circle.rb
+++ b/lib/knapsack_pro/config/ci/circle.rb
@@ -25,9 +25,6 @@ module KnapsackPro
         def project_dir
           working_dir = ENV['CIRCLE_WORKING_DIRECTORY']
           return working_dir if working_dir
-
-          project_repo_name = ENV['CIRCLE_PROJECT_REPONAME']
-          "/home/ubuntu/#{project_repo_name}" if project_repo_name
         end
       end
     end

--- a/lib/knapsack_pro/repository_adapters/git_adapter.rb
+++ b/lib/knapsack_pro/repository_adapters/git_adapter.rb
@@ -18,12 +18,7 @@ module KnapsackPro
 
       def working_dir
         dir = KnapsackPro::Config::Env.project_dir
-
-        if dir.to_s.include?('~')
-          File.expand_path(dir)
-        else
-          dir
-        end
+        File.expand_path(dir)
       end
     end
   end

--- a/lib/knapsack_pro/repository_adapters/git_adapter.rb
+++ b/lib/knapsack_pro/repository_adapters/git_adapter.rb
@@ -17,7 +17,13 @@ module KnapsackPro
       private
 
       def working_dir
-        KnapsackPro::Config::Env.project_dir
+        dir = KnapsackPro::Config::Env.project_dir
+
+        if dir.to_s.include?('~')
+          File.expand_path(dir)
+        else
+          dir
+        end
       end
     end
   end

--- a/lib/knapsack_pro/runners/base_runner.rb
+++ b/lib/knapsack_pro/runners/base_runner.rb
@@ -35,6 +35,10 @@ module KnapsackPro
 
       attr_reader :allocator_builder,
         :allocator
+
+      def self.child_status
+        $?
+      end
     end
   end
 end

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -29,6 +29,10 @@ module KnapsackPro
 
         attr_reader :allocator_builder,
           :allocator
+
+        def self.child_status
+          $?
+        end
       end
     end
   end

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -95,16 +95,14 @@ module KnapsackPro
           # which is defined in lib/knapsack_pro/adapters/cucumber_adapter.rb
           ENV['KNAPSACK_PRO_BEFORE_QUEUE_HOOK_CALLED'] = 'true'
 
-          process_status = $?
-
-          unless process_status.exited?
+          unless child_status.exited?
             raise "Cucumber process execution failed. It's likely that your CI server has exceeded"\
                     " its available memory. Please try changing CI config or retrying the CI build.\n"\
                     "Failed command: #{cmd}\n"\
-                    "Process status: #{process_status.inspect}"
+                    "Process status: #{child_status.inspect}"
           end
 
-          process_status.exitstatus
+          child_status.exitstatus
         end
       end
     end

--- a/lib/knapsack_pro/runners/spinach_runner.rb
+++ b/lib/knapsack_pro/runners/spinach_runner.rb
@@ -13,7 +13,7 @@ module KnapsackPro
           cmd = %Q[KNAPSACK_PRO_RECORDING_ENABLED=true KNAPSACK_PRO_TEST_SUITE_TOKEN=#{ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN']} bundle exec spinach #{args} --features_path #{runner.test_dir} -- #{runner.stringify_test_file_paths}]
 
           Kernel.system(cmd)
-          Kernel.exit($?.exitstatus) unless $?.exitstatus.zero?
+          Kernel.exit(child_status.exitstatus) unless child_status.exitstatus.zero?
         end
       end
     end

--- a/lib/knapsack_pro/runners/test_unit_runner.rb
+++ b/lib/knapsack_pro/runners/test_unit_runner.rb
@@ -11,20 +11,31 @@ module KnapsackPro
         if runner.test_files_to_execute_exist?
           adapter_class.verify_bind_method_called
 
-          require 'test/unit'
-
           cli_args =
             (args || '').split +
             runner.test_file_paths.map do |f|
               File.expand_path(f)
             end
 
-          exit ::Test::Unit::AutoRunner.run(
+          exit test_unit_autorunner_run(
             true,
             runner.test_dir,
             cli_args
           )
         end
+      end
+
+      private
+
+      # https://www.rubydoc.info/github/test-unit/test-unit/Test/Unit/AutoRunner#run-class_method
+      def self.test_unit_autorunner_run(force_standalone, default_dir, argv)
+        require 'test/unit'
+
+        ::Test::Unit::AutoRunner.run(
+          force_standalone,
+          default_dir,
+          argv
+        )
       end
     end
   end

--- a/spec/knapsack_pro/adapters/test_unit_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/test_unit_adapter_spec.rb
@@ -1,6 +1,6 @@
-require 'test/unit/testcase'
+#require 'test/unit/testcase'
 
-describe KnapsackPro::Adapters::TestUnitAdapter do
+xdescribe KnapsackPro::Adapters::TestUnitAdapter do
   it do
     expect(described_class::TEST_DIR_PATTERN).to eq 'test/**{,/*/**}/*_test.rb'
   end

--- a/spec/knapsack_pro/adapters/test_unit_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/test_unit_adapter_spec.rb
@@ -1,6 +1,13 @@
-#require 'test/unit/testcase'
+# fake class to make tests pass and to avoid require 'test/unit/testcase' to not break RSpec
+# https://www.rubydoc.info/gems/test-unit/3.4.1/Test/Unit/TestSuite
+module Test
+  module Unit
+    class TestSuite
+    end
+  end
+end
 
-xdescribe KnapsackPro::Adapters::TestUnitAdapter do
+describe KnapsackPro::Adapters::TestUnitAdapter do
   it do
     expect(described_class::TEST_DIR_PATTERN).to eq 'test/**{,/*/**}/*_test.rb'
   end

--- a/spec/knapsack_pro/config/ci/circle_spec.rb
+++ b/spec/knapsack_pro/config/ci/circle_spec.rb
@@ -75,9 +75,9 @@ describe KnapsackPro::Config::CI::Circle do
   describe '#project_dir' do
     subject { described_class.new.project_dir }
 
-    context 'when environment exists' do
-      let(:env) { { 'CIRCLE_PROJECT_REPONAME' => 'knapsack_pro-ruby' } }
-      it { should eql '/home/ubuntu/knapsack_pro-ruby' }
+    context 'when CIRCLE_WORKING_DIRECTORY environment variable exists' do
+      let(:env) { { 'CIRCLE_WORKING_DIRECTORY' => '~/knapsack_pro-ruby' } }
+      it { should eql '~/knapsack_pro-ruby' }
     end
 
     context "when environment doesn't exist" do

--- a/spec/knapsack_pro/repository_adapters/git_adapter_spec.rb
+++ b/spec/knapsack_pro/repository_adapters/git_adapter_spec.rb
@@ -15,20 +15,20 @@ describe KnapsackPro::RepositoryAdapters::GitAdapter do
 
     it { should_not be_nil }
     its(:size) { should eq 40 }
-    it { should eq circle_sha1 } if ENV['CIRCLE_SHA1']
+    it { should eq circle_sha1 } if ENV['CIRCLECI']
   end
 
   describe '#branch' do
     subject { described_class.new.branch }
 
     it { should_not be_nil }
-    it { should eq circle_branch } if ENV['CIRCLE_BRANCH']
+    it { should eq circle_branch } if ENV['CIRCLECI']
   end
 
   describe '#branches' do
     subject { described_class.new.branches }
 
     it { expect(subject.include?('master')).to be true }
-    it { expect(subject.include?(circle_branch)).to be true } if ENV['CIRCLE_BRANCH']
+    it { expect(subject.include?(circle_branch)).to be true } if ENV['CIRCLECI']
   end
 end

--- a/spec/knapsack_pro/repository_adapters/git_adapter_spec.rb
+++ b/spec/knapsack_pro/repository_adapters/git_adapter_spec.rb
@@ -2,33 +2,54 @@ describe KnapsackPro::RepositoryAdapters::GitAdapter do
   let!(:circle_sha1) { ENV['CIRCLE_SHA1'] }
   let!(:circle_branch) { ENV['CIRCLE_BRANCH'] }
 
-  before do
-    stub_const('ENV', {
-      'KNAPSACK_PRO_PROJECT_DIR' => KnapsackPro.root,
-    })
-  end
-
   it { should be_kind_of KnapsackPro::RepositoryAdapters::BaseAdapter }
 
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    it { should_not be_nil }
-    its(:size) { should eq 40 }
+    context do
+      before do
+        stub_const('ENV', {
+          'KNAPSACK_PRO_PROJECT_DIR' => KnapsackPro.root,
+        })
+      end
+
+      it { should_not be_nil }
+      its(:size) { should eq 40 }
+    end
+
     it { should eq circle_sha1 } if ENV['CIRCLECI']
   end
 
   describe '#branch' do
     subject { described_class.new.branch }
 
-    it { should_not be_nil }
+    context do
+      before do
+        stub_const('ENV', {
+          'KNAPSACK_PRO_PROJECT_DIR' => KnapsackPro.root,
+        })
+      end
+
+      it { should_not be_nil }
+    end
+
     it { should eq circle_branch } if ENV['CIRCLECI']
   end
 
   describe '#branches' do
     subject { described_class.new.branches }
 
-    it { expect(subject.include?('master')).to be true }
+    context do
+      before do
+        stub_const('ENV', {
+          'KNAPSACK_PRO_PROJECT_DIR' => KnapsackPro.root,
+        })
+      end
+
+      it { expect(subject.include?('master')).to be true }
+    end
+
     it { expect(subject.include?(circle_branch)).to be true } if ENV['CIRCLECI']
   end
 end

--- a/spec/knapsack_pro/repository_adapters/git_adapter_spec.rb
+++ b/spec/knapsack_pro/repository_adapters/git_adapter_spec.rb
@@ -2,54 +2,33 @@ describe KnapsackPro::RepositoryAdapters::GitAdapter do
   let!(:circle_sha1) { ENV['CIRCLE_SHA1'] }
   let!(:circle_branch) { ENV['CIRCLE_BRANCH'] }
 
+  before do
+    stub_const('ENV', {
+      'KNAPSACK_PRO_PROJECT_DIR' => KnapsackPro.root,
+    })
+  end
+
   it { should be_kind_of KnapsackPro::RepositoryAdapters::BaseAdapter }
 
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context do
-      before do
-        stub_const('ENV', {
-          'KNAPSACK_PRO_PROJECT_DIR' => KnapsackPro.root,
-        })
-      end
-
-      it { should_not be_nil }
-      its(:size) { should eq 40 }
-    end
-
+    it { should_not be_nil }
+    its(:size) { should eq 40 }
     it { should eq circle_sha1 } if ENV['CIRCLECI']
   end
 
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context do
-      before do
-        stub_const('ENV', {
-          'KNAPSACK_PRO_PROJECT_DIR' => KnapsackPro.root,
-        })
-      end
-
-      it { should_not be_nil }
-    end
-
+    it { should_not be_nil }
     it { should eq circle_branch } if ENV['CIRCLECI']
   end
 
   describe '#branches' do
     subject { described_class.new.branches }
 
-    context do
-      before do
-        stub_const('ENV', {
-          'KNAPSACK_PRO_PROJECT_DIR' => KnapsackPro.root,
-        })
-      end
-
-      it { expect(subject.include?('master')).to be true }
-    end
-
+    it { expect(subject.include?('master')).to be true }
     it { expect(subject.include?(circle_branch)).to be true } if ENV['CIRCLECI']
   end
 end

--- a/spec/knapsack_pro/runners/queue/cucumber_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/cucumber_runner_spec.rb
@@ -100,6 +100,7 @@ describe KnapsackPro::Runners::Queue::CucumberRunner do
 
     context 'when test files exist' do
       let(:test_file_paths) { ['features/a.feature', 'features/b.feature'] }
+      let(:child_status) { double }
 
       before do
         subset_queue_id = 'fake-subset-queue-id'
@@ -117,8 +118,9 @@ describe KnapsackPro::Runners::Queue::CucumberRunner do
 
         expect(ENV).to receive(:[]=).with('KNAPSACK_PRO_BEFORE_QUEUE_HOOK_CALLED', 'true')
 
-        expect($?).to receive(:exited?).and_return(process_exited)
-        allow($?).to receive(:exitstatus).and_return(exitstatus)
+        allow(described_class).to receive(:child_status).and_return(child_status)
+        expect(child_status).to receive(:exited?).and_return(process_exited)
+        allow(child_status).to receive(:exitstatus).and_return(exitstatus)
       end
 
       context 'when system process finished its work (exited)' do

--- a/spec/knapsack_pro/runners/spinach_runner_spec.rb
+++ b/spec/knapsack_pro/runners/spinach_runner_spec.rb
@@ -24,11 +24,14 @@ describe KnapsackPro::Runners::SpinachRunner do
                         stringify_test_file_paths: stringify_test_file_paths,
                         test_files_to_execute_exist?: true)
       end
+      let(:child_status) { double }
 
       before do
         expect(KnapsackPro::Adapters::SpinachAdapter).to receive(:verify_bind_method_called)
 
         expect(Kernel).to receive(:system).with('KNAPSACK_PRO_RECORDING_ENABLED=true KNAPSACK_PRO_TEST_SUITE_TOKEN=spinach-token bundle exec spinach --custom-arg --features_path fake-test-dir -- features/a.feature features/b.feature')
+
+        allow(described_class).to receive(:child_status).and_return(child_status)
       end
 
       after { subject }
@@ -37,7 +40,7 @@ describe KnapsackPro::Runners::SpinachRunner do
         let(:exitstatus) { 0 }
 
         before do
-          expect($?).to receive(:exitstatus).and_return(exitstatus)
+          expect(child_status).to receive(:exitstatus).and_return(exitstatus)
         end
 
         it do
@@ -49,7 +52,7 @@ describe KnapsackPro::Runners::SpinachRunner do
         let(:exitstatus) { 1 }
 
         before do
-          expect($?).to receive(:exitstatus).twice.and_return(exitstatus)
+          expect(child_status).to receive(:exitstatus).twice.and_return(exitstatus)
         end
 
         it do

--- a/spec/knapsack_pro/runners/test_unit_runner_spec.rb
+++ b/spec/knapsack_pro/runners/test_unit_runner_spec.rb
@@ -1,6 +1,6 @@
-require 'test/unit'
+#require 'test/unit'
 
-describe KnapsackPro::Runners::TestUnitRunner do
+xdescribe KnapsackPro::Runners::TestUnitRunner do
   subject { described_class.new(KnapsackPro::Adapters::TestUnitAdapter) }
 
   it { should be_kind_of KnapsackPro::Runners::BaseRunner }

--- a/spec/knapsack_pro/runners/test_unit_runner_spec.rb
+++ b/spec/knapsack_pro/runners/test_unit_runner_spec.rb
@@ -1,6 +1,4 @@
-#require 'test/unit'
-
-xdescribe KnapsackPro::Runners::TestUnitRunner do
+describe KnapsackPro::Runners::TestUnitRunner do
   subject { described_class.new(KnapsackPro::Adapters::TestUnitAdapter) }
 
   it { should be_kind_of KnapsackPro::Runners::BaseRunner }
@@ -27,7 +25,7 @@ xdescribe KnapsackPro::Runners::TestUnitRunner do
         .with(KnapsackPro::Adapters::TestUnitAdapter).and_return(runner)
 
         auto_runner_exit_code = 0
-        expect(Test::Unit::AutoRunner).to receive(:run) do |flag, test_dir, cli_args|
+        expect(described_class).to receive(:test_unit_autorunner_run) do |flag, test_dir, cli_args|
           expect(flag).to be true
           expect(test_dir).to eq 'test-unit_fake'
           expect(cli_args.size).to eq 4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,6 @@ require 'spinach'
 require 'timecop'
 Timecop.safe_mode = true
 
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 require 'vcr'
 require 'webmock/rspec'
 VCR.configure do |config|


### PR DESCRIPTION
* adjust test suite to work with Ruby 3
* update development dependencies
* remove deprecated codeclimate gem
* add support for CirleCI `CIRCLE_WORKING_DIRECTORY` env var 
* remove support for detecting project dir for CircleCI 1.0 because it's not longer supported
```
Starting Mar 15, 2019:

All projects will require a CircleCI 2.0 configuration.
CircleCI 1.0 jobs will be viewable but will no longer run.
https://circleci.com/sunset1-0/eol-policy/
```
* add support for project directory with `~` in path


# development tips

If you clone this project in development please remove your local copy of `Gemfile.lock` (it is ignored in `.gitignore`) and then run:

* rvm get stable
* rvm install ruby-3.0.1
* bundle install # this will generate a new `Gemfile.lock` with the latest gems as listed in `knapsack_pro.gemspec`