### PR TITLE
Suppress all RSpec spec file names displayed in stdout at the beginning of running tests in Regular Mode only when the log level is >= `warn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 3.9.0
+
+* Suppress all RSpec spec file names displayed in stdout at the beginning of running tests in Regular Mode only when the log level is >= `warn`
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/190
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v3.8.0...v3.9.0
+
 ### 3.8.0
 
 * Extract URLs and point them at `https://knapsackpro.com/perma/ruby/*`

--- a/lib/knapsack_pro/runners/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/rspec_runner.rb
@@ -32,6 +32,7 @@ module KnapsackPro
             # instead we pass test files and test example paths to t.rspec_opts
             t.pattern = []
             t.rspec_opts = "#{args} --default-path #{runner.test_dir} #{runner.stringify_test_file_paths}"
+            t.verbose = KnapsackPro::Config::Env.log_level < ::Logger::WARN
           end
           Rake::Task[task_name].invoke
         end


### PR DESCRIPTION
In Regular Mode, we use RSpec::Core::RakeTask. By default, it prints an RSpec command with all test files and options provided to it. For a big test suite, this can be a large output.
We can suppress that with a verbose false option for the rake task only when [the log level is >= `warn`](https://docs.knapsackpro.com/ruby/reference/#knapsack_pro_log_level). 

# related issue

* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/189

# related

https://stackoverflow.com/a/26299828/905697