### PR TITLE
Add mocking to fix randomly failing spec

### DIFF
--- a/spec/knapsack_pro/runners/minitest_runner_spec.rb
+++ b/spec/knapsack_pro/runners/minitest_runner_spec.rb
@@ -14,12 +14,17 @@ describe KnapsackPro::Runners::MinitestRunner do
     end
 
     context 'when test files were returned by Knapsack Pro API' do
+      let(:test_file_paths) { ['test_fake/a_test.rb', 'test_fake/b_test.rb'] }
+
       before do
         expect(KnapsackPro::Adapters::MinitestAdapter).to receive(:verify_bind_method_called)
+
+        tracker = instance_double(KnapsackPro::Tracker)
+        expect(KnapsackPro).to receive(:tracker).and_return(tracker)
+        expect(tracker).to receive(:set_prerun_tests).with(test_file_paths)
       end
 
       it 'runs tests' do
-        test_file_paths = ['test_fake/a_test.rb', 'test_fake/b_test.rb']
         runner = instance_double(described_class,
                                  test_dir: 'test',
                                  test_file_paths: test_file_paths,

--- a/spec/knapsack_pro/runners/test_unit_runner_spec.rb
+++ b/spec/knapsack_pro/runners/test_unit_runner_spec.rb
@@ -13,10 +13,15 @@ describe KnapsackPro::Runners::TestUnitRunner do
     end
 
     context 'when test files were returned by Knapsack Pro API' do
+      let(:test_file_paths) { ['test-unit_fake/a_test.rb', 'test-unit_fake/b_test.rb'] }
+
       it 'runs tests' do
         expect(KnapsackPro::Adapters::TestUnitAdapter).to receive(:verify_bind_method_called)
 
-        test_file_paths = ['test-unit_fake/a_test.rb', 'test-unit_fake/b_test.rb']
+        tracker = instance_double(KnapsackPro::Tracker)
+        expect(KnapsackPro).to receive(:tracker).and_return(tracker)
+        expect(tracker).to receive(:set_prerun_tests).with(test_file_paths)
+
         runner = instance_double(described_class,
                                  test_dir: 'test-unit_fake',
                                  test_file_paths: test_file_paths,


### PR DESCRIPTION
Failing CI build: https://app.circleci.com/pipelines/github/KnapsackPro/knapsack_pro-ruby/461/workflows/4d56022a-5b83-4f29-968f-d9e90c48b91e/jobs/1450

Error:

```
Failures:

  1) KnapsackPro::Runners::MinitestRunner.run when test files were returned by Knapsack Pro API runs tests
     Failure/Error:
       File.open(prerun_tests_report_path, 'w+') do |f|
         f.write(report_json)
       end
     
     Errno::ENOENT:
       No such file or directory @ rb_sysopen - tmp/knapsack_pro/tracker/prerun_tests_MinitestAdapter_node_0.json
     # ./lib/knapsack_pro/tracker.rb:107:in `initialize'
     # ./lib/knapsack_pro/tracker.rb:107:in `open'
     # ./lib/knapsack_pro/tracker.rb:107:in `save_prerun_tests_report'
     # ./lib/knapsack_pro/tracker.rb:64:in `set_prerun_tests'
     # ./lib/knapsack_pro/runners/minitest_runner.rb:15:in `run'
     # ./spec/knapsack_pro/runners/minitest_runner_spec.rb:10:in `block (3 levels) in <top (required)>'
     # ./spec/knapsack_pro/runners/minitest_runner_spec.rb:32:in `block (4 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.0.0/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```