### PR TITLE
Add support for CI node retry count on GitHub Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### 4.1.0
+
+* Add support for CI node retry count on GitHub Actions
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/197
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v4.0.0...v4.1.0
+
 ### 4.0.0
 
 * Raise when `KNAPSACK_PRO_CI_NODE_BUILD_ID` is missing

--- a/lib/knapsack_pro/config/ci/github_actions.rb
+++ b/lib/knapsack_pro/config/ci/github_actions.rb
@@ -16,6 +16,14 @@ module KnapsackPro
           ENV['GITHUB_RUN_ID']
         end
 
+        def node_retry_count
+          # A unique number for each attempt of a particular workflow run in a repository.
+          # This number begins at 1 for the workflow run's first attempt, and increments with each re-run.
+          run_attempt = ENV['GITHUB_RUN_ATTEMPT']
+          return unless run_attempt
+          run_attempt.to_i - 1
+        end
+
         def commit_hash
           ENV['GITHUB_SHA']
         end

--- a/spec/knapsack_pro/config/ci/app_veyor_spec.rb
+++ b/spec/knapsack_pro/config/ci/app_veyor_spec.rb
@@ -22,12 +22,12 @@ describe KnapsackPro::Config::CI::AppVeyor do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'APPVEYOR_BUILD_ID' => 123 } }
       it { should eql 123 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -35,12 +35,12 @@ describe KnapsackPro::Config::CI::AppVeyor do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'APPVEYOR_REPO_COMMIT' => '2e13512fc230d6f9ebf4923352718e4d' } }
       it { should eql '2e13512fc230d6f9ebf4923352718e4d' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -48,12 +48,12 @@ describe KnapsackPro::Config::CI::AppVeyor do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'APPVEYOR_REPO_BRANCH' => 'master' } }
       it { should eql 'master' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -61,12 +61,12 @@ describe KnapsackPro::Config::CI::AppVeyor do
   describe '#project_dir' do
     subject { described_class.new.project_dir }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'APPVEYOR_BUILD_FOLDER' => '/path/to/clone/repo' } }
       it { should eql '/path/to/clone/repo' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/buildkite_spec.rb
+++ b/spec/knapsack_pro/config/ci/buildkite_spec.rb
@@ -10,12 +10,12 @@ describe KnapsackPro::Config::CI::Buildkite do
   describe '#node_total' do
     subject { described_class.new.node_total }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'BUILDKITE_PARALLEL_JOB_COUNT' => 4 } }
       it { should eql 4 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -23,12 +23,12 @@ describe KnapsackPro::Config::CI::Buildkite do
   describe '#node_index' do
     subject { described_class.new.node_index }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'BUILDKITE_PARALLEL_JOB' => 3 } }
       it { should eql 3 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -36,12 +36,12 @@ describe KnapsackPro::Config::CI::Buildkite do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'BUILDKITE_BUILD_NUMBER' => 1514 } }
       it { should eql 1514 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -49,12 +49,12 @@ describe KnapsackPro::Config::CI::Buildkite do
   describe '#node_retry_count' do
     subject { described_class.new.node_retry_count }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'BUILDKITE_RETRY_COUNT' => '1' } }
       it { should eql '1' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -62,12 +62,12 @@ describe KnapsackPro::Config::CI::Buildkite do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'BUILDKITE_COMMIT' => '3fa64859337f6e56409d49f865d13fd7' } }
       it { should eql '3fa64859337f6e56409d49f865d13fd7' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -75,12 +75,12 @@ describe KnapsackPro::Config::CI::Buildkite do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'BUILDKITE_BRANCH' => 'main' } }
       it { should eql 'main' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -88,12 +88,12 @@ describe KnapsackPro::Config::CI::Buildkite do
   describe '#project_dir' do
     subject { described_class.new.project_dir }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'BUILDKITE_BUILD_CHECKOUT_PATH' => '/home/user/knapsack_pro-ruby' } }
       it { should eql '/home/user/knapsack_pro-ruby' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/circle_spec.rb
+++ b/spec/knapsack_pro/config/ci/circle_spec.rb
@@ -10,12 +10,12 @@ describe KnapsackPro::Config::CI::Circle do
   describe '#node_total' do
     subject { described_class.new.node_total }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CIRCLE_NODE_TOTAL' => 4 } }
       it { should eql 4 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -23,12 +23,12 @@ describe KnapsackPro::Config::CI::Circle do
   describe '#node_index' do
     subject { described_class.new.node_index }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CIRCLE_NODE_INDEX' => 3 } }
       it { should eql 3 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -36,12 +36,12 @@ describe KnapsackPro::Config::CI::Circle do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CIRCLE_BUILD_NUM' => 123 } }
       it { should eql 123 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -49,12 +49,12 @@ describe KnapsackPro::Config::CI::Circle do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CIRCLE_SHA1' => '3fa64859337f6e56409d49f865d13fd7' } }
       it { should eql '3fa64859337f6e56409d49f865d13fd7' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -62,12 +62,12 @@ describe KnapsackPro::Config::CI::Circle do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CIRCLE_BRANCH' => 'main' } }
       it { should eql 'main' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -80,7 +80,7 @@ describe KnapsackPro::Config::CI::Circle do
       it { should eql '~/knapsack_pro-ruby' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/cirrus_ci_spec.rb
+++ b/spec/knapsack_pro/config/ci/cirrus_ci_spec.rb
@@ -10,12 +10,12 @@ describe KnapsackPro::Config::CI::CirrusCI do
   describe '#node_total' do
     subject { described_class.new.node_total }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CI_NODE_TOTAL' => 4 } }
       it { should eql 4 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -23,12 +23,12 @@ describe KnapsackPro::Config::CI::CirrusCI do
   describe '#node_index' do
     subject { described_class.new.node_index }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CI_NODE_INDEX' => 3 } }
       it { should eql 3 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -36,12 +36,12 @@ describe KnapsackPro::Config::CI::CirrusCI do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CIRRUS_BUILD_ID' => 123 } }
       it { should eql 123 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -49,12 +49,12 @@ describe KnapsackPro::Config::CI::CirrusCI do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CIRRUS_CHANGE_IN_REPO' => '2e13512fc230d6f9ebf4923352718e4d' } }
       it { should eql '2e13512fc230d6f9ebf4923352718e4d' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -62,12 +62,12 @@ describe KnapsackPro::Config::CI::CirrusCI do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CIRRUS_BRANCH' => 'master' } }
       it { should eql 'master' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -75,12 +75,12 @@ describe KnapsackPro::Config::CI::CirrusCI do
   describe '#project_dir' do
     subject { described_class.new.project_dir }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CIRRUS_WORKING_DIR' => '/tmp/cirrus-ci-build' } }
       it { should eql '/tmp/cirrus-ci-build' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/codefresh_spec.rb
+++ b/spec/knapsack_pro/config/ci/codefresh_spec.rb
@@ -22,12 +22,12 @@ describe KnapsackPro::Config::CI::Codefresh do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CF_BUILD_ID' => '1005' } }
       it { should eql '1005' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -35,12 +35,12 @@ describe KnapsackPro::Config::CI::Codefresh do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CF_REVISION' => 'b624067a61d2134df1db74ebdabb1d8d' } }
       it { should eql 'b624067a61d2134df1db74ebdabb1d8d' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -48,12 +48,12 @@ describe KnapsackPro::Config::CI::Codefresh do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CF_BRANCH' => 'codefresh-branch' } }
       it { should eql 'codefresh-branch' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/codeship_spec.rb
+++ b/spec/knapsack_pro/config/ci/codeship_spec.rb
@@ -22,12 +22,12 @@ describe KnapsackPro::Config::CI::Codeship do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CI_BUILD_NUMBER' => 2013 } }
       it { should eql 2013 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -35,12 +35,12 @@ describe KnapsackPro::Config::CI::Codeship do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CI_COMMIT_ID' => 'a22aec3ee5d334fd658da35646b42bc5' } }
       it { should eql 'a22aec3ee5d334fd658da35646b42bc5' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -48,12 +48,12 @@ describe KnapsackPro::Config::CI::Codeship do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CI_BRANCH' => 'master' } }
       it { should eql 'master' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/github_actions_spec.rb
+++ b/spec/knapsack_pro/config/ci/github_actions_spec.rb
@@ -32,6 +32,19 @@ describe KnapsackPro::Config::CI::GithubActions do
     end
   end
 
+  describe '#node_retry_count' do
+    subject { described_class.new.node_retry_count }
+
+    context 'when the environment exists' do
+      let(:env) { { 'GITHUB_RUN_ATTEMPT' => 2 } }
+      it { should eql 1 }
+    end
+
+    context "when the environment doesn't exist" do
+      it { should be nil }
+    end
+  end
+
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 

--- a/spec/knapsack_pro/config/ci/github_actions_spec.rb
+++ b/spec/knapsack_pro/config/ci/github_actions_spec.rb
@@ -22,12 +22,12 @@ describe KnapsackPro::Config::CI::GithubActions do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'GITHUB_RUN_ID' => 2706 } }
       it { should eql 2706 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -48,12 +48,12 @@ describe KnapsackPro::Config::CI::GithubActions do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'GITHUB_SHA' => '2e13512fc230d6f9ebf4923352718e4d' } }
       it { should eql '2e13512fc230d6f9ebf4923352718e4d' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -61,7 +61,7 @@ describe KnapsackPro::Config::CI::GithubActions do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       context 'when GITHUB_REF has value' do
         let(:env) do
           {
@@ -84,7 +84,7 @@ describe KnapsackPro::Config::CI::GithubActions do
       end
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -92,12 +92,12 @@ describe KnapsackPro::Config::CI::GithubActions do
   describe '#project_dir' do
     subject { described_class.new.project_dir }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'GITHUB_WORKSPACE' => '/home/runner/work/my-repo-name/my-repo-name' } }
       it { should eql '/home/runner/work/my-repo-name/my-repo-name' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/gitlab_ci_spec.rb
+++ b/spec/knapsack_pro/config/ci/gitlab_ci_spec.rb
@@ -10,12 +10,12 @@ describe KnapsackPro::Config::CI::GitlabCI do
   describe '#node_total' do
     subject { described_class.new.node_total }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CI_NODE_TOTAL' => 4 } }
       it { should eql 4 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -23,12 +23,12 @@ describe KnapsackPro::Config::CI::GitlabCI do
   describe '#node_index' do
     subject { described_class.new.node_index }
 
-    context 'when environment exists and is in GitLab CI' do
+    context 'when the environment exists and is in GitLab CI' do
       let(:env) { { 'CI_NODE_INDEX' => 4, 'GITLAB_CI' => 'true' } }
       it { should eql 3 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -46,7 +46,7 @@ describe KnapsackPro::Config::CI::GitlabCI do
       it { should eql 7046508 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -64,7 +64,7 @@ describe KnapsackPro::Config::CI::GitlabCI do
       it { should eql 'f76c468e3e1d570f71f5822b1e48bb04' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -82,7 +82,7 @@ describe KnapsackPro::Config::CI::GitlabCI do
       it { should eql 'main' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -90,12 +90,12 @@ describe KnapsackPro::Config::CI::GitlabCI do
   describe '#project_dir' do
     subject { described_class.new.project_dir }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CI_PROJECT_DIR' => '/home/user/knapsack_pro-ruby' } }
       it { should eql '/home/user/knapsack_pro-ruby' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/heroku_spec.rb
+++ b/spec/knapsack_pro/config/ci/heroku_spec.rb
@@ -10,12 +10,12 @@ describe KnapsackPro::Config::CI::Heroku do
   describe '#node_total' do
     subject { described_class.new.node_total }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CI_NODE_TOTAL' => 4 } }
       it { should eql 4 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -23,12 +23,12 @@ describe KnapsackPro::Config::CI::Heroku do
   describe '#node_index' do
     subject { described_class.new.node_index }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'CI_NODE_INDEX' => 3 } }
       it { should eql 3 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -36,12 +36,12 @@ describe KnapsackPro::Config::CI::Heroku do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'HEROKU_TEST_RUN_ID' => 1234 } }
       it { should eql 1234 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -49,12 +49,12 @@ describe KnapsackPro::Config::CI::Heroku do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'HEROKU_TEST_RUN_COMMIT_VERSION' => 'abbaec3ee5d334fd658da35646b42bc5' } }
       it { should eql 'abbaec3ee5d334fd658da35646b42bc5' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -62,12 +62,12 @@ describe KnapsackPro::Config::CI::Heroku do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'HEROKU_TEST_RUN_BRANCH' => 'master' } }
       it { should eql 'master' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -75,12 +75,12 @@ describe KnapsackPro::Config::CI::Heroku do
   describe '#project_dir' do
     subject { described_class.new.project_dir }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'HEROKU_TEST_RUN_ID' => 1234 } }
       it { should eq '/app' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/semaphore2_spec.rb
+++ b/spec/knapsack_pro/config/ci/semaphore2_spec.rb
@@ -10,12 +10,12 @@ describe KnapsackPro::Config::CI::Semaphore2 do
   describe '#node_total' do
     subject { described_class.new.node_total }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'SEMAPHORE_JOB_COUNT' => 4 } }
       it { should eql 4 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -23,12 +23,12 @@ describe KnapsackPro::Config::CI::Semaphore2 do
   describe '#node_index' do
     subject { described_class.new.node_index }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'SEMAPHORE_JOB_INDEX' => 4 } }
       it { should eql 3 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -36,12 +36,12 @@ describe KnapsackPro::Config::CI::Semaphore2 do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'SEMAPHORE_WORKFLOW_ID' => 123 } }
       it { should eql 123 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -49,12 +49,12 @@ describe KnapsackPro::Config::CI::Semaphore2 do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'SEMAPHORE_GIT_SHA' => '4323320992a21b1169e3ac5b7789d379597738e6' } }
       it { should eql '4323320992a21b1169e3ac5b7789d379597738e6' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -62,12 +62,12 @@ describe KnapsackPro::Config::CI::Semaphore2 do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'SEMAPHORE_GIT_BRANCH' => 'master' } }
       it { should eql 'master' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -103,7 +103,7 @@ describe KnapsackPro::Config::CI::Semaphore2 do
       it { should be nil }
     end
 
-    context "when environments don't exist" do
+    context "when the environments don't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/semaphore_spec.rb
+++ b/spec/knapsack_pro/config/ci/semaphore_spec.rb
@@ -10,12 +10,12 @@ describe KnapsackPro::Config::CI::Semaphore do
   describe '#node_total' do
     subject { described_class.new.node_total }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'SEMAPHORE_THREAD_COUNT' => 4 } }
       it { should eql 4 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -23,12 +23,12 @@ describe KnapsackPro::Config::CI::Semaphore do
   describe '#node_index' do
     subject { described_class.new.node_index }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'SEMAPHORE_CURRENT_THREAD' => 4 } }
       it { should eql 3 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -36,12 +36,12 @@ describe KnapsackPro::Config::CI::Semaphore do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'SEMAPHORE_BUILD_NUMBER' => 23 } }
       it { should eql 23 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -49,12 +49,12 @@ describe KnapsackPro::Config::CI::Semaphore do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'REVISION' => '3fa64859337f6e56409d49f865d13fd7' } }
       it { should eql '3fa64859337f6e56409d49f865d13fd7' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -62,12 +62,12 @@ describe KnapsackPro::Config::CI::Semaphore do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'BRANCH_NAME' => 'master' } }
       it { should eql 'master' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -75,12 +75,12 @@ describe KnapsackPro::Config::CI::Semaphore do
   describe '#project_dir' do
     subject { described_class.new.project_dir }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'SEMAPHORE_PROJECT_DIR' => '/home/runner/knapsack_pro-ruby' } }
       it { should eql '/home/runner/knapsack_pro-ruby' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end

--- a/spec/knapsack_pro/config/ci/travis_spec.rb
+++ b/spec/knapsack_pro/config/ci/travis_spec.rb
@@ -22,12 +22,12 @@ describe KnapsackPro::Config::CI::Travis do
   describe '#node_build_id' do
     subject { described_class.new.node_build_id }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'TRAVIS_BUILD_NUMBER' => 4 } }
       it { should eql 4 }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -35,12 +35,12 @@ describe KnapsackPro::Config::CI::Travis do
   describe '#commit_hash' do
     subject { described_class.new.commit_hash }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'TRAVIS_COMMIT' => '3fa64859337f6e56409d49f865d13fd7' } }
       it { should eql '3fa64859337f6e56409d49f865d13fd7' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -48,12 +48,12 @@ describe KnapsackPro::Config::CI::Travis do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'TRAVIS_BRANCH' => 'master' } }
       it { should eql 'master' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end
@@ -61,12 +61,12 @@ describe KnapsackPro::Config::CI::Travis do
   describe '#project_dir' do
     subject { described_class.new.project_dir }
 
-    context 'when environment exists' do
+    context 'when the environment exists' do
       let(:env) { { 'TRAVIS_BUILD_DIR' => '/home/travis/build/KnapsackPro/rails-app-with-knapsack_pro' } }
       it { should eql '/home/travis/build/KnapsackPro/rails-app-with-knapsack_pro' }
     end
 
-    context "when environment doesn't exist" do
+    context "when the environment doesn't exist" do
       it { should be nil }
     end
   end


### PR DESCRIPTION
# Related

* [`KNAPSACK_PRO_CI_NODE_RETRY_COUNT`](https://docs.knapsackpro.com/ruby/reference/#knapsack_pro_ci_node_retry_count)