### PR TITLE
Add an attempt to read from the cache for Regular Mode API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 3.6.0
+
+* Add an attempt to read from the cache for Regular Mode API
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/182
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v3.5.0...v3.6.0
+
 ### 3.5.0
 
 * Add the `KnapsackPro::Hooks::Queue.before_subset_queue` hook in Queue Mode

--- a/lib/knapsack_pro/client/api/v1/build_distributions.rb
+++ b/lib/knapsack_pro/client/api/v1/build_distributions.rb
@@ -3,13 +3,13 @@ module KnapsackPro
     module API
       module V1
         class BuildDistributions < Base
-          CODE_ATTEMPT_TO_READ_FROM_CACHE_CANCELED = 'ATTEMPT_TO_READ_FROM_CACHE_CANCELED'
+          TEST_SUITE_SPLIT_CACHE_MISS_CODE = 'TEST_SUITE_SPLIT_CACHE_MISS'
 
           class << self
             def subset(args)
               request_hash = {
                 :fixed_test_suite_split => KnapsackPro::Config::Env.fixed_test_suite_split,
-                :attempt_to_read_from_cache => args.fetch(:attempt_to_read_from_cache),
+                :cache_read_attempt => args.fetch(:cache_read_attempt),
                 :commit_hash => args.fetch(:commit_hash),
                 :branch => args.fetch(:branch),
                 :node_total => args.fetch(:node_total),
@@ -17,7 +17,7 @@ module KnapsackPro
                 :ci_build_id => KnapsackPro::Config::Env.ci_node_build_id,
               }
 
-              unless request_hash[:attempt_to_read_from_cache]
+              unless request_hash[:cache_read_attempt]
                 request_hash.merge!({
                   :test_files => args.fetch(:test_files)
                 })

--- a/lib/knapsack_pro/client/api/v1/build_distributions.rb
+++ b/lib/knapsack_pro/client/api/v1/build_distributions.rb
@@ -3,19 +3,30 @@ module KnapsackPro
     module API
       module V1
         class BuildDistributions < Base
+          CODE_ATTEMPT_TO_READ_FROM_CACHE_CANCELED = 'ATTEMPT_TO_READ_FROM_CACHE_CANCELED'
+
           class << self
             def subset(args)
+              request_hash = {
+                :fixed_test_suite_split => KnapsackPro::Config::Env.fixed_test_suite_split,
+                :attempt_to_read_from_cache => args.fetch(:attempt_to_read_from_cache),
+                :commit_hash => args.fetch(:commit_hash),
+                :branch => args.fetch(:branch),
+                :node_total => args.fetch(:node_total),
+                :node_index => args.fetch(:node_index),
+                :ci_build_id => KnapsackPro::Config::Env.ci_node_build_id,
+              }
+
+              unless request_hash[:attempt_to_read_from_cache]
+                request_hash.merge!({
+                  :test_files => args.fetch(:test_files)
+                })
+              end
+
               action_class.new(
                 endpoint_path: '/v1/build_distributions/subset',
                 http_method: :post,
-                request_hash: {
-                  :fixed_test_suite_split => KnapsackPro::Config::Env.fixed_test_suite_split,
-                  :commit_hash => args.fetch(:commit_hash),
-                  :branch => args.fetch(:branch),
-                  :node_total => args.fetch(:node_total),
-                  :node_index => args.fetch(:node_index),
-                  :test_files => args.fetch(:test_files)
-                }
+                request_hash: request_hash
               )
             end
 

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -62,7 +62,6 @@ module KnapsackPro
     end
 
     def build_action(can_initialize_queue, attempt_connect_to_queue:)
-      # read test files from disk only when needed because it can be slow operation
       test_files =
         if can_initialize_queue && !attempt_connect_to_queue
           encrypted_test_files

--- a/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/invalid_test_suite_token.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/invalid_test_suite_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.knapsackpro.test:3000/v1/build_distributions/subset
     body:
       encoding: UTF-8
-      string: '{"fixed_test_suite_split":true,"attempt_to_read_from_cache":true,"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
+      string: '{"fixed_test_suite_split":true,"cache_read_attempt":true,"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
     headers:
       Content-Type:
       - application/json
@@ -14,7 +14,7 @@ http_interactions:
       Knapsack-Pro-Client-Name:
       - knapsack_pro-ruby
       Knapsack-Pro-Client-Version:
-      - 3.4.2
+      - 3.5.0
       Knapsack-Pro-Test-Suite-Token:
       - fake
       Accept-Encoding:
@@ -43,16 +43,17 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - d0fc0868-1521-4351-b1aa-730649b01ecb
+      - a5ffe97f-4558-426b-9475-166eb89ab7cb
       X-Runtime:
-      - '0.038631'
+      - '0.231483'
       Server-Timing:
-      - sql.active_record;dur=7.25, start_processing.action_controller;dur=0.00, instantiation.active_record;dur=0.01,
-        halted_callback.action_controller;dur=0.00, process_action.action_controller;dur=8.93
+      - sql.active_record;dur=24.31, start_processing.action_controller;dur=0.00,
+        instantiation.active_record;dur=0.02, halted_callback.action_controller;dur=0.00,
+        process_action.action_controller;dur=15.10
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: '{"errors":["invalid test suite token"]}'
-  recorded_at: Tue, 22 Nov 2022 23:50:57 GMT
+  recorded_at: Thu, 08 Dec 2022 23:27:10 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/invalid_test_suite_token.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/invalid_test_suite_token.yml
@@ -5,12 +5,18 @@ http_interactions:
     uri: http://api.knapsackpro.test:3000/v1/build_distributions/subset
     body:
       encoding: UTF-8
-      string: '{"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb"},{"path":"b_spec.rb"}],"test_suite_token":"fake"}'
+      string: '{"fixed_test_suite_split":true,"attempt_to_read_from_cache":true,"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
+      Knapsack-Pro-Client-Name:
+      - knapsack_pro-ruby
+      Knapsack-Pro-Client-Version:
+      - 3.4.2
+      Knapsack-Pro-Test-Suite-Token:
+      - fake
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       User-Agent:
@@ -18,33 +24,35 @@ http_interactions:
   response:
     status:
       code: 403
-      message: 'Forbidden '
+      message: Forbidden
     headers:
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       X-Content-Type-Options:
       - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
       Content-Type:
       - application/json; charset=utf-8
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 6d40fe71-7fad-449a-812f-9773429777ce
+      - d0fc0868-1521-4351-b1aa-730649b01ecb
       X-Runtime:
-      - '0.054890'
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
-      Date:
-      - Fri, 31 Jul 2015 16:09:00 GMT
-      Content-Length:
-      - '39'
-      Connection:
-      - Keep-Alive
+      - '0.038631'
+      Server-Timing:
+      - sql.active_record;dur=7.25, start_processing.action_controller;dur=0.00, instantiation.active_record;dur=0.01,
+        halted_callback.action_controller;dur=0.00, process_action.action_controller;dur=8.93
+      Transfer-Encoding:
+      - chunked
     body:
       encoding: UTF-8
       string: '{"errors":["invalid test suite token"]}'
-    http_version: 
-  recorded_at: Fri, 31 Jul 2015 16:09:00 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Tue, 22 Nov 2022 23:50:57 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/success.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/success.yml
@@ -5,12 +5,18 @@ http_interactions:
     uri: http://api.knapsackpro.test:3000/v1/build_distributions/subset
     body:
       encoding: UTF-8
-      string: '{"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb"},{"path":"b_spec.rb"}],"test_suite_token":"3fa64859337f6e56409d49f865d13fd7"}'
+      string: '{"fixed_test_suite_split":true,"attempt_to_read_from_cache":true,"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
+      Knapsack-Pro-Client-Name:
+      - knapsack_pro-ruby
+      Knapsack-Pro-Client-Version:
+      - 3.4.2
+      Knapsack-Pro-Test-Suite-Token:
+      - 3fa64859337f6e56409d49f865d13fd7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       User-Agent:
@@ -18,35 +24,41 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 'OK '
+      message: OK
     headers:
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       X-Content-Type-Options:
       - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"bba747f5e635a765e120718b7876d174"
+      - W/"580af2708793b77366473fbff34efab9"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 190e26fb-676b-4b85-9737-8a90d0cce310
+      - 12f18830-2f57-443b-8a80-d8fd8536857a
       X-Runtime:
-      - '0.639590'
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.2.3/2015-08-18)
-      Date:
-      - Tue, 28 Jun 2016 20:40:35 GMT
-      Content-Length:
-      - '137'
-      Connection:
-      - Keep-Alive
+      - '0.089243'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.01, sql.active_record;dur=26.60,
+        instantiation.active_record;dur=6.71, unpermitted_parameters.action_controller;dur=0.01,
+        process_action.action_controller;dur=64.32
+      Transfer-Encoding:
+      - chunked
     body:
       encoding: UTF-8
-      string: '{"build_distribution_id":"1f905f45-c203-40f1-9891-d9a91dd11245","node_index":1,"test_files":[{"path":"b_spec.rb","time_execution":null}]}'
-    http_version: 
-  recorded_at: Tue, 28 Jun 2016 20:40:35 GMT
-recorded_with: VCR 2.9.3
+      string: '{"message":"An attempt to read from the cached test suite split was
+        canceled due to a missing cache. If you see this message, everything works
+        as expected. Now Knapsack Pro client will repeat the request with a list of
+        test files to initialize a new test suite split in Regular Mode.","code":"ATTEMPT_TO_READ_FROM_CACHE_CANCELED"}'
+  recorded_at: Tue, 22 Nov 2022 23:50:32 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/success.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/success.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.knapsackpro.test:3000/v1/build_distributions/subset
     body:
       encoding: UTF-8
-      string: '{"fixed_test_suite_split":true,"attempt_to_read_from_cache":true,"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
+      string: '{"fixed_test_suite_split":true,"cache_read_attempt":true,"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
     headers:
       Content-Type:
       - application/json
@@ -14,7 +14,7 @@ http_interactions:
       Knapsack-Pro-Client-Name:
       - knapsack_pro-ruby
       Knapsack-Pro-Client-Version:
-      - 3.4.2
+      - 3.5.0
       Knapsack-Pro-Test-Suite-Token:
       - 3fa64859337f6e56409d49f865d13fd7
       Accept-Encoding:
@@ -41,24 +41,21 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"580af2708793b77366473fbff34efab9"
+      - W/"1f643e3528e8ff45d9d2d67ab7e32be1"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 12f18830-2f57-443b-8a80-d8fd8536857a
+      - 9b378323-c960-4868-894e-5ae0cdab8840
       X-Runtime:
-      - '0.089243'
+      - '0.273775'
       Server-Timing:
-      - start_processing.action_controller;dur=0.01, sql.active_record;dur=26.60,
-        instantiation.active_record;dur=6.71, unpermitted_parameters.action_controller;dur=0.01,
-        process_action.action_controller;dur=64.32
+      - sql.active_record;dur=55.90, start_processing.action_controller;dur=0.00,
+        unpermitted_parameters.action_controller;dur=0.01, instantiation.active_record;dur=10.69,
+        process_action.action_controller;dur=92.24
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"message":"An attempt to read from the cached test suite split was
-        canceled due to a missing cache. If you see this message, everything works
-        as expected. Now Knapsack Pro client will repeat the request with a list of
-        test files to initialize a new test suite split in Regular Mode.","code":"ATTEMPT_TO_READ_FROM_CACHE_CANCELED"}'
-  recorded_at: Tue, 22 Nov 2022 23:50:32 GMT
+      string: '{"code":"TEST_SUITE_SPLIT_CACHE_MISS"}'
+  recorded_at: Thu, 08 Dec 2022 23:27:07 GMT
 recorded_with: VCR 6.1.0

--- a/spec/integration/api/build_distributions_subset_spec.rb
+++ b/spec/integration/api/build_distributions_subset_spec.rb
@@ -6,7 +6,7 @@ describe 'Request API /v1/build_distributions/subset' do
 
   let(:action) do
     KnapsackPro::Client::API::V1::BuildDistributions.subset(
-      attempt_to_read_from_cache: true,
+      cache_read_attempt: true,
       commit_hash: 'abcdefg',
       branch: 'master',
       node_total: '2',

--- a/spec/integration/api/build_distributions_subset_spec.rb
+++ b/spec/integration/api/build_distributions_subset_spec.rb
@@ -6,6 +6,7 @@ describe 'Request API /v1/build_distributions/subset' do
 
   let(:action) do
     KnapsackPro::Client::API::V1::BuildDistributions.subset(
+      attempt_to_read_from_cache: true,
       commit_hash: 'abcdefg',
       branch: 'master',
       node_total: '2',

--- a/spec/knapsack_pro/allocator_spec.rb
+++ b/spec/knapsack_pro/allocator_spec.rb
@@ -78,12 +78,12 @@ describe KnapsackPro::Allocator do
 
       action = double
       expect(KnapsackPro::Client::API::V1::BuildDistributions).to receive(:subset).with({
-        attempt_to_read_from_cache: true,
+        cache_read_attempt: true,
         commit_hash: repository_adapter.commit_hash,
         branch: encrypted_branch,
         node_total: ci_node_total,
         node_index: ci_node_index,
-        test_files: nil, # when `attempt_to_read_from_cache=true` then expect `test_files` is `nil` to make the request fast
+        test_files: nil, # when `cache_read_attempt=true` then expect `test_files` is `nil` to make the request fast due to small payload
       }).and_return(action)
 
       connection = instance_double(KnapsackPro::Client::Connection,
@@ -125,11 +125,11 @@ describe KnapsackPro::Allocator do
           it { should eq ['a_spec.rb', 'b_spec.rb'] }
         end
 
-        context 'when the response has the API code=ATTEMPT_TO_READ_FROM_CACHE_CANCELED' do
+        context 'when the response has the API code=TEST_SUITE_SPLIT_CACHE_MISS' do
           let(:response) do
-            { 'code' => 'ATTEMPT_TO_READ_FROM_CACHE_CANCELED' }
+            { 'code' => 'TEST_SUITE_SPLIT_CACHE_MISS' }
           end
-          let(:api_code) { 'ATTEMPT_TO_READ_FROM_CACHE_CANCELED' }
+          let(:api_code) { 'TEST_SUITE_SPLIT_CACHE_MISS' }
 
           before do
             encrypted_branch = double
@@ -142,7 +142,7 @@ describe KnapsackPro::Allocator do
             # Try to initalize a new test suite split by sending a list of test files from disk.
             action = double
             expect(KnapsackPro::Client::API::V1::BuildDistributions).to receive(:subset).with({
-              attempt_to_read_from_cache: false,
+              cache_read_attempt: false,
               commit_hash: repository_adapter.commit_hash,
               branch: encrypted_branch,
               node_total: ci_node_total,

--- a/spec/knapsack_pro/allocator_spec.rb
+++ b/spec/knapsack_pro/allocator_spec.rb
@@ -17,66 +17,11 @@ describe KnapsackPro::Allocator do
 
   describe '#test_file_paths' do
     let(:response) { double }
+    let(:api_code) { nil }
 
     subject { allocator.test_file_paths }
 
-    before do
-      encrypted_test_files = double
-      expect(KnapsackPro::Crypto::Encryptor).to receive(:call).with(fast_and_slow_test_files_to_run).and_return(encrypted_test_files)
-
-      encrypted_branch = double
-      expect(KnapsackPro::Crypto::BranchEncryptor).to receive(:call).with(repository_adapter.branch).and_return(encrypted_branch)
-
-      action = double
-      expect(KnapsackPro::Client::API::V1::BuildDistributions).to receive(:subset).with({
-        commit_hash: repository_adapter.commit_hash,
-        branch: encrypted_branch,
-        node_total: ci_node_total,
-        node_index: ci_node_index,
-        test_files: encrypted_test_files,
-      }).and_return(action)
-
-      connection = instance_double(KnapsackPro::Client::Connection,
-                                   call: response,
-                                   success?: success?,
-                                   errors?: errors?)
-      expect(KnapsackPro::Client::Connection).to receive(:new).with(action).and_return(connection)
-    end
-
-    context 'when successful request to API' do
-      let(:success?) { true }
-
-      context 'when response has errors' do
-        let(:errors?) { true }
-
-        it do
-          expect { subject }.to raise_error(ArgumentError)
-        end
-      end
-
-      context 'when response has no errors' do
-        let(:errors?) { false }
-        let(:response) do
-          {
-            'test_files' => [
-              { 'path' => 'a_spec.rb' },
-              { 'path' => 'b_spec.rb' },
-            ]
-          }
-        end
-
-        before do
-          expect(KnapsackPro::Crypto::Decryptor).to receive(:call).with(fast_and_slow_test_files_to_run, response['test_files']).and_call_original
-        end
-
-        it { should eq ['a_spec.rb', 'b_spec.rb'] }
-      end
-    end
-
-    context 'when not successful request to API' do
-      let(:success?) { false }
-      let(:errors?) { false }
-
+    shared_examples_for 'when connection to API failed (fallback mode)' do
       context 'when fallback mode is disabled' do
         before do
           expect(KnapsackPro::Config::Env).to receive(:fallback_mode_enabled?).and_return(false)
@@ -125,6 +70,144 @@ describe KnapsackPro::Allocator do
 
         it { should eq ['c_spec.rb', 'd_spec.rb'] }
       end
+    end
+
+    before do
+      encrypted_branch = double
+      expect(KnapsackPro::Crypto::BranchEncryptor).to receive(:call).with(repository_adapter.branch).and_return(encrypted_branch)
+
+      action = double
+      expect(KnapsackPro::Client::API::V1::BuildDistributions).to receive(:subset).with({
+        attempt_to_read_from_cache: true,
+        commit_hash: repository_adapter.commit_hash,
+        branch: encrypted_branch,
+        node_total: ci_node_total,
+        node_index: ci_node_index,
+        test_files: nil, # when `attempt_to_read_from_cache=true` then expect `test_files` is `nil` to make the request fast
+      }).and_return(action)
+
+      connection = instance_double(KnapsackPro::Client::Connection,
+                                   call: response,
+                                   success?: success?,
+                                   errors?: errors?,
+                                   api_code: api_code)
+      expect(KnapsackPro::Client::Connection).to receive(:new).with(action).and_return(connection)
+    end
+
+    context 'when successful request to API' do
+      let(:success?) { true }
+
+      context 'when response has errors' do
+        let(:errors?) { true }
+
+        it do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'when response has no errors' do
+        let(:errors?) { false }
+
+        context 'when the response returns test files (successful attempt to read from the cache - the cached test suite split exists on the API side)' do
+          let(:response) do
+            {
+              'test_files' => [
+                { 'path' => 'a_spec.rb' },
+                { 'path' => 'b_spec.rb' },
+              ]
+            }
+          end
+
+          before do
+            expect(KnapsackPro::Crypto::Decryptor).to receive(:call).with(fast_and_slow_test_files_to_run, response['test_files']).and_call_original
+          end
+
+          it { should eq ['a_spec.rb', 'b_spec.rb'] }
+        end
+
+        context 'when the response has the API code=ATTEMPT_TO_READ_FROM_CACHE_CANCELED' do
+          let(:response) do
+            { 'code' => 'ATTEMPT_TO_READ_FROM_CACHE_CANCELED' }
+          end
+          let(:api_code) { 'ATTEMPT_TO_READ_FROM_CACHE_CANCELED' }
+
+          before do
+            encrypted_branch = double
+            expect(KnapsackPro::Crypto::BranchEncryptor).to receive(:call).with(repository_adapter.branch).and_return(encrypted_branch)
+
+            encrypted_test_files = double
+            expect(KnapsackPro::Crypto::Encryptor).to receive(:call).with(fast_and_slow_test_files_to_run).and_return(encrypted_test_files)
+
+            # 2nd request is not an attempt to read from the cache.
+            # Try to initalize a new test suite split by sending a list of test files from disk.
+            action = double
+            expect(KnapsackPro::Client::API::V1::BuildDistributions).to receive(:subset).with({
+              attempt_to_read_from_cache: false,
+              commit_hash: repository_adapter.commit_hash,
+              branch: encrypted_branch,
+              node_total: ci_node_total,
+              node_index: ci_node_index,
+              test_files: encrypted_test_files,
+            }).and_return(action)
+
+            connection = instance_double(KnapsackPro::Client::Connection,
+                                         call: response2,
+                                         success?: response2_success?,
+                                         errors?: response2_errors?,
+                                         api_code: nil)
+            expect(KnapsackPro::Client::Connection).to receive(:new).with(action).and_return(connection)
+          end
+
+          context 'when successful 2nd request to API' do
+            let(:response2_success?) { true }
+
+            context 'when 2nd response has errors' do
+              let(:response2_errors?) { true }
+              let(:response2) { nil }
+
+              it do
+                expect { subject }.to raise_error(ArgumentError)
+              end
+            end
+
+            context 'when 2nd response has no errors' do
+              let(:response2_errors?) { false }
+
+              context 'when 2nd response returns test files' do
+                let(:response2) do
+                  {
+                    'test_files' => [
+                      { 'path' => 'a_spec.rb' },
+                      { 'path' => 'b_spec.rb' },
+                    ]
+                  }
+                end
+
+                before do
+                  expect(KnapsackPro::Crypto::Decryptor).to receive(:call).with(fast_and_slow_test_files_to_run, response2['test_files']).and_call_original
+                end
+
+                it { should eq ['a_spec.rb', 'b_spec.rb'] }
+              end
+            end
+          end
+
+          context 'when not successful 2nd request to API' do
+            let(:response2_success?) { false }
+            let(:response2_errors?) { false }
+            let(:response2) { nil }
+
+            it_behaves_like 'when connection to API failed (fallback mode)'
+          end
+        end
+      end
+    end
+
+    context 'when not successful request to API' do
+      let(:success?) { false }
+      let(:errors?) { false }
+
+      it_behaves_like 'when connection to API failed (fallback mode)'
     end
   end
 end

--- a/spec/knapsack_pro/allocator_spec.rb
+++ b/spec/knapsack_pro/allocator_spec.rb
@@ -83,7 +83,7 @@ describe KnapsackPro::Allocator do
         branch: encrypted_branch,
         node_total: ci_node_total,
         node_index: ci_node_index,
-        test_files: nil, # when `cache_read_attempt=true` then expect `test_files` is `nil` to make the request fast due to small payload
+        test_files: nil, # when `cache_read_attempt=true`, then expect `test_files` is `nil` to make the request fast due to a small payload
       }).and_return(action)
 
       connection = instance_double(KnapsackPro::Client::Connection,
@@ -139,7 +139,7 @@ describe KnapsackPro::Allocator do
             expect(KnapsackPro::Crypto::Encryptor).to receive(:call).with(fast_and_slow_test_files_to_run).and_return(encrypted_test_files)
 
             # 2nd request is not an attempt to read from the cache.
-            # Try to initalize a new test suite split by sending a list of test files from disk.
+            # Try to initalize a new test suite split by sending a list of test files from the disk.
             action = double
             expect(KnapsackPro::Client::API::V1::BuildDistributions).to receive(:subset).with({
               cache_read_attempt: false,

--- a/spec/knapsack_pro/client/api/v1/build_distributions_spec.rb
+++ b/spec/knapsack_pro/client/api/v1/build_distributions_spec.rb
@@ -5,10 +5,12 @@ describe KnapsackPro::Client::API::V1::BuildDistributions do
     let(:branch) { double }
     let(:node_total) { double }
     let(:node_index) { double }
+    let(:ci_build_id) { double }
     let(:test_files) { double }
 
     subject do
       described_class.subset(
+        attempt_to_read_from_cache: attempt_to_read_from_cache,
         commit_hash: commit_hash,
         branch: branch,
         node_total: node_total,
@@ -19,23 +21,52 @@ describe KnapsackPro::Client::API::V1::BuildDistributions do
 
     before do
       expect(KnapsackPro::Config::Env).to receive(:fixed_test_suite_split).and_return(fixed_test_suite_split)
+      expect(KnapsackPro::Config::Env).to receive(:ci_node_build_id).and_return(ci_build_id)
     end
 
-    it do
-      action = double
-      expect(KnapsackPro::Client::API::Action).to receive(:new).with({
-        endpoint_path: '/v1/build_distributions/subset',
-        http_method: :post,
-        request_hash: {
-          fixed_test_suite_split: fixed_test_suite_split,
-          commit_hash: commit_hash,
-          branch: branch,
-          node_total: node_total,
-          node_index: node_index,
-          test_files: test_files
-        }
-      }).and_return(action)
-      expect(subject).to eq action
+    context 'when attempt_to_read_from_cache=true' do
+      let(:attempt_to_read_from_cache) { true }
+
+      it 'does not send test_files among other params' do
+        action = double
+        expect(KnapsackPro::Client::API::Action).to receive(:new).with({
+          endpoint_path: '/v1/build_distributions/subset',
+          http_method: :post,
+          request_hash: {
+            fixed_test_suite_split: fixed_test_suite_split,
+            attempt_to_read_from_cache: attempt_to_read_from_cache,
+            commit_hash: commit_hash,
+            branch: branch,
+            node_total: node_total,
+            node_index: node_index,
+            ci_build_id: ci_build_id,
+          }
+        }).and_return(action)
+        expect(subject).to eq action
+      end
+    end
+
+    context 'when attempt_to_read_from_cache=false' do
+      let(:attempt_to_read_from_cache) { false }
+
+      it 'sends test_files among other params' do
+        action = double
+        expect(KnapsackPro::Client::API::Action).to receive(:new).with({
+          endpoint_path: '/v1/build_distributions/subset',
+          http_method: :post,
+          request_hash: {
+            fixed_test_suite_split: fixed_test_suite_split,
+            attempt_to_read_from_cache: attempt_to_read_from_cache,
+            commit_hash: commit_hash,
+            branch: branch,
+            node_total: node_total,
+            node_index: node_index,
+            ci_build_id: ci_build_id,
+            test_files: test_files
+          }
+        }).and_return(action)
+        expect(subject).to eq action
+      end
     end
   end
 

--- a/spec/knapsack_pro/client/api/v1/build_distributions_spec.rb
+++ b/spec/knapsack_pro/client/api/v1/build_distributions_spec.rb
@@ -10,7 +10,7 @@ describe KnapsackPro::Client::API::V1::BuildDistributions do
 
     subject do
       described_class.subset(
-        attempt_to_read_from_cache: attempt_to_read_from_cache,
+        cache_read_attempt: cache_read_attempt,
         commit_hash: commit_hash,
         branch: branch,
         node_total: node_total,
@@ -24,8 +24,8 @@ describe KnapsackPro::Client::API::V1::BuildDistributions do
       expect(KnapsackPro::Config::Env).to receive(:ci_node_build_id).and_return(ci_build_id)
     end
 
-    context 'when attempt_to_read_from_cache=true' do
-      let(:attempt_to_read_from_cache) { true }
+    context 'when cache_read_attempt=true' do
+      let(:cache_read_attempt) { true }
 
       it 'does not send test_files among other params' do
         action = double
@@ -34,7 +34,7 @@ describe KnapsackPro::Client::API::V1::BuildDistributions do
           http_method: :post,
           request_hash: {
             fixed_test_suite_split: fixed_test_suite_split,
-            attempt_to_read_from_cache: attempt_to_read_from_cache,
+            cache_read_attempt: cache_read_attempt,
             commit_hash: commit_hash,
             branch: branch,
             node_total: node_total,
@@ -46,8 +46,8 @@ describe KnapsackPro::Client::API::V1::BuildDistributions do
       end
     end
 
-    context 'when attempt_to_read_from_cache=false' do
-      let(:attempt_to_read_from_cache) { false }
+    context 'when cache_read_attempt=false' do
+      let(:cache_read_attempt) { false }
 
       it 'sends test_files among other params' do
         action = double
@@ -56,7 +56,7 @@ describe KnapsackPro::Client::API::V1::BuildDistributions do
           http_method: :post,
           request_hash: {
             fixed_test_suite_split: fixed_test_suite_split,
-            attempt_to_read_from_cache: attempt_to_read_from_cache,
+            cache_read_attempt: cache_read_attempt,
             commit_hash: commit_hash,
             branch: branch,
             node_total: node_total,

--- a/spec/knapsack_pro/queue_allocator_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_spec.rb
@@ -147,10 +147,7 @@ describe KnapsackPro::QueueAllocator do
             it { should eq ['a_spec.rb', 'b_spec.rb'] }
           end
 
-          context 'when response has code=ATTEMPT_CONNECT_TO_QUEUE_FAILED' do
-            let(:response) do
-              { 'code' => 'ATTEMPT_CONNECT_TO_QUEUE_FAILED' }
-            end
+          context 'when the response has the API code=ATTEMPT_CONNECT_TO_QUEUE_FAILED' do
             let(:api_code) { 'ATTEMPT_CONNECT_TO_QUEUE_FAILED' }
 
             before do
@@ -197,7 +194,7 @@ describe KnapsackPro::QueueAllocator do
               context 'when 2nd response has no errors' do
                 let(:response2_errors?) { false }
 
-                context 'when 2nd response returns test files (successful attempt to connect to queue already existing on the API side)' do
+                context 'when 2nd response returns test files (successfully initialized a new queue or connected to an existing queue on the API side)' do
                   let(:response2) do
                     {
                       'test_files' => [


### PR DESCRIPTION
Add an attempt to read from the cache for Regular Mode API.

This way, we can read the test suite split from the cache, and there is no need to send `test_files` in the request payload from the knapsack_pro gem for all parallel CI nodes.
This allows using Regular Mode with a large test suite (many thousands of test files across hundreds of parallel CI nodes) because requests from parallel CI nodes are fast. There is a limited number of slow requests with a big list of test files in the request payload.

# related PRs

* https://github.com/KnapsackPro/rails-app-with-knapsack_pro/pull/43
* https://github.com/KnapsackPro/docs.knapsackpro.com/pull/94

# related old PR

This PR is inspired by the improvement made for Queue Mode:

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/133
  * follow up improvement https://github.com/KnapsackPro/knapsack_pro-ruby/pull/135
