### PR TITLE
Use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` as default value in Queue Mode and use `false` for proper CI providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,19 @@
 
 ### Unreleased
 
-* Set `RAILS_ENV=test` / `RACK_ENV=test` in Queue Mode
+* __(breaking change)__ Use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` as default value in Queue Mode and use `false` for proper CI providers
 
-    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/199
-
-### Unreleased
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/198
 
 * Detect CI from environment and get the correct ENVs instead of trying all of them and risk conflicts
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/201
+
+* Set `RAILS_ENV=test` / `RACK_ENV=test` in Queue Mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/199
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v4.1.0...v5.0.0
 
 ### 4.1.0
 
@@ -24,7 +28,7 @@ https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v4.0.0...v4.1.0
 
 ### 4.0.0
 
-* Raise when `KNAPSACK_PRO_CI_NODE_BUILD_ID` is missing
+* __(breaking change)__  Raise when `KNAPSACK_PRO_CI_NODE_BUILD_ID` is missing
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/195
 

--- a/lib/knapsack_pro/config/ci/app_veyor.rb
+++ b/lib/knapsack_pro/config/ci/app_veyor.rb
@@ -30,6 +30,10 @@ module KnapsackPro
         def detected
           ENV.key?('APPVEYOR') ? self.class : nil
         end
+
+        def fixed_queue_split
+          false
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/base.rb
+++ b/lib/knapsack_pro/config/ci/base.rb
@@ -28,6 +28,10 @@ module KnapsackPro
 
         def detected
         end
+
+        def fixed_queue_split
+          true
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/buildkite.rb
+++ b/lib/knapsack_pro/config/ci/buildkite.rb
@@ -37,6 +37,10 @@ module KnapsackPro
         def detected
           ENV.key?('BUILDKITE') ? self.class : nil
         end
+
+        def fixed_queue_split
+          true
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/circle.rb
+++ b/lib/knapsack_pro/config/ci/circle.rb
@@ -33,6 +33,10 @@ module KnapsackPro
         def detected
           ENV.key?('CIRCLECI') ? self.class : nil
         end
+
+        def fixed_queue_split
+          false
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/cirrus_ci.rb
+++ b/lib/knapsack_pro/config/ci/cirrus_ci.rb
@@ -29,6 +29,10 @@ module KnapsackPro
         def detected
           ENV.key?('CIRRUS_CI') ? self.class : nil
         end
+
+        def fixed_queue_split
+          false
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/codefresh.rb
+++ b/lib/knapsack_pro/config/ci/codefresh.rb
@@ -30,6 +30,10 @@ module KnapsackPro
         def detected
           ENV.key?('CF_BUILD_ID') ? self.class : nil
         end
+
+        def fixed_queue_split
+          false
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/codeship.rb
+++ b/lib/knapsack_pro/config/ci/codeship.rb
@@ -29,6 +29,10 @@ module KnapsackPro
         def detected
           ENV['CI_NAME'] == 'codeship' ? self.class : nil
         end
+
+        def fixed_queue_split
+          true
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/github_actions.rb
+++ b/lib/knapsack_pro/config/ci/github_actions.rb
@@ -45,6 +45,10 @@ module KnapsackPro
         def detected
           ENV.key?('GITHUB_ACTIONS') ? self.class : nil
         end
+
+        def fixed_queue_split
+          true
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/gitlab_ci.rb
+++ b/lib/knapsack_pro/config/ci/gitlab_ci.rb
@@ -41,6 +41,10 @@ module KnapsackPro
         def detected
           ENV.key?('GITLAB_CI') ? self.class : nil
         end
+
+        def fixed_queue_split
+          false
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/heroku.rb
+++ b/lib/knapsack_pro/config/ci/heroku.rb
@@ -29,6 +29,10 @@ module KnapsackPro
         def detected
           ENV.key?('HEROKU_TEST_RUN_ID') ? self.class : nil
         end
+
+        def fixed_queue_split
+          false
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/semaphore.rb
+++ b/lib/knapsack_pro/config/ci/semaphore.rb
@@ -30,6 +30,10 @@ module KnapsackPro
         def detected
           ENV.key?('SEMAPHORE_BUILD_NUMBER') ? self.class : nil
         end
+
+        def fixed_queue_split
+          false
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/semaphore2.rb
+++ b/lib/knapsack_pro/config/ci/semaphore2.rb
@@ -34,6 +34,10 @@ module KnapsackPro
           # check 2 keys to be sure we are using Semaphore 2.0
           ENV.key?('SEMAPHORE') && ENV.key?('SEMAPHORE_WORKFLOW_ID') ? self.class : nil
         end
+
+        def fixed_queue_split
+          false
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/travis.rb
+++ b/lib/knapsack_pro/config/ci/travis.rb
@@ -21,6 +21,10 @@ module KnapsackPro
         def detected
           ENV.key?('TRAVIS') ? self.class : nil
         end
+
+        def fixed_queue_split
+          true
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -186,7 +186,16 @@ module KnapsackPro
         end
 
         def fixed_queue_split
-          ENV.fetch('KNAPSACK_PRO_FIXED_QUEUE_SPLIT', false)
+          @fixed_queue_split ||= begin
+            env_name = 'KNAPSACK_PRO_FIXED_QUEUE_SPLIT'
+            computed = ENV.fetch(env_name, ci_env_for(:fixed_queue_split)).to_s
+
+            if !ENV.key?(env_name)
+              KnapsackPro.logger.info("#{env_name} is not set. Using default value: #{computed}. Learn more at #{KnapsackPro::Urls::FIXED_QUEUE_SPLIT}")
+            end
+
+            computed
+          end
         end
 
         def fixed_queue_split?


### PR DESCRIPTION
Use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` as the default value and ensure it's `true` for:

* GitHub Actions
* Buildkite
* Travis
* CodeShip

For other CI providers use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=false`:

* App Veyor
* Cirrurs CI
* CodeFresh
* GitLab CI
* Heroku CI
* Semaphore CI 1.0
* Semaphore CI 2.0


More info:

GitHub Actions, CodeShip use the same CI build ID for retried CI node. In such a case, Queue Mode would assume the queue is already consumed and there are no tests to run for retried CI node. You would expect to run the same set of tests as it was assigned to the CI node during the very first run. To achieve that, we use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` then a retried CI node will run the same set of tests as on the very first run for a given (commit SHA, branch, and number of nodes).

Some CI providers like Buildkite (or Github Actions) allow you to retry an individual CI node. In such a case, you would expect to run the same set of tests as it was assigned to the CI providers. To do so, you need to set `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` (we will do it automatically from now on).

Other CI providers use a new CI build ID when you retry the CI node. So it's safe to use for them `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=false`, in such case, a new dynamic tests split happens in Queue Mode. This also assumes that all nodes are retried.

If you would rerun only a single CI node, then it's better to set `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` so that the retried CI node won't run the whole test suite on the retried CI node. Instead, it would run the same set of tests as during the very first run of tests for a given set of (commit hash, branch, number of nodes).


