### PR TITLE
Track all test files assigned to a CI node in Regular Mode including pending test files in order to retry proper set of tests on the retried CI node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 2.18.2
+
+* Track all test files assigned to a CI node in Regular Mode including pending test files in order to retry proper set of tests on the retried CI node
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/152
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.18.1...v2.18.2
+
 ### 2.18.1
 
 * Ensure RSpec is loaded to check its version for RSpec split by test examples feature

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -257,6 +257,14 @@ module KnapsackPro
           ENV['KNAPSACK_PRO_LOG_DIR']
         end
 
+        def test_runner_adapter
+          ENV['KNAPSACK_PRO_TEST_RUNNER_ADAPTER']
+        end
+
+        def set_test_runner_adapter(adapter_class)
+          ENV['KNAPSACK_PRO_TEST_RUNNER_ADAPTER'] = adapter_class.to_s.split('::').last
+        end
+
         private
 
         def required_env(env_name)

--- a/lib/knapsack_pro/runners/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/cucumber_runner.rb
@@ -11,6 +11,8 @@ module KnapsackPro
         if runner.test_files_to_execute_exist?
           adapter_class.verify_bind_method_called
 
+          KnapsackPro.tracker.set_prerun_tests(runner.test_file_paths)
+
           require 'cucumber/rake/task'
 
           task_name = 'knapsack_pro:cucumber_run'

--- a/lib/knapsack_pro/runners/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/cucumber_runner.rb
@@ -6,6 +6,7 @@ module KnapsackPro
         ENV['KNAPSACK_PRO_RECORDING_ENABLED'] = 'true'
 
         adapter_class = KnapsackPro::Adapters::CucumberAdapter
+        KnapsackPro::Config::Env.set_test_runner_adapter(adapter_class)
         runner = new(adapter_class)
 
         if runner.test_files_to_execute_exist?

--- a/lib/knapsack_pro/runners/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/minitest_runner.rb
@@ -11,6 +11,8 @@ module KnapsackPro
         if runner.test_files_to_execute_exist?
           adapter_class.verify_bind_method_called
 
+          KnapsackPro.tracker.set_prerun_tests(runner.test_file_paths)
+
           task_name = 'knapsack_pro:minitest_run'
 
           if Rake::Task.task_defined?(task_name)

--- a/lib/knapsack_pro/runners/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/minitest_runner.rb
@@ -6,6 +6,7 @@ module KnapsackPro
         ENV['KNAPSACK_PRO_RECORDING_ENABLED'] = 'true'
 
         adapter_class = KnapsackPro::Adapters::MinitestAdapter
+        KnapsackPro::Config::Env.set_test_runner_adapter(adapter_class)
         runner = new(adapter_class)
 
         if runner.test_files_to_execute_exist?

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -9,7 +9,9 @@ module KnapsackPro
           ENV['KNAPSACK_PRO_QUEUE_RECORDING_ENABLED'] = 'true'
           ENV['KNAPSACK_PRO_QUEUE_ID'] = KnapsackPro::Config::EnvGenerator.set_queue_id
 
-          runner = new(KnapsackPro::Adapters::CucumberAdapter)
+          adapter_class = KnapsackPro::Adapters::CucumberAdapter
+          KnapsackPro::Config::Env.set_test_runner_adapter(adapter_class)
+          runner = new(adapter_class)
 
           accumulator = {
             status: :next,

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -9,7 +9,9 @@ module KnapsackPro
           ENV['KNAPSACK_PRO_QUEUE_RECORDING_ENABLED'] = 'true'
           ENV['KNAPSACK_PRO_QUEUE_ID'] = KnapsackPro::Config::EnvGenerator.set_queue_id
 
-          runner = new(KnapsackPro::Adapters::MinitestAdapter)
+          adapter_class = KnapsackPro::Adapters::MinitestAdapter
+          KnapsackPro::Config::Env.set_test_runner_adapter(adapter_class)
+          runner = new(adapter_class)
 
           # Add test_dir to load path to make work:
           #   require 'test_helper'

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -12,6 +12,7 @@ module KnapsackPro
           ENV['KNAPSACK_PRO_QUEUE_ID'] = KnapsackPro::Config::EnvGenerator.set_queue_id
 
           adapter_class = KnapsackPro::Adapters::RSpecAdapter
+          KnapsackPro::Config::Env.set_test_runner_adapter(adapter_class)
           runner = new(adapter_class)
 
           cli_args = (args || '').split

--- a/lib/knapsack_pro/runners/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/rspec_runner.rb
@@ -6,6 +6,7 @@ module KnapsackPro
         ENV['KNAPSACK_PRO_RECORDING_ENABLED'] = 'true'
 
         adapter_class = KnapsackPro::Adapters::RSpecAdapter
+        KnapsackPro::Config::Env.set_test_runner_adapter(adapter_class)
         runner = new(adapter_class)
 
         if runner.test_files_to_execute_exist?

--- a/lib/knapsack_pro/runners/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/rspec_runner.rb
@@ -14,6 +14,8 @@ module KnapsackPro
           cli_args = (args || '').split
           adapter_class.ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!(cli_args)
 
+          KnapsackPro.tracker.set_prerun_tests(runner.test_file_paths)
+
           require 'rspec/core/rake_task'
 
           task_name = 'knapsack_pro:rspec_run'

--- a/lib/knapsack_pro/runners/spinach_runner.rb
+++ b/lib/knapsack_pro/runners/spinach_runner.rb
@@ -10,6 +10,8 @@ module KnapsackPro
         if runner.test_files_to_execute_exist?
           adapter_class.verify_bind_method_called
 
+          KnapsackPro.tracker.set_prerun_tests(runner.test_file_paths)
+
           cmd = %Q[KNAPSACK_PRO_RECORDING_ENABLED=true KNAPSACK_PRO_TEST_SUITE_TOKEN=#{ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN']} bundle exec spinach #{args} --features_path #{runner.test_dir} -- #{runner.stringify_test_file_paths}]
 
           Kernel.system(cmd)

--- a/lib/knapsack_pro/runners/spinach_runner.rb
+++ b/lib/knapsack_pro/runners/spinach_runner.rb
@@ -5,6 +5,7 @@ module KnapsackPro
         ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN'] = KnapsackPro::Config::Env.test_suite_token_spinach
 
         adapter_class = KnapsackPro::Adapters::SpinachAdapter
+        KnapsackPro::Config::Env.set_test_runner_adapter(adapter_class)
         runner = new(adapter_class)
 
         if runner.test_files_to_execute_exist?

--- a/lib/knapsack_pro/runners/test_unit_runner.rb
+++ b/lib/knapsack_pro/runners/test_unit_runner.rb
@@ -11,6 +11,8 @@ module KnapsackPro
         if runner.test_files_to_execute_exist?
           adapter_class.verify_bind_method_called
 
+          KnapsackPro.tracker.set_prerun_tests(runner.test_file_paths)
+
           cli_args =
             (args || '').split +
             runner.test_file_paths.map do |f|

--- a/lib/knapsack_pro/runners/test_unit_runner.rb
+++ b/lib/knapsack_pro/runners/test_unit_runner.rb
@@ -6,6 +6,7 @@ module KnapsackPro
         ENV['KNAPSACK_PRO_RECORDING_ENABLED'] = 'true'
 
         adapter_class = KnapsackPro::Adapters::TestUnitAdapter
+        KnapsackPro::Config::Env.set_test_runner_adapter(adapter_class)
         runner = new(adapter_class)
 
         if runner.test_files_to_execute_exist?

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -20,7 +20,7 @@ module KnapsackPro
 
       # Remove report only when the reset! method is called explicitly.
       # The report should be persisted on the disk so that multiple tracker instances can share the report state.
-      # Tracker instance can be created by knapsack_pro process and a separate tracker is created by rake task (e.g. RSpec) in Regular Mode.
+      # Tracker instance can be created by knapsack_pro process and a separate tracker is created by rake task (e.g., RSpec) in Regular Mode.
       File.delete(prerun_tests_report_path) if File.exists?(prerun_tests_report_path)
     end
 
@@ -69,7 +69,7 @@ module KnapsackPro
     def to_a
       # When the test files are not loaded in the memory then load them from the disk.
       # Useful for the Regular Mode when the memory is not shared between tracker instances.
-      # Tracker instance can be created by knapsack_pro process and a separate tracker is created by rake task (e.g. RSpec)
+      # Tracker instance can be created by knapsack_pro process and a separate tracker is created by rake task (e.g., RSpec)
       load_prerun_tests unless prerun_tests_loaded
 
       test_files = []
@@ -116,7 +116,7 @@ module KnapsackPro
     def load_prerun_tests
       read_prerun_tests_report.each do |test_file_path, hash|
         # Load only test files that were not measured. For example,
-        # track test files assigned to CI node but never executed by test runner (e.g. pending RSpec spec files).
+        # track test files assigned to CI node but never executed by test runner (e.g., pending RSpec spec files).
         next if @test_files_with_time.key?(test_file_path)
 
         @test_files_with_time[test_file_path] = {

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -66,6 +66,7 @@ module KnapsackPro
     def to_a
       # When the test files are not loaded in the memory then load them from the disk.
       # Useful for the Regular Mode when the memory is not shared between tracker instances.
+      # Tracker instance can be created by knapsack_pro process and a separate tracker is created by rake task (e.g. RSpec)
       load_prerun_tests unless prerun_tests_loaded
 
       test_files = []

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -91,7 +91,8 @@ module KnapsackPro
     end
 
     def prerun_tests_report_path
-      report_name = "prerun_tests_node_#{KnapsackPro::Config::Env.ci_node_index}.json"
+      raise 'Test runner adapter not set. Report a bug to the Knapsack Pro support.' unless KnapsackPro::Config::Env.test_runner_adapter
+      report_name = "prerun_tests_#{KnapsackPro::Config::Env.test_runner_adapter}_node_#{KnapsackPro::Config::Env.ci_node_index}.json"
       File.join(tracker_dir_path, report_name)
     end
 

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -17,7 +17,11 @@ module KnapsackPro
 
     def reset!
       set_defaults
-      set_default_prerun_tests
+
+      # Remove report only when the reset! method is called explicitly.
+      # The report should be persisted on the disk so that multiple tracker instances can share the report state.
+      # Tracker instance can be created by knapsack_pro process and a separate tracker is created by rake task (e.g. RSpec) in Regular Mode.
+      File.delete(prerun_tests_report_path) if File.exists?(prerun_tests_report_path)
     end
 
     def start_timer
@@ -103,10 +107,6 @@ module KnapsackPro
       File.open(prerun_tests_report_path, 'w+') do |f|
         f.write(report_json)
       end
-    end
-
-    def set_default_prerun_tests
-      save_prerun_tests_report({})
     end
 
     def read_prerun_tests_report

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -115,8 +115,8 @@ module KnapsackPro
 
     def load_prerun_tests
       read_prerun_tests_report.each do |test_file_path, hash|
-        # load only test files that were not measured yet
-        # track test files assigned to CI node but never executed by test runner (e.g. pending RSpec spec files)
+        # Load only test files that were not measured. For example,
+        # track test files assigned to CI node but never executed by test runner (e.g. pending RSpec spec files).
         next if @test_files_with_time.key?(test_file_path)
 
         @test_files_with_time[test_file_path] = {

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -11,7 +11,6 @@ module KnapsackPro
 
     def initialize
       @global_time_since_beginning = 0
-      @prerun_tests_loaded = false
       FileUtils.mkdir_p(tracker_dir_path)
       set_defaults
     end
@@ -85,6 +84,7 @@ module KnapsackPro
       @global_time = 0
       @test_files_with_time = {}
       @current_test_path = nil
+      @prerun_tests_loaded = false
     end
 
     def tracker_dir_path

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -124,6 +124,8 @@ module KnapsackPro
           measured_time: hash.fetch('measured_time'),
         }
       end
+
+      @prerun_tests_loaded = true
     end
 
     def update_global_time(execution_time)

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -950,4 +950,29 @@ describe KnapsackPro::Config::Env do
       it { should be_nil }
     end
   end
+
+  describe '.test_runner_adapter' do
+    subject { described_class.test_runner_adapter }
+
+    context 'when ENV exists' do
+      let(:test_runner_adapter) { 'RSpecAdapter' }
+      before { stub_const('ENV', { 'KNAPSACK_PRO_TEST_RUNNER_ADAPTER' => test_runner_adapter }) }
+      it { should eql 'RSpecAdapter' }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should be_nil }
+    end
+  end
+
+  describe '.set_test_runner_adapter' do
+    let(:adapter_class) { KnapsackPro::Adapters::RSpecAdapter }
+
+    subject { described_class.set_test_runner_adapter(adapter_class) }
+
+    it 'sets test runner adapter' do
+      subject
+      expect(described_class.test_runner_adapter).to eql 'RSpecAdapter'
+    end
+  end
 end

--- a/spec/knapsack_pro/runners/queue/cucumber_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/cucumber_runner_spec.rb
@@ -19,6 +19,8 @@ describe KnapsackPro::Runners::Queue::CucumberRunner do
       expect(ENV).to receive(:[]=).with('KNAPSACK_PRO_QUEUE_RECORDING_ENABLED', 'true')
       expect(ENV).to receive(:[]=).with('KNAPSACK_PRO_QUEUE_ID', queue_id)
 
+      expect(KnapsackPro::Config::Env).to receive(:set_test_runner_adapter).with(KnapsackPro::Adapters::CucumberAdapter)
+
       expect(described_class).to receive(:new).with(KnapsackPro::Adapters::CucumberAdapter).and_return(runner)
     end
 

--- a/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
@@ -19,6 +19,8 @@ describe KnapsackPro::Runners::Queue::MinitestRunner do
       expect(ENV).to receive(:[]=).with('KNAPSACK_PRO_QUEUE_RECORDING_ENABLED', 'true')
       expect(ENV).to receive(:[]=).with('KNAPSACK_PRO_QUEUE_ID', queue_id)
 
+      expect(KnapsackPro::Config::Env).to receive(:set_test_runner_adapter).with(KnapsackPro::Adapters::MinitestAdapter)
+
       expect(described_class).to receive(:new).with(KnapsackPro::Adapters::MinitestAdapter).and_return(runner)
 
       expect($LOAD_PATH).to receive(:unshift).with(test_dir)

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -26,6 +26,8 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
       expect(ENV).to receive(:[]=).with('KNAPSACK_PRO_QUEUE_RECORDING_ENABLED', 'true')
       expect(ENV).to receive(:[]=).with('KNAPSACK_PRO_QUEUE_ID', queue_id)
 
+      expect(KnapsackPro::Config::Env).to receive(:set_test_runner_adapter).with(KnapsackPro::Adapters::RSpecAdapter)
+
       expect(described_class).to receive(:new).with(KnapsackPro::Adapters::RSpecAdapter).and_return(runner)
     end
 

--- a/spec/knapsack_pro/runners/spinach_runner_spec.rb
+++ b/spec/knapsack_pro/runners/spinach_runner_spec.rb
@@ -11,16 +11,20 @@ describe KnapsackPro::Runners::SpinachRunner do
     before do
       stub_const("ENV", { 'KNAPSACK_PRO_TEST_SUITE_TOKEN_SPINACH' => 'spinach-token' })
 
+      expect(KnapsackPro::Config::Env).to receive(:set_test_runner_adapter).with(KnapsackPro::Adapters::SpinachAdapter)
+
       expect(described_class).to receive(:new)
       .with(KnapsackPro::Adapters::SpinachAdapter).and_return(runner)
     end
 
     context 'when test files were returned by Knapsack Pro API' do
-      let(:stringify_test_file_paths) { 'features/a.feature features/b.feature' }
+      let(:test_file_paths) { ['features/a.feature', 'features/b.feature'] }
+      let(:stringify_test_file_paths) { test_file_paths.join(' ') }
       let(:test_dir) { 'fake-test-dir' }
       let(:runner) do
         instance_double(described_class,
                         test_dir: test_dir,
+                        test_file_paths: test_file_paths,
                         stringify_test_file_paths: stringify_test_file_paths,
                         test_files_to_execute_exist?: true)
       end
@@ -28,6 +32,10 @@ describe KnapsackPro::Runners::SpinachRunner do
 
       before do
         expect(KnapsackPro::Adapters::SpinachAdapter).to receive(:verify_bind_method_called)
+
+        tracker = instance_double(KnapsackPro::Tracker)
+        expect(KnapsackPro).to receive(:tracker).and_return(tracker)
+        expect(tracker).to receive(:set_prerun_tests).with(test_file_paths)
 
         expect(Kernel).to receive(:system).with('KNAPSACK_PRO_RECORDING_ENABLED=true KNAPSACK_PRO_TEST_SUITE_TOKEN=spinach-token bundle exec spinach --custom-arg --features_path fake-test-dir -- features/a.feature features/b.feature')
 

--- a/spec/knapsack_pro/tracker_spec.rb
+++ b/spec/knapsack_pro/tracker_spec.rb
@@ -164,12 +164,15 @@ describe KnapsackPro::Tracker do
     end
 
     before do
+      expect(tracker.prerun_tests_loaded).to be true
+
       tracker.current_test_path = test_file_path
       tracker.start_timer
       sleep 0.1
       tracker.stop_timer
+
       expect(tracker.global_time).not_to eql 0
-      expect(tracker.prerun_tests_loaded).to be true
+
       tracker.reset!
     end
 

--- a/spec/knapsack_pro/tracker_spec.rb
+++ b/spec/knapsack_pro/tracker_spec.rb
@@ -117,6 +117,43 @@ describe KnapsackPro::Tracker do
       end
       it_behaves_like '#to_a'
     end
+
+    context 'when a new tracker instance is created' do
+      let(:non_pending_test_paths) { ['a_spec.rb', 'b_spec.rb'] }
+      let(:test_paths) { non_pending_test_paths + ['pending_spec.rb'] }
+
+      before do
+        # measure tests only for non pending tests
+        non_pending_test_paths.each_with_index do |test_path, index|
+          tracker.current_test_path = test_path
+          tracker.start_timer
+          sleep index.to_f / 10 + 0.1
+          tracker.stop_timer
+        end
+      end
+
+      it '2nd tracker instance loads prerun tests from the disk' do
+        expect(tracker.prerun_tests_loaded).to be true
+        expect(tracker.to_a.size).to eq 3
+        expect(tracker.to_a[0][:path]).to eq 'a_spec.rb'
+        expect(tracker.to_a[0][:time_execution]).to be >= 0
+        expect(tracker.to_a[1][:path]).to eq 'b_spec.rb'
+        expect(tracker.to_a[1][:time_execution]).to be >= 0
+        expect(tracker.to_a[2][:path]).to eq 'pending_spec.rb'
+        expect(tracker.to_a[2][:time_execution]).to eq 0
+
+        tracker2 = described_class.send(:new)
+        expect(tracker2.prerun_tests_loaded).to be false
+        expect(tracker2.to_a.size).to eq 3
+        expect(tracker2.to_a[0][:path]).to eq 'a_spec.rb'
+        expect(tracker2.to_a[0][:time_execution]).to be >= 0
+        expect(tracker2.to_a[1][:path]).to eq 'b_spec.rb'
+        expect(tracker2.to_a[1][:time_execution]).to be >= 0
+        expect(tracker2.to_a[2][:path]).to eq 'pending_spec.rb'
+        expect(tracker2.to_a[2][:time_execution]).to eq 0
+        expect(tracker2.prerun_tests_loaded).to be true
+      end
+    end
   end
 
   describe '#reset!' do


### PR DESCRIPTION
# bug

* When you use Regular Mode and RSpec and you run first CI build then Knapsack Pro API returns a list of test files assigned to the CI node. If the test files have a pending test file then RSpec won't run it. This causes not measuring time execution for the pending test file. Because of that list of test files that is saved to Knapsack Pro API does not contain the pending test file.
* Problem happens when you retry CI node and you expect the same set of test files will be assigned to the CI node. But there is missing pending spec file which was not recorded during the first CI build run.

# fix

Track all test files assigned to the CI node and save them to Knapsack Pro API after tests are executed. Thanks to that pending test file will have default 0 seconds time execution. When you retry CI node then the pending test file will be assigned to the retired CI node properly.

Improvement was made for Regular Mode for all test runners (RSpec, Cucumber, Minitest, ...etc)

# related old PR for a similar change in Queue Mode
https://github.com/KnapsackPro/knapsack_pro-ruby/pull/71