### PR TITLE
add error message to RspecAdapter#bind

### DIFF
--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -101,6 +101,11 @@ module KnapsackPro
     # In case someone is doing switch from knapsack gem to the knapsack_pro gem
     # and didn't notice the class name changed
     class RspecAdapter < RSpecAdapter
+      def self.bind
+        error_message = 'You have attempted to call KnapsackPro::Adapters::RspecAdapter.bind. Please switch to using the new class name: KnapsackPro::Adapters::RSpecAdapter. See https://docs.knapsackpro.com/knapsack_pro-ruby/guide for up-to-date configuration instructions.'
+        KnapsackPro.logger.error(error_message)
+        raise error_message
+      end
     end
   end
 end


### PR DESCRIPTION
Due to the way the adapter name is inferred in `KnapsackPro::Adapters::BaseAdapter`, `RspecAdapter#bind` will not write the bind file to the correct location and the command will fail. 

This adds an error message when `RspecAdapter#bind` is called, rather than silently inheriting the method from `RSpecAdapter`.