### PR TITLE
Fix: Load `rspec/core` in Regular Mode when using RSpec split by test examples feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 3.4.2
+
+* Fix: Load `rspec/core` in Regular Mode when using RSpec split by test examples feature
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/181
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v3.4.1...v3.4.2
+
 ### 3.4.1
 
 * Improve the RSpec Queue Mode runner log output (add seed)

--- a/lib/knapsack_pro/runners/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/rspec_runner.rb
@@ -2,6 +2,8 @@ module KnapsackPro
   module Runners
     class RSpecRunner < BaseRunner
       def self.run(args)
+        require 'rspec/core'
+
         ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN'] = KnapsackPro::Config::Env.test_suite_token_rspec
         ENV['KNAPSACK_PRO_RECORDING_ENABLED'] = 'true'
 


### PR DESCRIPTION
# problem

When you run Knapsack Pro for RSpec in Regular Mode, and you enable [RSpec split by test examples](https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it) feature, and you forget to set `RAILS_ENV=test` then`RSpec::Core::Parser` is not loaded.

```
... other envs
export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
bundle exec rake "knapsack_pro:rspec[--format d]"
```

It crashes with:

```
rake aborted!
NameError: uninitialized constant RSpec::Core::Parser

        ::RSpec::Core::Parser.parse(cli_args)
```

# reported issue

https://github.com/KnapsackPro/knapsack_pro-ruby/issues/180

# solution

Require `rspec/core` when running in Regular Mode. Thanks to that you don't need to remember to explicitly set `RAILS_ENV=test`.

It's easier to [try Knapsack Pro in development (locally)](https://knapsackpro.com/faq/question/how-to-run-tests-for-particular-ci-node-in-your-development-environment). 
