### PR TITLE
Fix a flaky test for a tracker

### DIFF
--- a/spec/knapsack_pro/tracker_spec.rb
+++ b/spec/knapsack_pro/tracker_spec.rb
@@ -102,6 +102,7 @@ describe KnapsackPro::Tracker do
       before do
         test_paths.each_with_index do |test_path, index|
           tracker.current_test_path = test_path
+          sleep 0.001
           tracker.stop_timer
         end
       end


### PR DESCRIPTION
You could reproduce it with:

```
rspec --seed 4497 spec/knapsack_pro/tracker_spec.rb
```

OR

```
rspec --seed 4497 spec/knapsack_pro/tracker_spec.rb:101
```

OR 

you could keep running the test file a few times till you see an error. The flaky tests failed with the following error:

```
➜  knapsack_pro-ruby git:(master) rspec spec/knapsack_pro/tracker_spec.rb:101
Run options: include {:locations=>{"./spec/knapsack_pro/tracker_spec.rb"=>[101]}}

Randomized with seed 64227

KnapsackPro::Tracker
  track time execution
    when start timer was not called (rspec-retry issue)
      is expected to eq 0
      2nd spec (b_spec.rb) should have recorded time execution - because start_time was set during first call of stop_timer for the first spec (a_spec.rb) (FAILED - 1)
      is expected to eql 2
      is expected to equal true
      is expected to be > 0 (FAILED - 2)
      behaves like #to_a
        is expected to be >= 0
        is expected to eq "a_spec.rb"
        is expected to be >= 0
        is expected to eq "b_spec.rb"
        size
          is expected to eq 2

Failures:

  1) KnapsackPro::Tracker track time execution when start timer was not called (rspec-retry issue) 2nd spec (b_spec.rb) should have recorded time execution - because start_time was set during first call of stop_timer for the first spec (a_spec.rb)
     Failure/Error: expect(tracker.test_files_with_time['b_spec.rb'][:time_execution]).to be > 0

       expected: > 0
            got:   0.0
     # ./spec/knapsack_pro/tracker_spec.rb:114:in `block (4 levels) in <top (required)>'
     # /Users/artur/.rvm/gems/ruby-3.1.2/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

  2) KnapsackPro::Tracker track time execution when start timer was not called (rspec-retry issue) is expected to be > 0
     Failure/Error: it { expect(tracker.global_time).to be > 0 }

       expected: > 0
            got:   0.0
     # ./spec/knapsack_pro/tracker_spec.rb:109:in `block (4 levels) in <top (required)>'
     # /Users/artur/.rvm/gems/ruby-3.1.2/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

Finished in 0.01101 seconds (files took 0.18846 seconds to load)
10 examples, 2 failures

Failed examples:

rspec ./spec/knapsack_pro/tracker_spec.rb:113 # KnapsackPro::Tracker track time execution when start timer was not called (rspec-retry issue) 2nd spec (b_spec.rb) should have recorded time execution - because start_time was set during first call of stop_timer for the first spec (a_spec.rb)
rspec ./spec/knapsack_pro/tracker_spec.rb:109 # KnapsackPro::Tracker track time execution when start timer was not called (rspec-retry issue) is expected to be > 0

Randomized with seed 64227
```

# solution

Add some delay to simulate the test file took some time to execute.