### PR TITLE
Fix bug when test files have no recorded time execution then they should not be detected as slow test files for RSpec split by test examples feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 3.1.2
+
+* Fix bug when test files have no recorded time execution then they should not be detected as slow test files for RSpec split by test examples feature
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/163
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v3.1.1...v3.1.2
+
 ### 3.1.1
 
 * Rephrase log outputs in the Queue Mode RSpec runner

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -8,7 +8,8 @@ module KnapsackPro
       time_threshold = (time_execution / KnapsackPro::Config::Env.ci_node_total) * TIME_THRESHOLD_PER_CI_NODE
 
       test_files.select do |test_file|
-        test_file.fetch('time_execution') >= time_threshold
+        time_execution = test_file.fetch('time_execution')
+        time_execution >= time_threshold && time_execution > 0
       end
     end
 

--- a/spec/knapsack_pro/slow_test_file_determiner_spec.rb
+++ b/spec/knapsack_pro/slow_test_file_determiner_spec.rb
@@ -1,16 +1,6 @@
 describe KnapsackPro::SlowTestFileDeterminer do
   describe '.call' do
     let(:node_total) { 4 }
-    let(:time_execution) { 20.0 }
-    let(:test_files) do
-      [
-        { 'path' => 'a_spec.rb', 'time_execution' => 1.0 },
-        { 'path' => 'b_spec.rb', 'time_execution' => 3.4 },
-        # slow tests are above 3.5s threshold (20.0 / 4 * 0.7 = 3.5)
-        { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
-        { 'path' => 'd_spec.rb', 'time_execution' => 5.9 },
-      ]
-    end
 
     before do
       expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(node_total)
@@ -18,11 +8,38 @@ describe KnapsackPro::SlowTestFileDeterminer do
 
     subject { described_class.call(test_files, time_execution) }
 
-    it do
-      expect(subject).to eq([
-        { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
-        { 'path' => 'd_spec.rb', 'time_execution' => 5.9 },
-      ])
+    context 'when test files have recorded time execution' do
+      let(:time_execution) { 20.0 }
+      let(:test_files) do
+        [
+          { 'path' => 'a_spec.rb', 'time_execution' => 1.0 },
+          { 'path' => 'b_spec.rb', 'time_execution' => 3.4 },
+          # slow tests are above 3.5s threshold (20.0 / 4 * 0.7 = 3.5)
+          { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
+          { 'path' => 'd_spec.rb', 'time_execution' => 5.9 },
+        ]
+      end
+
+      it do
+        expect(subject).to eq([
+          { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
+          { 'path' => 'd_spec.rb', 'time_execution' => 5.9 },
+        ])
+      end
+    end
+
+    context 'when test files have no recorded time execution' do
+      let(:time_execution) { 0.0 }
+      let(:test_files) do
+        [
+          { 'path' => 'a_spec.rb', 'time_execution' => 0.0 },
+          { 'path' => 'b_spec.rb', 'time_execution' => 0.0 },
+        ]
+      end
+
+      it do
+        expect(subject).to eq([])
+      end
     end
   end
 


### PR DESCRIPTION
# bug

The bug is related to feature: [RSpec split by examples](https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it).

When API https://docs.knapsackpro.com/api/v1/#build_distributions_last_get returns build distribution with all test files having time execution 0 seconds then all test files were detected as slow test files in knapsack_pro gem. This leads to loading a lot of test examples in RSpec. RSpec could take a lot of memory and slow down, freeze the CI server for the larger test suite.

# solution

When test files have no recorded time execution (time execution is 0 seconds) then they should not be detected as slow test files by [RSpec split by examples feature](https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it).

