### PR TITLE
Show a JSON report file content when RSpec fails during a dry run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 3.3.0
+
+* Show a JSON report file content when RSpec fails during a dry run 
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/172
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v3.2.1...v3.3.0
+
 ### 3.2.1
 
 * Raise exception when using `:focus` tag to avoid skipping RSpec tests

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -38,7 +38,7 @@ module KnapsackPro
           KnapsackPro.logger.error('-'*10 + ' START of actionable error message ' + '-'*50)
           KnapsackPro.logger.error('RSpec (with a dry-run option) had a problem generating the report with test examples for the slow test files. Here is what you can do:')
 
-          KnapsackPro.logger.error("a)  Please look for an error message from the RSpec in the output above or below. If you don't see anything, that is fine. Sometimes RSpec does not produce any errors in the output.")
+          KnapsackPro.logger.error("a) Please look for an error message from RSpec in the output above or below. If you don't see anything, that is fine. Sometimes RSpec does not produce any errors in the output.")
 
           KnapsackPro.logger.error("b) Check if RSpec generated the report file #{report_path}. If the report exists, it may contain an error message. Here is a preview of the report file:")
           KnapsackPro.logger.error(report_content || 'N/A')

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -36,8 +36,16 @@ module KnapsackPro
           ] + cli_args).join(' ')
 
           KnapsackPro.logger.error('-'*10 + ' START of actionable error message ' + '-'*50)
-          KnapsackPro.logger.error('There was a problem while generating test examples for the slow test files using the RSpec dry-run flag. To reproduce the error triggered by the RSpec, please try to run below command (this way, you can find out what is causing the error):')
+          KnapsackPro.logger.error('RSpec (with a dry-run option) had a problem generating the report with test examples for the slow test files. Here is what you can do:')
+
+          KnapsackPro.logger.error("a)  Please look for an error message from the RSpec in the output above or below. If you don't see anything, that is fine. Sometimes RSpec does not produce any errors in the output.")
+
+          KnapsackPro.logger.error("b) Check if RSpec generated the report file #{report_path}. If the report exists, it may contain an error message. Here is a preview of the report file:")
+          KnapsackPro.logger.error(report_content || 'N/A')
+
+          KnapsackPro.logger.error('c) To reproduce the error manually, please run the following RSpec command. This way, you can find out what is causing the error. Please ensure you run the command in the same environment where the error occurred. For instance, if the error happens on the CI server, you should run the command in the CI environment:')
           KnapsackPro.logger.error(debug_cmd)
+
           KnapsackPro.logger.error('-'*10 + ' END of actionable error message ' + '-'*50)
 
           raise 'There was a problem while generating test examples for the slow test files. Please read actionable error message above.'
@@ -73,6 +81,10 @@ module KnapsackPro
 
       def report_path
         "#{report_dir}/rspec_dry_run_json_report_node_#{KnapsackPro::Config::Env.ci_node_index}.json"
+      end
+
+      def report_content
+        File.read(report_path) if File.exist?(report_path)
       end
 
       def adapter_class

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -48,7 +48,7 @@ module KnapsackPro
 
           KnapsackPro.logger.error('-'*10 + ' END of actionable error message ' + '-'*50)
 
-          raise 'There was a problem while generating test examples for the slow test files. Please read actionable error message above.'
+          raise 'There was a problem while generating test examples for the slow test files. Please read the actionable error message above.'
         end
       end
 

--- a/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
+++ b/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
@@ -11,7 +11,7 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
 
       expect(FileUtils).to receive(:mkdir_p).with(report_dir)
 
-      expect(File).to receive(:exist?).with(report_path).and_return(true)
+      expect(File).to receive(:exist?).at_least(1).with(report_path).and_return(true)
       expect(File).to receive(:delete).with(report_path)
 
       expect(rspec_test_example_detector).to receive(:slow_test_files).and_return(test_file_entities)
@@ -67,6 +67,13 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
 
         context 'when exit code from RSpec::Core::Runner is 1' do
           let(:exit_code) { 1 }
+
+          before do
+            json_file = %{
+            {"version":"3.11.0","messages":["An error occurred while loading ./spec/a_spec.rb"],"examples":[],"summary":{"duration":3.6e-05,"example_count":0,"failure_count":0,"pending_count":0,"errors_outside_of_examples_count":1},"summary_line":"0 examples, 0 failures, 1 error occurred outside of examples"}
+            }.strip
+            expect(File).to receive(:read).with(report_path).and_return(json_file)
+          end
 
           it do
             expect { subject }.to raise_error(RuntimeError, 'There was a problem while generating test examples for the slow test files. Please read actionable error message above.')

--- a/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
+++ b/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
@@ -11,7 +11,7 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
 
       expect(FileUtils).to receive(:mkdir_p).with(report_dir)
 
-      expect(File).to receive(:exist?).at_least(1).with(report_path).and_return(true)
+      expect(File).to receive(:exist?).at_least(:once).with(report_path).and_return(true)
       expect(File).to receive(:delete).with(report_path)
 
       expect(rspec_test_example_detector).to receive(:slow_test_files).and_return(test_file_entities)

--- a/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
+++ b/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
@@ -76,7 +76,7 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
           end
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'There was a problem while generating test examples for the slow test files. Please read actionable error message above.')
+            expect { subject }.to raise_error(RuntimeError, 'There was a problem while generating test examples for the slow test files. Please read the actionable error message above.')
           end
         end
       end


### PR DESCRIPTION
Show a JSON report file content when RSpec fails during a dry run. The JSON report may contain the error message while RSpec does not produce any error to stdout/stderr. Let's show the JSON report content to make debugging easier.

This PR is an improvement for the [RSpec split by test examples feature](https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it).
Thanks to that you can easily debug and find out what's the root issue of the RSpec failure during the dry run on your CI environment.

# Related issue
https://github.com/KnapsackPro/knapsack_pro-ruby/issues/170

More context in:
https://github.com/KnapsackPro/knapsack_pro-ruby/issues/170#issuecomment-1178140729

# How to reproduce the problem

How to verify this PR actually helps.

We use https://github.com/KnapsackPro/rails-app-with-knapsack_pro for local testing of the knapsack_pro gem.

You can edit the content of the slow test file: [`spec/slow_shared_examples_spec.rb`](https://github.com/KnapsackPro/rails-app-with-knapsack_pro/blob/7e5e67feb483261320e223a3a8d17502f7cfdadf/spec/slow_shared_examples_spec.rb) and add there a fake method name (`fake_method_name`) outside of the RSpec example scope. This should cause RSpec failure.

```ruby
# spec/slow_shared_examples_spec.rb
RSpec.shared_context "shared stuff", :shared_context => :metadata do
  before do
    sleep 1
    sleep ENV['EXTRA_TEST_FILES_DELAY'].to_i
  end
end

describe 'Example of slow shared examples' do
  # this should add 1s for each it below including
  # shared example.
  include_context "shared stuff"

  # this should add 1.5s to the total timing of this test file recorded by knapsack_pro
  # 1.5s + 1s from include_context
  it_behaves_like 'slow shared example test'

  # a fake method name outside of the RSpec example scope
  fake_method_name

  # ~0.001s + 1s from include_context
  it do
    expect(true).to be true
  end

  # in total this file should take ~3.5s
end
```

Now when you run locally knapsack_pro with bin script [`bin/knapsack_pro_queue_rspec_split_by_test_examples`](https://github.com/KnapsackPro/rails-app-with-knapsack_pro/blob/7e5e67feb483261320e223a3a8d17502f7cfdadf/bin/knapsack_pro_queue_rspec_split_by_test_examples) that has enabled [RSpec split by examples feature](https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it) you can see the actionable error message showing the content of the generated JSON report by RSpec dry run.

```
D, [2022-07-08T18:46:07.397523 #72100] DEBUG -- : [knapsack_pro] Detected 2 slow test files: [{"path"=>"spec/slow_shared_examples_spec.rb", "time_execution"=>3.611868000036338}, {"path"=>"spec/time_helpers_spec.rb", "time_execution"=>3.075624000019161}]
I, [2022-07-08T18:46:07.397542 #72100]  INFO -- : [knapsack_pro] Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual 'it's. Thanks to that a single slow test file can be split across parallel CI nodes). Analyzing 2 slow test files.
D, [2022-07-08T18:46:08.805819 #72114] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.
E, [2022-07-08T18:46:09.266662 #72114] ERROR -- : [knapsack_pro] ---------- START of actionable error message --------------------------------------------------
E, [2022-07-08T18:46:09.266697 #72114] ERROR -- : [knapsack_pro] RSpec (with a dry-run option) had a problem generating the report with test examples for the slow test files. Here is what you can do:
E, [2022-07-08T18:46:09.266708 #72114] ERROR -- : [knapsack_pro] a)  Please look for an error message from the RSpec in the output above or below. If you don't see anything, that is fine. Sometimes RSpec does not produce any errors in the output.
E, [2022-07-08T18:46:09.266721 #72114] ERROR -- : [knapsack_pro] b) Check if RSpec generated the report file .knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json. If the report exists, it may contain an error message. Here is a preview of the report file:
E, [2022-07-08T18:46:09.266757 #72114] ERROR -- : [knapsack_pro] {"version":"3.11.0","messages":["\nAn error occurred while loading ./spec/slow_shared_examples_spec.rb.\n\u001b[31mFailure/Error: \u001b[0mfake_method_name\u001b[0m\n\u001b[31m\u001b[0m\n\u001b[31mNameError:\u001b[0m\n\u001b[31m  undefined local variable or method `fake_method_name' for RSpec::ExampleGroups::ExampleOfSlowSharedExamples:Class\u001b[0m\n\u001b[36m# ./spec/slow_shared_examples_spec.rb:18:in `block in \u003ctop (required)\u003e'\u001b[0m\n\u001b[36m# ./spec/slow_shared_examples_spec.rb:8:in `\u003ctop (required)\u003e'\u001b[0m\n\u001b[36m# /Users/artur/Documents/github/knapsack-pro/knapsack_pro-ruby/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb:32:in `generate_json_report'\u001b[0m\n\u001b[36m# /Users/artur/Documents/github/knapsack-pro/knapsack_pro-ruby/lib/tasks/rspec.rake:11:in `block (2 levels) in \u003ctop (required)\u003e'\u001b[0m\n"],"examples":[],"summary":{"duration":4.9e-05,"example_count":0,"failure_count":0,"pending_count":0,"errors_outside_of_examples_count":1},"summary_line":"0 examples, 0 failures, 1 error occurred outside of examples"}
E, [2022-07-08T18:46:09.267160 #72114] ERROR -- : [knapsack_pro] c) To reproduce the error manually, please run the following RSpec command. This way, you can find out what is causing the error. Please ensure you run the command in the same environment where the error occurred. For instance, if the error happens on the CI server, you should run the command in the CI environment:
E, [2022-07-08T18:46:09.267170 #72114] ERROR -- : [knapsack_pro] bundle exec rspec --format json --dry-run --out .knapsack_pro/test_case_detectors/rspec/rspec_dry_run_json_report_node_0.json --default-path spec spec/slow_shared_examples_spec.rb spec/time_helpers_spec.rb
E, [2022-07-08T18:46:09.267177 #72114] ERROR -- : [knapsack_pro] ---------- END of actionable error message --------------------------------------------------
rake aborted!
There was a problem while generating test examples for the slow test files. Please read the actionable error message above.
```

As you can see the JSON report has an error message:

```
An error occurred while loading ./spec/slow_shared_examples_spec.rb.\n\u001b[31mFailure/Error: \u001b[0mfake_method_name\u001b[0m\n\u001b[31m\u001b[0m\n\u001b[31mNameError:\u001b[0m\n\u001b[31m  undefined local variable or method `fake_method_name' for RSpec::ExampleGroups::ExampleOfSlowSharedExamples:Class
```

This gives the developer an idea of where to look for the root issue. It's a fake method name.

