### PR TITLE
Adjust the timer behaviour in the RSpec adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 3.7.0
+
+* Adjust the timer behaviour in the RSpec adapter
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/184
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v3.6.0...v3.7.0
+
 ### 3.6.0
 
 * Add an attempt to read from the cache for Regular Mode API

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -48,11 +48,15 @@ module KnapsackPro
           end
 
           config.around(:each) do |example|
-            # stop timer to update time for a previously run test example
-            # this way we count time spend in runtime for the previous test example after around(:each) is already done
-            KnapsackPro.tracker.stop_timer
-
             current_test_path = KnapsackPro::Adapters::RSpecAdapter.test_path(example)
+
+            # Stop timer to update time for a previously run test example.
+            # This way we count time spent in runtime for the previous test example after around(:each) is already done.
+            # Only do that if we're in the same test file. Otherwise, `before(:all)` execution time in the current file
+            # will be applied to the previously ran test file.
+            if KnapsackPro.tracker.current_test_path&.start_with?(KnapsackPro::TestFileCleaner.clean(current_test_path))
+              KnapsackPro.tracker.stop_timer
+            end
 
             KnapsackPro.tracker.current_test_path =
               if KnapsackPro::Config::Env.rspec_split_by_test_examples? && KnapsackPro::Adapters::RSpecAdapter.slow_test_file?(RSpecAdapter, current_test_path)

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -46,7 +46,8 @@ module KnapsackPro
     end
 
     def current_test_path
-      raise("current_test_path needs to be set by Knapsack Pro Adapter's bind method") unless @current_test_path
+      return unless @current_test_path
+
       KnapsackPro::TestFileCleaner.clean(@current_test_path)
     end
 

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -243,6 +243,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
           expect(config).to receive(:around).with(:each).and_yield(current_example)
           expect(::RSpec).to receive(:configure).and_yield(config)
 
+          expect(tracker).to receive(:current_test_path).ordered.and_return(test_path)
           expect(tracker).to receive(:stop_timer).ordered
 
           expect(described_class).to receive(:test_path).with(current_example).and_return(test_path)
@@ -273,6 +274,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
           expect(config).to receive(:after).with(:suite).and_yield
           expect(::RSpec).to receive(:configure).and_yield(config)
 
+          expect(tracker).to receive(:current_test_path).ordered.and_return(test_path)
           expect(tracker).to receive(:stop_timer).ordered
 
           expect(described_class).to receive(:test_path).with(current_example).and_return(test_path)
@@ -316,6 +318,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
             expect(config).to receive(:after).with(:suite).and_yield
             expect(::RSpec).to receive(:configure).and_yield(config)
 
+            expect(tracker).to receive(:current_test_path).ordered.and_return(test_path)
             expect(tracker).to receive(:stop_timer).ordered
 
             expect(described_class).to receive(:test_path).with(current_example).and_return(test_path)
@@ -352,6 +355,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
 
             expect(described_class).to receive(:test_path).with(current_example).and_return(test_path)
 
+            expect(tracker).to receive(:current_test_path).ordered.and_return(test_path)
             expect(tracker).to receive(:stop_timer).ordered
 
             expect(tracker).to receive(:current_test_path=).with(test_path).ordered

--- a/spec/knapsack_pro/tracker_spec.rb
+++ b/spec/knapsack_pro/tracker_spec.rb
@@ -19,9 +19,7 @@ describe KnapsackPro::Tracker do
     subject { tracker.current_test_path }
 
     context 'when current_test_path not set' do
-      it do
-        expect { subject }.to raise_error("current_test_path needs to be set by Knapsack Pro Adapter's bind method")
-      end
+      it { should eql nil }
     end
 
     context 'when current_test_path set' do


### PR DESCRIPTION
Prevent the timer being stopped in the same test file.

Shout-out to @evanlok for the inspiration and code example