### PR TITLE
Remove preview for encrypted RSpec test examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+### 3.4.0
+
+* Update documentation and code because the encryption feature does not work with the RSpec split by examples feature
+
+    Update docs: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/176
+
+    Update code: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/177
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v3.3.1...v3.4.0
+
 ### 3.3.1
 
 * Skip loading a test file path for Minitest in Queue Mode when it does not exist on the disk

--- a/lib/tasks/encrypted_test_file_names.rake
+++ b/lib/tasks/encrypted_test_file_names.rake
@@ -19,15 +19,8 @@ namespace :knapsack_pro do
                       raise('Provide adapter name like rspec, minitest, test_unit, cucumber, spinach')
                     end
 
-    test_files =
-      if adapter_class == KnapsackPro::Adapters::RSpecAdapter && KnapsackPro::Config::Env.rspec_split_by_test_examples?
-        detector = KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector.new
-        detector.generate_json_report
-        detector.test_file_example_paths
-      else
-        test_file_pattern = KnapsackPro::TestFilePattern.call(adapter_class)
-        KnapsackPro::TestFileFinder.call(test_file_pattern)
-      end
+    test_file_pattern = KnapsackPro::TestFilePattern.call(adapter_class)
+    test_files = KnapsackPro::TestFileFinder.call(test_file_pattern)
 
     test_file_names = []
     test_files.each do |t|


### PR DESCRIPTION
[RSpec split by test examples](https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it) feature can't be used at the same time when [encryption is enabled](https://github.com/KnapsackPro/knapsack_pro-ruby#test-file-names-encryption). 

Let's remove a preview of test examples from the rake task (`KNAPSACK_PRO_SALT=xxx bundle exec rake "knapsack_pro:encrypted_test_file_names[rspec]"`). It's not needed.

# Related

Related changes in the documentation: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/176/files

Related old commit that we undo https://github.com/KnapsackPro/knapsack_pro-ruby/commit/96ec95d6c697a8b8753583615fca5a5a0416162c

# Context

There are technical limitations that prevented us from using the RSpec split by test examples feature at the same time with encryption.
Currently, encryption works in one direction. Each test file name is generated with `Digest::SHA2.hexdigest` method and 64 chars salt.
We are unable to decrypt the test file paths until we know them (we need the file name to calculate the hash value). We know what test files are on your local/CI disk so we can calculate their value with `Digest::SHA2.hexdigest` 
but we don't know what were the test examples that were executed in the previous CI build to calculate the hash value and thanks to that, decrypt values returned from the API.

## Idea for future improvement

There is a possible solution to that problem. We would have to completely change the way how encryption is done and use an algorithm that allows decrypting only based on encrypted values and a key stored in the CI. 
Thanks to that, the list of encrypted test cases fetched from Knapsack Pro API could be decrypted on the CI.