### PR TITLE
Add before_subset_queue hook in queue mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 3.5.0
+
+* Add the `KnapsackPro::Hooks::Queue.before_subset_queue` hook in Queue Mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/183
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v3.4.2...v3.5.0
+
 ### 3.4.2
 
 * Fix: Load `rspec/core` in Regular Mode when using RSpec split by test examples feature

--- a/lib/knapsack_pro/hooks/queue.rb
+++ b/lib/knapsack_pro/hooks/queue.rb
@@ -3,11 +3,16 @@ module KnapsackPro
     class Queue
       class << self
         attr_reader :before_queue_store,
+          :before_subset_queue_store,
           :after_subset_queue_store,
           :after_queue_store
 
         def reset_before_queue
           @before_queue_store = nil
+        end
+
+        def reset_before_subset_queue
+          @reset_before_subset_queue = nil
         end
 
         def reset_after_subset_queue
@@ -21,6 +26,11 @@ module KnapsackPro
         def before_queue(&block)
           @before_queue_store ||= []
           @before_queue_store << block
+        end
+
+        def before_subset_queue(&block)
+          @before_subset_queue_store ||= []
+          @before_subset_queue_store << block
         end
 
         def after_subset_queue(&block)
@@ -38,6 +48,16 @@ module KnapsackPro
           before_queue_store.each do |block|
             block.call(
               KnapsackPro::Config::Env.queue_id
+            )
+          end
+        end
+
+        def call_before_subset_queue
+          return unless before_subset_queue_store
+          before_subset_queue_store.each do |block|
+            block.call(
+              KnapsackPro::Config::Env.queue_id,
+              KnapsackPro::Config::Env.subset_queue_id
             )
           end
         end

--- a/lib/knapsack_pro/hooks/queue.rb
+++ b/lib/knapsack_pro/hooks/queue.rb
@@ -12,7 +12,7 @@ module KnapsackPro
         end
 
         def reset_before_subset_queue
-          @reset_before_subset_queue = nil
+          @before_subset_queue_store = nil
         end
 
         def reset_after_subset_queue

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -60,6 +60,8 @@ module KnapsackPro
             KnapsackPro.tracker.reset!
             KnapsackPro.tracker.set_prerun_tests(test_file_paths)
 
+            KnapsackPro::Hooks::Queue.call_before_subset_queue
+
             all_test_file_paths += test_file_paths
 
             result_exitstatus = cucumber_run(runner, test_file_paths, args)

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -67,6 +67,8 @@ module KnapsackPro
             KnapsackPro.tracker.reset!
             KnapsackPro.tracker.set_prerun_tests(test_file_paths)
 
+            KnapsackPro::Hooks::Queue.call_before_subset_queue
+
             all_test_file_paths += test_file_paths
 
             result = minitest_run(runner, test_file_paths, args)

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -82,6 +82,8 @@ module KnapsackPro
             KnapsackPro.tracker.reset!
             KnapsackPro.tracker.set_prerun_tests(test_file_paths)
 
+            KnapsackPro::Hooks::Queue.call_before_subset_queue
+
             all_test_file_paths += test_file_paths
             cli_args = args + test_file_paths
 

--- a/spec/knapsack_pro/hooks/queue_spec.rb
+++ b/spec/knapsack_pro/hooks/queue_spec.rb
@@ -37,6 +37,46 @@ describe KnapsackPro::Hooks::Queue do
     end
   end
 
+  describe '.call_before_subset_queue' do
+    subject { described_class.call_before_subset_queue }
+
+    context 'when callback is not set' do
+      before do
+        described_class.reset_before_subset_queue
+      end
+
+      it { should be_nil }
+    end
+
+    context 'when callback is set multiple times' do
+      let(:queue_id) { double }
+      let(:subset_queue_id) { double }
+
+      before do
+        expect(KnapsackPro::Config::Env).to receive(:queue_id).twice.and_return(queue_id)
+        expect(KnapsackPro::Config::Env).to receive(:subset_queue_id).twice.and_return(subset_queue_id)
+
+        $expected_called_blocks = []
+
+        described_class.before_subset_queue do |q_id, subset_q_id|
+          $expected_called_blocks << [:block_1_called, q_id, subset_q_id]
+        end
+        described_class.before_subset_queue do |q_id, subset_q_id|
+          $expected_called_blocks << [:block_2_called, q_id, subset_q_id]
+        end
+      end
+
+      it 'each block is called' do
+        subject
+
+        expect($expected_called_blocks).to eq([
+          [:block_1_called, queue_id, subset_queue_id],
+          [:block_2_called, queue_id, subset_queue_id],
+        ])
+      end
+    end
+  end
+
   describe '.call_after_subset_queue' do
     subject { described_class.call_after_subset_queue }
 

--- a/spec/knapsack_pro/runners/queue/cucumber_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/cucumber_runner_spec.rb
@@ -115,6 +115,8 @@ describe KnapsackPro::Runners::Queue::CucumberRunner do
         expect(tracker).to receive(:reset!)
         expect(tracker).to receive(:set_prerun_tests).with(test_file_paths)
 
+        expect(KnapsackPro::Hooks::Queue).to receive(:call_before_subset_queue)
+
         # .cucumber_run
         expect(Kernel).to receive(:system).with('bundle exec cucumber --retry 5 --no-strict-flaky --require fake-features-dir -- "features/a.feature" "features/b.feature"')
 

--- a/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
@@ -125,6 +125,7 @@ describe KnapsackPro::Runners::Queue::MinitestRunner do
 
         expect(Minitest::Runnable).to receive(:reset)
 
+        expect(KnapsackPro::Hooks::Queue).to receive(:call_before_subset_queue)
 
         expect(KnapsackPro::Hooks::Queue).to receive(:call_after_subset_queue)
 

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -225,6 +225,8 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
         expect(described_class).to receive(:rspec_clear_examples)
 
+        expect(KnapsackPro::Hooks::Queue).to receive(:call_before_subset_queue)
+
         expect(KnapsackPro::Hooks::Queue).to receive(:call_after_subset_queue)
 
         expect(KnapsackPro::Report).to receive(:save_subset_queue_to_file)


### PR DESCRIPTION
Currently there is only `after_subset_queue` hook and only works when subset finished. Adding a before subset hook to provide an ability to access to the subset queue to preserve some information beforehand which might be loss while CI node terminated in the middle of processing.