### PR TITLE
Detect CI from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### Unreleased
+
+* Detect CI from environment and get the correct ENVs instead of trying all of them and risk conflicts
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/201
+
 ### 4.1.0
 
 * Add support for CI node retry count on GitHub Actions

--- a/lib/knapsack_pro/config/ci/app_veyor.rb
+++ b/lib/knapsack_pro/config/ci/app_veyor.rb
@@ -26,6 +26,10 @@ module KnapsackPro
         def project_dir
           ENV['APPVEYOR_BUILD_FOLDER']
         end
+
+        def detected
+          ENV.key?('APPVEYOR') ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/base.rb
+++ b/lib/knapsack_pro/config/ci/base.rb
@@ -25,6 +25,10 @@ module KnapsackPro
 
         def user_seat
         end
+
+        def detected
+          nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/base.rb
+++ b/lib/knapsack_pro/config/ci/base.rb
@@ -27,7 +27,6 @@ module KnapsackPro
         end
 
         def detected
-          nil
         end
       end
     end

--- a/lib/knapsack_pro/config/ci/buildkite.rb
+++ b/lib/knapsack_pro/config/ci/buildkite.rb
@@ -35,7 +35,7 @@ module KnapsackPro
         end
 
         def detected
-          ENV['BUILDKITE'] == 'true' ? self.class : nil
+          ENV.key?('BUILDKITE') ? self.class : nil
         end
       end
     end

--- a/lib/knapsack_pro/config/ci/buildkite.rb
+++ b/lib/knapsack_pro/config/ci/buildkite.rb
@@ -33,6 +33,10 @@ module KnapsackPro
         def user_seat
           ENV['BUILDKITE_BUILD_AUTHOR'] || ENV['BUILDKITE_BUILD_CREATOR']
         end
+
+        def detected
+          ENV['BUILDKITE'] == 'true' ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/circle.rb
+++ b/lib/knapsack_pro/config/ci/circle.rb
@@ -31,7 +31,7 @@ module KnapsackPro
         end
 
         def detected
-          ENV['CIRCLECI'] == 'true' ? self.class : nil
+          ENV.key?('CIRCLECI') ? self.class : nil
         end
       end
     end

--- a/lib/knapsack_pro/config/ci/circle.rb
+++ b/lib/knapsack_pro/config/ci/circle.rb
@@ -29,6 +29,10 @@ module KnapsackPro
         def user_seat
           ENV['CIRCLE_USERNAME'] || ENV['CIRCLE_PR_USERNAME']
         end
+
+        def detected
+          ENV['CIRCLECI'] == 'true' ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/cirrus_ci.rb
+++ b/lib/knapsack_pro/config/ci/cirrus_ci.rb
@@ -25,6 +25,10 @@ module KnapsackPro
         def project_dir
           ENV['CIRRUS_WORKING_DIR']
         end
+
+        def detected
+          ENV.key?('CIRRUS_CI') ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/codefresh.rb
+++ b/lib/knapsack_pro/config/ci/codefresh.rb
@@ -26,6 +26,10 @@ module KnapsackPro
         def project_dir
           # not provided
         end
+
+        def detected
+          ENV.key?('CF_BUILD_ID') ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/codeship.rb
+++ b/lib/knapsack_pro/config/ci/codeship.rb
@@ -25,6 +25,10 @@ module KnapsackPro
         def project_dir
           # not provided
         end
+
+        def detected
+          ENV['CI_NAME'] == 'codeship' ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/github_actions.rb
+++ b/lib/knapsack_pro/config/ci/github_actions.rb
@@ -41,6 +41,10 @@ module KnapsackPro
         def user_seat
           ENV['GITHUB_ACTOR']
         end
+
+        def detected
+          ENV.key?('GITHUB_ACTIONS') ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/gitlab_ci.rb
+++ b/lib/knapsack_pro/config/ci/gitlab_ci.rb
@@ -37,6 +37,10 @@ module KnapsackPro
           ENV['GITLAB_USER_NAME'] || # Gitlab Release 10.0
           ENV['GITLAB_USER_EMAIL'] # Gitlab Release 8.12
         end
+
+        def detected
+          ENV['GITLAB_CI'] == 'true' ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/gitlab_ci.rb
+++ b/lib/knapsack_pro/config/ci/gitlab_ci.rb
@@ -39,7 +39,7 @@ module KnapsackPro
         end
 
         def detected
-          ENV['GITLAB_CI'] == 'true' ? self.class : nil
+          ENV.key?('GITLAB_CI') ? self.class : nil
         end
       end
     end

--- a/lib/knapsack_pro/config/ci/heroku.rb
+++ b/lib/knapsack_pro/config/ci/heroku.rb
@@ -25,6 +25,10 @@ module KnapsackPro
         def project_dir
           '/app' if node_build_id
         end
+
+        def detected
+          ENV.key?('HEROKU_TEST_RUN_ID') ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/semaphore.rb
+++ b/lib/knapsack_pro/config/ci/semaphore.rb
@@ -26,6 +26,10 @@ module KnapsackPro
         def project_dir
           ENV['SEMAPHORE_PROJECT_DIR']
         end
+
+        def detected
+          ENV.key?('SEMAPHORE_BUILD_NUMBER') ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/semaphore2.rb
+++ b/lib/knapsack_pro/config/ci/semaphore2.rb
@@ -29,6 +29,10 @@ module KnapsackPro
             "#{ENV['HOME']}/#{ENV['SEMAPHORE_GIT_DIR']}"
           end
         end
+
+        def detected
+          ENV['SEMAPHORE'] == 'true' && ENV.key?('SEMAPHORE_WORKFLOW_ID') ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/ci/semaphore2.rb
+++ b/lib/knapsack_pro/config/ci/semaphore2.rb
@@ -31,7 +31,7 @@ module KnapsackPro
         end
 
         def detected
-          ENV['SEMAPHORE'] == 'true' && ENV.key?('SEMAPHORE_WORKFLOW_ID') ? self.class : nil
+          ENV.key?('SEMAPHORE') && ENV.key?('SEMAPHORE_WORKFLOW_ID') ? self.class : nil
         end
       end
     end

--- a/lib/knapsack_pro/config/ci/semaphore2.rb
+++ b/lib/knapsack_pro/config/ci/semaphore2.rb
@@ -31,6 +31,7 @@ module KnapsackPro
         end
 
         def detected
+          # check 2 keys to be sure we are using Semaphore 2.0
           ENV.key?('SEMAPHORE') && ENV.key?('SEMAPHORE_WORKFLOW_ID') ? self.class : nil
         end
       end

--- a/lib/knapsack_pro/config/ci/travis.rb
+++ b/lib/knapsack_pro/config/ci/travis.rb
@@ -19,7 +19,7 @@ module KnapsackPro
         end
 
         def detected
-          ENV['TRAVIS'] == 'true' ? self.class : nil
+          ENV.key?('TRAVIS') ? self.class : nil
         end
       end
     end

--- a/lib/knapsack_pro/config/ci/travis.rb
+++ b/lib/knapsack_pro/config/ci/travis.rb
@@ -17,6 +17,10 @@ module KnapsackPro
         def project_dir
           ENV['TRAVIS_BUILD_DIR']
         end
+
+        def detected
+          ENV['TRAVIS'] == 'true' ? self.class : nil
+        end
       end
     end
   end

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -246,17 +246,17 @@ module KnapsackPro
         end
 
         def ci_env_for(env_name)
-          value = nil
-          ci_list = KnapsackPro::Config::CI.constants - [:Base, :GitlabCI]
-          # load GitLab CI first to avoid edge case with order of loading envs for CI_NODE_INDEX
-          ci_list = [:GitlabCI] + ci_list
-          ci_list.each do |ci_name|
-            ci_class = Object.const_get("KnapsackPro::Config::CI::#{ci_name}")
-            ci = ci_class.new
-            value = ci.send(env_name)
-            break unless value.nil?
+          detected_ci.new.send(env_name)
+        end
+
+        def detected_ci
+          detected = KnapsackPro::Config::CI.constants.map do |constant|
+            Object.const_get("KnapsackPro::Config::CI::#{constant}").new.detected
           end
-          value
+            .compact
+            .first
+
+          detected || KnapsackPro::Config::CI::Base
         end
 
         def log_level


### PR DESCRIPTION
Detect CI from environment and get the correct ENVs instead of trying all of them and risk conflicts.

Fixes https://trello.com/c/duyuldsW/76-detect-ci-first-before-reading-the-env-vars