### PR TITLE
Ensure RSpec is loaded to check its version for RSpec split by test examples feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.18.1
+
+* Ensure RSpec is loaded to check its version for RSpec split by test examples feature
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/151
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.18.0...v2.18.1
+
 ### 2.18.0
 
 * Do not allow to use the RSpec tag option together with the RSpec split by test examples feature in knapsack_pro gem in Regular Mode 

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -34,6 +34,7 @@ module KnapsackPro
       test_files_to_run = all_test_files_to_run
 
       if adapter_class == KnapsackPro::Adapters::RSpecAdapter && KnapsackPro::Config::Env.rspec_split_by_test_examples?
+        require 'rspec/core/version'
         unless Gem::Version.new(::RSpec::Core::Version::STRING) >= Gem::Version.new('3.3.0')
           raise 'RSpec >= 3.3.0 is required to split test files by test examples. Learn more: https://github.com/KnapsackPro/knapsack_pro-ruby#split-test-files-by-test-cases'
         end


### PR DESCRIPTION
# related issue
https://github.com/KnapsackPro/knapsack_pro-ruby/issues/150

# info
I decided to use `require 'rspec/core/version'` instead of `Gem.loaded_specs["rspec-core"].version` because `require` would give us a more explicit error when RSpec gem can't be loaded (for instance it is not present in proper Gemfile group).