### PR TITLE
Raise exception when using `:focus` tag to avoid skipping RSpec tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 3.2.1
+
+* Raise exception when using `:focus` tag to avoid skipping RSpec tests
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/167
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v3.2.0...v3.2.1
+
 ### 3.2.0
 
 * Add an error message to `KnapsackPro::Adapters::RspecAdapter#bind`

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -63,7 +63,7 @@ module KnapsackPro
               end
 
             if example.metadata[:focus] && KnapsackPro::Adapters::RSpecAdapter.rspec_configuration.filter.rules[:focus]
-              raise "We detected a test file path #{current_test_path} with a test using metadata `:focus` tag. RSpec might not run some tests in Queue Mode (causing random tests skipping problem). Please remove `:focus` tag from your codebase. See more: https://knapsackpro.com/faq/question/rspec-is-not-running-some-tests"
+              raise "We detected a test file path #{current_test_path} with a test using the metadata `:focus` tag. RSpec might not run some tests in the Queue Mode (causing random tests skipping problem). Please remove the `:focus` tag from your codebase. See more: https://knapsackpro.com/faq/question/rspec-is-not-running-some-tests"
             end
 
             example.run

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -63,7 +63,7 @@ module KnapsackPro
               end
 
             if example.metadata[:focus] && KnapsackPro::Adapters::RSpecAdapter.rspec_configuration.filter.rules[:focus]
-              raise "We detected a test file path #{current_test_path} with a test using metadata `:focus` tag. Using the `:focus` tag should be a temporary change in the development environment when you only want to run tests with the `:focus` tag. In the CI environment, it is not recommended to use `:focus` tag because this can lead to skipping test cases. Especially it can lead to skipping random test file paths without `:focus` tag in the Knapsack Pro Queue Mode when the test files are loaded after the test file with `:focus` tag. Please remove `:focus` tags from your test files and commit the change and push to the repository. RSpec provides aliases `fit`, `fdescribe` and `fcontext` as a shorthand for `it`, `describe` and `context` with `:focus` metadata, making it easy to temporarily focus an example or group by prefixing an `f`. Please remove all occurrences of it or use an alternative solution: https://knapsackpro.com/faq/question/why-is-rspec-skipping-some-of-the-tests#if-you-have-too-many-test-files-with-focus-tag-and-you-dont-want-to-remove-the-tag-manually"
+              raise "We detected a test file path #{current_test_path} with a test using metadata `:focus` tag. RSpec might not run some tests in Queue Mode (causing random tests skipping problem). Please remove `:focus` tag from your codebase. See more: https://knapsackpro.com/faq/question/rspec-is-not-running-some-tests"
             end
 
             example.run

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -62,6 +62,10 @@ module KnapsackPro
                 current_test_path
               end
 
+            if example.metadata[:focus] && KnapsackPro::Adapters::RSpecAdapter.rspec_configuration.filter.rules[:focus]
+              raise "We detected a test file path #{current_test_path} with a test using metadata `:focus` tag. Using the `:focus` tag should be a temporary change in the development environment when you only want to run tests with the `:focus` tag. In the CI environment, it is not recommended to use `:focus` tag because this can lead to skipping test cases. Especially it can lead to skipping random test file paths without `:focus` tag in the Knapsack Pro Queue Mode when the test files are loaded after the test file with `:focus` tag. Please remove `:focus` tags from your test files and commit the change and push to the repository. RSpec provides aliases `fit`, `fdescribe` and `fcontext` as a shorthand for `it`, `describe` and `context` with `:focus` metadata, making it easy to temporarily focus an example or group by prefixing an `f`. Please remove all occurrences of it or use an alternative solution: https://knapsackpro.com/faq/question/why-is-rspec-skipping-some-of-the-tests#if-you-have-too-many-test-files-with-focus-tag-and-you-dont-want-to-remove-the-tag-manually"
+            end
+
             example.run
           end
 
@@ -94,6 +98,14 @@ module KnapsackPro
             end
           end
         end
+      end
+
+      private
+
+      # Hide RSpec configuration so that we could mock it in the spec.
+      # Mocking existing RSpec configuration could impact test's runtime.
+      def self.rspec_configuration
+        ::RSpec.configuration
       end
     end
 

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -201,7 +201,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
 
           expect {
             subject.bind_time_tracker
-          }.to raise_error /We detected a test file path spec\/a_spec\.rb with a test using metadata `:focus` tag/
+          }.to raise_error /We detected a test file path spec\/a_spec\.rb with a test using the metadata `:focus` tag/
         end
       end
 


### PR DESCRIPTION
Raise exception only when RSpec inclusion rule includes `:focus` tag.

# problem description

When tests can be skipped by RSpec?

The problem occurs when at least one of the test files has `:focus` tag. And when you use 

```ruby
RSpec.configure do |c|
  c.filter_run_when_matching :focus
end
```

For instance, if a test file has content like this:

```ruby
describe ArticlesController, :focus do
  it '1' do
    expect(true).to be true
  end

  # another way to make test focused is to add prefix f to it (fit)
  fit '2' do
    expect(true).to be true
  end
end
```


Then this sets RSpec filter to `focus: true`. You can see in RSpec output this: `Run options: include {:focus=>true}`
and as a result we can see in the RSpec output: `All examples were filtered out` so tests without the tag are skipped.

All further test files fetched from Queue are going to be skipped due to this filter `:focus => true`.

# solution

Using the `:focus` tag should be a temporary change in the development environment when you only want to run tests with the `:focus` tag. In the CI environment, it is not recommended to use `:focus` tag because this can lead to skipping test cases. Especially it can lead to skipping random test file paths without `:focus` tag in the Knapsack Pro Queue Mode when the test files are loaded after the test file with `:focus` tag. Please remove `:focus` tags from your test files and commit the change and push to the repository. RSpec provides aliases `fit`, `fdescribe` and `fcontext` as a shorthand for `it`, `describe` and `context` with `:focus` metadata, making it easy to temporarily focus an example or group by prefixing an `f`. Please remove all occurrences of it or use an alternative solution: https://knapsackpro.com/faq/question/why-is-rspec-skipping-some-of-the-tests#if-you-have-too-many-test-files-with-focus-tag-and-you-dont-want-to-remove-the-tag-manually