### PR TITLE
Do not allow to use the RSpec tag option together with the RSpec split by test examples feature in knapsack_pro gem in Regular Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.18.0
+
+* Do not allow to use the RSpec tag option together with the RSpec split by test examples feature in knapsack_pro gem in Regular Mode 
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/148
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.17.0...v2.18.0
+
 ### 2.17.0
 
 * Use Ruby 3 in development and add small improvements

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -3,6 +3,27 @@ module KnapsackPro
     class RSpecAdapter < BaseAdapter
       TEST_DIR_PATTERN = 'spec/**{,/*/**}/*_spec.rb'
 
+      def self.ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!(cli_args)
+        if KnapsackPro::Config::Env.rspec_split_by_test_examples? && has_tag_option?(cli_args)
+          error_message = 'It is not allowed to use the RSpec tag option together with the RSpec split by test examples feature. Please see: https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it#warning-dont-use-rspec-tag-option'
+          KnapsackPro.logger.error(error_message)
+          raise error_message
+        end
+      end
+
+      def self.has_tag_option?(cli_args)
+        # use start_with? because user can define tag option in a few ways:
+        # -t mytag
+        # -tmytag
+        # --tag mytag
+        # --tag=mytag
+        cli_args.any? { |arg| arg.start_with?('-t') || arg.start_with?('--tag') }
+      end
+
+      def self.has_format_option?(cli_args)
+        cli_args.any? { |arg| arg.start_with?('-f') || arg.start_with?('--format') }
+      end
+
       def self.test_path(example_group)
         if defined?(::Turnip) && ::Turnip::VERSION.to_i < 2
           unless example_group[:turnip]

--- a/lib/knapsack_pro/runners/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/rspec_runner.rb
@@ -11,6 +11,9 @@ module KnapsackPro
         if runner.test_files_to_execute_exist?
           adapter_class.verify_bind_method_called
 
+          cli_args = (args || '').split
+          adapter_class.ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!(cli_args)
+
           require 'rspec/core/rake_task'
 
           task_name = 'knapsack_pro:rspec_run'

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -12,6 +12,48 @@ describe KnapsackPro::Adapters::RSpecAdapter do
     it_behaves_like 'adapter'
   end
 
+  describe '.ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!' do
+    let(:cli_args) { double }
+
+    subject { described_class.ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!(cli_args) }
+
+    before do
+      expect(KnapsackPro::Config::Env).to receive(:rspec_split_by_test_examples?).and_return(rspec_split_by_test_examples_enabled)
+    end
+
+    context 'when RSpec split by test examples enabled' do
+      let(:rspec_split_by_test_examples_enabled) { true }
+
+      before do
+        expect(described_class).to receive(:has_tag_option?).with(cli_args).and_return(has_tag_option)
+      end
+
+      context 'when RSpec tag option is provided' do
+        let(:has_tag_option) { true }
+
+        it do
+          expect { subject }.to raise_error(/It is not allowed to use the RSpec tag option together with the RSpec split by test examples feature/)
+        end
+      end
+
+      context 'when RSpec tag option is not provided' do
+        let(:has_tag_option) { false }
+
+        it 'does nothing' do
+          expect(subject).to be_nil
+        end
+      end
+    end
+
+    context 'when RSpec split by test examples disabled' do
+      let(:rspec_split_by_test_examples_enabled) { false }
+
+      it 'does nothing' do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
   describe '.has_tag_option?' do
     subject { described_class.has_tag_option?(cli_args) }
 

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -12,6 +12,62 @@ describe KnapsackPro::Adapters::RSpecAdapter do
     it_behaves_like 'adapter'
   end
 
+  describe '.has_tag_option?' do
+    subject { described_class.has_tag_option?(cli_args) }
+
+    context 'when tag option is provided as -t' do
+      let(:cli_args) { ['-t', 'mytag'] }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when tag option is provided as --tag' do
+      let(:cli_args) { ['--tag', 'mytag'] }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when tag option is provided without delimiter' do
+      let(:cli_args) { ['-tmytag'] }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when tag option is not provided' do
+      let(:cli_args) { ['--fake', 'value'] }
+
+      it { expect(subject).to be false }
+    end
+  end
+
+  describe '.has_format_option?' do
+    subject { described_class.has_format_option?(cli_args) }
+
+    context 'when format option is provided as -f' do
+      let(:cli_args) { ['-f', 'documentation'] }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when format option is provided as --format' do
+      let(:cli_args) { ['--format', 'documentation'] }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when format option is provided without delimiter' do
+      let(:cli_args) { ['-fd'] }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when format option is not provided' do
+      let(:cli_args) { ['--fake', 'value'] }
+
+      it { expect(subject).to be false }
+    end
+  end
+
   describe '.test_path' do
     let(:current_example_metadata) do
       {

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -133,26 +133,11 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
       context 'when RSpec split by test examples feature is enabled' do
         before do
           expect(KnapsackPro::Config::Env).to receive(:rspec_split_by_test_examples?).and_return(true)
+          expect(KnapsackPro::Adapters::RSpecAdapter).to receive(:ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!).and_call_original
         end
 
-        context 'when tag option is provided as --tag' do
+        context 'when tag option is provided' do
           let(:args) { '--tag example-value' }
-
-          it do
-            expect { subject }.to raise_error(/It is not allowed to use the RSpec tag option together with the RSpec split by test examples feature/)
-          end
-        end
-
-        context 'when tag option is provided as -t' do
-          let(:args) { '-t example-value' }
-
-          it do
-            expect { subject }.to raise_error(/It is not allowed to use the RSpec tag option together with the RSpec split by test examples feature/)
-          end
-        end
-
-        context 'when tag option is provided without delimiter' do
-          let(:args) { '-texample-value' }
 
           it do
             expect { subject }.to raise_error(/It is not allowed to use the RSpec tag option together with the RSpec split by test examples feature/)

--- a/spec/knapsack_pro/runners/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/rspec_runner_spec.rb
@@ -44,7 +44,7 @@ describe KnapsackPro::Runners::RSpecRunner do
         expect(t).to receive(:pattern=).with([])
       end
 
-      context 'when task already exists' do
+      context 'when rake task already exists' do
         before do
           expect(Rake::Task).to receive(:task_defined?).with('knapsack_pro:rspec_run').and_return(true)
           expect(task).to receive(:clear)
@@ -57,7 +57,7 @@ describe KnapsackPro::Runners::RSpecRunner do
         end
       end
 
-      context "when task doesn't exist" do
+      context "when rake task doesn't exist" do
         before do
           expect(Rake::Task).to receive(:task_defined?).with('knapsack_pro:rspec_run').and_return(false)
           expect(task).not_to receive(:clear)

--- a/spec/knapsack_pro/runners/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/rspec_runner_spec.rb
@@ -34,7 +34,8 @@ describe KnapsackPro::Runners::RSpecRunner do
       let(:task) { double }
 
       before do
-        expect(KnapsackPro::Adapters::RSpecAdapter).to receive(:verify_bind_method_called)
+        expect(KnapsackPro::Adapters::RSpecAdapter).to receive(:verify_bind_method_called).ordered
+        expect(KnapsackPro::Adapters::RSpecAdapter).to receive(:ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!).with(['--profile', '--color']).ordered
 
         expect(Rake::Task).to receive(:[]).with('knapsack_pro:rspec_run').at_least(1).and_return(task)
 


### PR DESCRIPTION
Why don't allow to use RSpec tag option with [RSpec split by test examples feature](https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it)?
https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it#warning-dont-use-rspec-tag-option

If you do it and you use at the same time `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true` then `--tag` option might not be respected by RSpec due to [a bug in the RSpec](https://github.com/rspec/rspec-core/issues/2522). RSpec has a higher priority to run test examples like `spec/a_spec.rb[1:1]` than respect the `--tag` option. This can result in running test cases that you didn't intend to run.

# solution

We raise an exception when the user uses RSpec tag option at the same time with RSpec split by test examples feature to warn him. 

# related

We already implemented such an exception for Queue Mode in https://github.com/KnapsackPro/knapsack_pro-ruby/pull/139