### PR TITLE
Fix broken RSpec split by test examples feature when `SPEC_OPTS` is set in Queue Mode. Ignore `SPEC_OPTS` when generating test examples report for slow test files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 5.1.2
 
-* Fix broken RSpec split by test examples feature when `SPEC_OPTS` is set in Queue Mode
+* Fix broken RSpec split by test examples feature when `SPEC_OPTS` is set in Queue Mode. Ignore `SPEC_OPTS` when generating test examples report for slow test files.
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/191
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 5.1.2
+
+* Fix broken RSpec split by test examples feature when `SPEC_OPTS` is set in Queue Mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/191
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v5.1.1...v5.1.2
+
 ### 5.1.1
 
 * Use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` as default value in Queue Mode for GitLab CI

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -87,9 +87,7 @@ module KnapsackPro
             all_test_file_paths += test_file_paths
             cli_args = args + test_file_paths
 
-            if ENV['SPEC_OPTS'] && !ENV['SPEC_OPTS'].include?(KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s)
-              ENV['SPEC_OPTS'] = ENV['SPEC_OPTS'] + " --format #{KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s}"
-            end
+            ensure_spec_opts_have_rspec_queue_summary_formatter
             options = ::RSpec::Core::ConfigurationOptions.new(cli_args)
             rspec_runner = ::RSpec::Core::Runner.new(options)
 
@@ -182,6 +180,15 @@ module KnapsackPro
           @@used_seed = rspec_runner.configuration.seed.to_s
 
           args + ['--seed', @@used_seed]
+        end
+
+        def self.ensure_spec_opts_have_rspec_queue_summary_formatter
+          spec_opts = ENV['SPEC_OPTS']
+
+          return unless spec_opts
+          return if spec_opts.include?(KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s)
+
+          ENV['SPEC_OPTS'] = "#{spec_opts} --format #{KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s}"
         end
       end
     end

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -87,6 +87,9 @@ module KnapsackPro
             all_test_file_paths += test_file_paths
             cli_args = args + test_file_paths
 
+            if ENV['SPEC_OPTS'] && !ENV['SPEC_OPTS'].include?(KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s)
+              ENV['SPEC_OPTS'] = ENV['SPEC_OPTS'] + " --format #{KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s}"
+            end
             options = ::RSpec::Core::ConfigurationOptions.new(cli_args)
             rspec_runner = ::RSpec::Core::Runner.new(options)
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -114,6 +114,15 @@ module KnapsackPro
           end
         end
 
+        def self.ensure_spec_opts_have_rspec_queue_summary_formatter
+          spec_opts = ENV['SPEC_OPTS']
+
+          return unless spec_opts
+          return if spec_opts.include?(KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s)
+
+          ENV['SPEC_OPTS'] = "#{spec_opts} --format #{KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s}"
+        end
+
         private
 
         def self.adapter_class
@@ -180,15 +189,6 @@ module KnapsackPro
           @@used_seed = rspec_runner.configuration.seed.to_s
 
           args + ['--seed', @@used_seed]
-        end
-
-        def self.ensure_spec_opts_have_rspec_queue_summary_formatter
-          spec_opts = ENV['SPEC_OPTS']
-
-          return unless spec_opts
-          return if spec_opts.include?(KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s)
-
-          ENV['SPEC_OPTS'] = "#{spec_opts} --format #{KnapsackPro::Formatters::RSpecQueueSummaryFormatter.to_s}"
         end
       end
     end

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -7,6 +7,8 @@ namespace :knapsack_pro do
 
   desc "Generate JSON report for test suite based on default test pattern or based on defined pattern with ENV vars"
   task :rspec_test_example_detector do
+    # disable `SPEC_OPTS` to not affect the RSpec executed within the rake task
+    ENV.delete('SPEC_OPTS')
     detector = KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector.new
     detector.generate_json_report
   end

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -7,8 +7,9 @@ namespace :knapsack_pro do
 
   desc "Generate JSON report for test suite based on default test pattern or based on defined pattern with ENV vars"
   task :rspec_test_example_detector do
-    # disable `SPEC_OPTS` to not affect the RSpec executed within the rake task
+    # ignore the `SPEC_OPTS` options to not affect RSpec execution within this rake task
     ENV.delete('SPEC_OPTS')
+
     detector = KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector.new
     detector.generate_json_report
   end

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -212,6 +212,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
         expect(tracker).to receive(:reset!)
         expect(tracker).to receive(:set_prerun_tests).with(test_file_paths)
 
+        expect(described_class).to receive(:ensure_spec_opts_have_rspec_queue_summary_formatter)
         options = double
         expect(RSpec::Core::ConfigurationOptions).to receive(:new).with([
           '--no-color',
@@ -336,6 +337,41 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
             exitstatus: exitstatus,
           })
         end
+      end
+    end
+  end
+
+  describe '.ensure_spec_opts_have_rspec_queue_summary_formatter' do
+    subject { described_class.ensure_spec_opts_have_rspec_queue_summary_formatter }
+
+    context 'when `SPEC_OPTS` is set' do
+      context 'when `SPEC_OPTS` has RSpec Queue Summary Formatter' do
+        before do
+          stub_const('ENV', { 'SPEC_OPTS' => '--format json --format KnapsackPro::Formatters::RSpecQueueSummaryFormatter' })
+        end
+
+        it 'does nothing' do
+          subject
+          expect(ENV['SPEC_OPTS']).to eq '--format json --format KnapsackPro::Formatters::RSpecQueueSummaryFormatter'
+        end
+      end
+
+      context 'when `SPEC_OPTS` has no RSpec Queue Summary Formatter' do
+        before do
+          stub_const('ENV', { 'SPEC_OPTS' => '--format json' })
+        end
+
+        it 'adds RSpec Queue Summary Formatter to `SPEC_OPTS`' do
+          subject
+          expect(ENV['SPEC_OPTS']).to eq '--format json --format KnapsackPro::Formatters::RSpecQueueSummaryFormatter'
+        end
+      end
+    end
+
+    context 'when `SPEC_OPTS` is not set' do
+      it 'does nothing' do
+        subject
+        expect(ENV['SPEC_OPTS']).to be_nil
       end
     end
   end


### PR DESCRIPTION
# problem

Related to the [RSpec split by test examples feature](https://docs.knapsackpro.com/ruby/split-by-test-examples/).

Some users use `SPEC_OPTS` to pass options to the RSpec. `SPEC_OPTS` overrides the options configured by Knapsack Pro.

When `SPEC_OPTS` is set, then this impacts the options (overrides them) passed to the `rake knapsack_pro:rspec_test_example_detector`, which is responsible for detecting test examples for slow test files.

# solution

We should ignore `SPEC_OPTS` for the `rake knapsack_pro:rspec_test_example_detector` to fix the problem with the [RSpec split by test examples feature](https://docs.knapsackpro.com/ruby/split-by-test-examples/).

# related

https://rspec.info/documentation/3.0/rspec-core/RSpec/Core/Configuration.html

The `SPEC_OPTS` env var overrides the args provided to the `RSpec::Core::ConfigurationOptions.new`.

# support thread

https://groups.google.com/a/knapsackpro.com/g/support/c/6XMMZhIUZNA

# story

https://trello.com/c/Et7HS05r