### PR TITLE
Use RSpec `example` block argument instead of the global `RSpec.current_example`. This allows to run tests with the `async-rspec` gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+### 3.0.0
+
+* __(breaking change)__ Remove support for RSpec 2.x. This change was already done by accident in [the pull request](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/143) when we added RSpec `context` hook available only for RSpec 3.x.
+* Use RSpec `example` from RSpec `each` hook instead of global `RSpec.current_example`. It allows running tests with async-rspec gem.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/153
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v2.18.2...v3.0.0
+
 ### 2.18.2
 
 * Track all test files assigned to a CI node in Regular Mode including pending test files in order to retry proper set of tests on the retried CI node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### 3.0.0
 
-* __(breaking change)__ Remove support for RSpec 2.x. This change was already done by accident in [the pull request](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/143) when we added RSpec `context` hook available only for RSpec 3.x.
-* Use RSpec `example` from RSpec `each` hook instead of global `RSpec.current_example`. It allows running tests with async-rspec gem.
+* __(breaking change)__ Remove support for RSpec 2.x. This change was already done by accident in [the pull request](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/143) when we added the RSpec `context` hook, which is available only since RSpec 3.x.
+* Use RSpec `example` block argument instead of the global `RSpec.current_example`. This allows to run tests with the `async-rspec` gem.
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/153
 

--- a/knapsack_pro.gemspec
+++ b/knapsack_pro.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake', '>= 0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
-  spec.add_development_dependency 'rspec', '~> 3.0', '>= 2.10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.3'
   spec.add_development_dependency 'cucumber', '>= 0'
   spec.add_development_dependency 'spinach', '>= 0.8'

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -24,8 +24,10 @@ module KnapsackPro
         cli_args.any? { |arg| arg.start_with?('-f') || arg.start_with?('--format') }
       end
 
-      def self.test_path(example_group)
-        if defined?(::Turnip) && ::Turnip::VERSION.to_i < 2
+      def self.test_path(example)
+        example_group = example.metadata[:example_group]
+
+        if defined?(::Turnip) && Gem::Version.new(::Turnip::VERSION) < Gem::Version.new('2.0.0')
           unless example_group[:turnip]
             until example_group[:parent_example_group].nil?
               example_group = example_group[:parent_example_group]
@@ -51,14 +53,7 @@ module KnapsackPro
             # this way we count time spend in runtime for the previous test example after around(:each) is already done
             KnapsackPro.tracker.stop_timer
 
-            current_example_group =
-              if ::RSpec.respond_to?(:current_example)
-                ::RSpec.current_example.metadata[:example_group]
-              else
-                example.metadata
-              end
-
-            current_test_path = KnapsackPro::Adapters::RSpecAdapter.test_path(current_example_group)
+            current_test_path = KnapsackPro::Adapters::RSpecAdapter.test_path(example)
 
             KnapsackPro.tracker.current_test_path =
               if KnapsackPro::Config::Env.rspec_split_by_test_examples? && KnapsackPro::Adapters::RSpecAdapter.slow_test_file?(RSpecAdapter, current_test_path)

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -111,7 +111,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
   end
 
   describe '.test_path' do
-    let(:current_example_metadata) do
+    let(:example_group) do
       {
         file_path: '1_shared_example.rb',
         parent_example_group: {
@@ -122,14 +122,19 @@ describe KnapsackPro::Adapters::RSpecAdapter do
         }
       }
     end
+    let(:current_example) do
+      OpenStruct.new(metadata: {
+        example_group: example_group
+      })
+    end
 
-    subject { described_class.test_path(current_example_metadata) }
+    subject { described_class.test_path(current_example) }
 
     it { should eql 'a_spec.rb' }
 
     context 'with turnip features' do
       describe 'when the turnip version is less than 2' do
-        let(:current_example_metadata) do
+        let(:example_group) do
           {
             file_path: "./spec/features/logging_in.feature",
             turnip: true,
@@ -145,7 +150,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
       end
 
       describe 'when turnip is version 2 or greater' do
-        let(:current_example_metadata) do
+        let(:example_group) do
           {
             file_path: "gems/turnip-2.0.0/lib/turnip/rspec.rb",
             turnip: true,
@@ -170,13 +175,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
       let(:logger) { instance_double(Logger) }
       let(:global_time) { 'Global time: 01m 05s' }
       let(:test_path) { 'spec/a_spec.rb' }
-      let(:example) { double }
-      let(:example_group) { double }
-      let(:current_example) do
-        OpenStruct.new(metadata: {
-          example_group: example_group
-        })
-      end
+      let(:current_example) { double }
 
       context 'when rspec split by test examples is disabled' do
         before do
@@ -189,19 +188,18 @@ describe KnapsackPro::Adapters::RSpecAdapter do
           allow(KnapsackPro).to receive(:tracker).and_return(tracker)
           expect(tracker).to receive(:start_timer).ordered
 
-          expect(config).to receive(:around).with(:each).and_yield(example)
+          expect(config).to receive(:around).with(:each).and_yield(current_example)
           expect(config).to receive(:append_after).with(:context).and_yield
           expect(config).to receive(:after).with(:suite).and_yield
           expect(::RSpec).to receive(:configure).and_yield(config)
 
           expect(tracker).to receive(:stop_timer).ordered
 
-          expect(::RSpec).to receive(:current_example).twice.and_return(current_example)
-          expect(described_class).to receive(:test_path).with(example_group).and_return(test_path)
+          expect(described_class).to receive(:test_path).with(current_example).and_return(test_path)
 
           expect(tracker).to receive(:current_test_path=).with(test_path).ordered
 
-          expect(example).to receive(:run)
+          expect(current_example).to receive(:run)
 
           expect(tracker).to receive(:stop_timer).ordered
 
@@ -226,26 +224,25 @@ describe KnapsackPro::Adapters::RSpecAdapter do
           end
 
           it 'records time for example.id' do
-            expect(example).to receive(:id).and_return(test_example_path)
+            expect(current_example).to receive(:id).and_return(test_example_path)
 
             expect(config).to receive(:prepend_before).with(:context).and_yield
 
             allow(KnapsackPro).to receive(:tracker).and_return(tracker)
             expect(tracker).to receive(:start_timer).ordered
 
-            expect(config).to receive(:around).with(:each).and_yield(example)
+            expect(config).to receive(:around).with(:each).and_yield(current_example)
             expect(config).to receive(:append_after).with(:context).and_yield
             expect(config).to receive(:after).with(:suite).and_yield
             expect(::RSpec).to receive(:configure).and_yield(config)
 
             expect(tracker).to receive(:stop_timer).ordered
 
-            expect(::RSpec).to receive(:current_example).twice.and_return(current_example)
-            expect(described_class).to receive(:test_path).with(example_group).and_return(test_path)
+            expect(described_class).to receive(:test_path).with(current_example).and_return(test_path)
 
             expect(tracker).to receive(:current_test_path=).with(test_example_path).ordered
 
-            expect(example).to receive(:run)
+            expect(current_example).to receive(:run)
 
             expect(tracker).to receive(:stop_timer).ordered
 
@@ -268,19 +265,18 @@ describe KnapsackPro::Adapters::RSpecAdapter do
             allow(KnapsackPro).to receive(:tracker).and_return(tracker)
             expect(tracker).to receive(:start_timer).ordered
 
-            expect(config).to receive(:around).with(:each).and_yield(example)
+            expect(config).to receive(:around).with(:each).and_yield(current_example)
             expect(config).to receive(:append_after).with(:context).and_yield
             expect(config).to receive(:after).with(:suite).and_yield
             expect(::RSpec).to receive(:configure).and_yield(config)
 
-            expect(::RSpec).to receive(:current_example).twice.and_return(current_example)
-            expect(described_class).to receive(:test_path).with(example_group).and_return(test_path)
+            expect(described_class).to receive(:test_path).with(current_example).and_return(test_path)
 
             expect(tracker).to receive(:stop_timer).ordered
 
             expect(tracker).to receive(:current_test_path=).with(test_path).ordered
 
-            expect(example).to receive(:run)
+            expect(current_example).to receive(:run)
 
             expect(tracker).to receive(:stop_timer).ordered
 


### PR DESCRIPTION
* Use RSpec `example` from RSpec `each` hook instead of global `RSpec.current_example`. It allows running tests with async-rspec gem.
* breaking change: drop support for RSpec 2.x. It was already accidentally dropped due to added `context` RSpec hooks.

# Related
This PR is based on changes from knapsack gem:
https://github.com/KnapsackPro/knapsack/pull/117