### PR TITLE
Let users set custom environment variables with `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX`. Use a command that boots the program (`$PROGRAM_NAME`) instead of the hardcoded `bundle exec` prefix.

### DIFF
--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -48,8 +48,9 @@ module KnapsackPro
           'RACK_ENV=test',
           'RAILS_ENV=test',
           KnapsackPro::Config::Env.rspec_test_example_detector_prefix,
-          'rake knapsack_pro:rspec_test_example_detector',
-        ].join(' ')
+          $PROGRAM_NAME,
+          'knapsack_pro:rspec_test_example_detector',
+        ].compact.join(' ')
         unless Kernel.system(cmd)
           raise "Could not generate JSON report for RSpec. Rake task failed when running #{cmd}"
         end

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -216,7 +216,7 @@ module KnapsackPro
         end
 
         def rspec_test_example_detector_prefix
-          ENV.fetch('KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX', 'bundle exec')
+          ENV['KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX']
         end
 
         def test_suite_token

--- a/spec/knapsack_pro/base_allocator_builder_spec.rb
+++ b/spec/knapsack_pro/base_allocator_builder_spec.rb
@@ -132,7 +132,7 @@ describe KnapsackPro::BaseAllocatorBuilder do
     context 'when RSpec adapter AND rspec split by test examples is enabled' do
       let(:adapter_class) { KnapsackPro::Adapters::RSpecAdapter }
       let(:test_files_to_run) { double }
-      let(:cmd) { 'RACK_ENV=test RAILS_ENV=test bundle exec rake knapsack_pro:rspec_test_example_detector' }
+      let(:cmd) { "RACK_ENV=test RAILS_ENV=test #{$PROGRAM_NAME} knapsack_pro:rspec_test_example_detector" }
 
       before do
         expect(KnapsackPro::Config::Env).to receive(:rspec_split_by_test_examples?).and_return(true)
@@ -192,7 +192,7 @@ describe KnapsackPro::BaseAllocatorBuilder do
         end
 
         it do
-          expect { subject }.to raise_error(RuntimeError, 'Could not generate JSON report for RSpec. Rake task failed when running RACK_ENV=test RAILS_ENV=test bundle exec rake knapsack_pro:rspec_test_example_detector')
+          expect { subject }.to raise_error(RuntimeError, "Could not generate JSON report for RSpec. Rake task failed when running RACK_ENV=test RAILS_ENV=test #{$PROGRAM_NAME} knapsack_pro:rspec_test_example_detector")
         end
       end
     end

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -801,13 +801,13 @@ describe KnapsackPro::Config::Env do
     subject { described_class.rspec_test_example_detector_prefix }
 
     context 'when ENV exists' do
-      before { stub_const("ENV", { 'KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX' => '' }) }
-      it { should eq '' }
+      before { stub_const("ENV", { 'KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX' => 'MY_VARIABLE=123' }) }
+      it { should eq 'MY_VARIABLE=123' }
     end
 
     context "when ENV doesn't exist" do
       before { stub_const("ENV", {}) }
-      it { should eq 'bundle exec' }
+      it { should be_nil }
     end
   end
 


### PR DESCRIPTION
# changes

* Let users set custom environment variables with `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX`.

For example you can do:

```bash
KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true \
KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX="CUSTOM_VARIABLE='custom-value'" \
KNAPSACK_PRO_CI_NODE_BUILD_ID=123 \
bin/rake "knapsack_pro:queue:rspec[--format d]"
```

`CUSTOM_VARIABLE` is set only when Knapsack Pro runs the `knapsack_pro:rspec_test_example_detector` rake task. The rake task is responsible for running RSpec in dry run to generate test examples JSON report which is needed to [run tests split by test examples](https://docs.knapsackpro.com/ruby/split-by-test-examples/).

You can use a custom environment variable to behave RSpec differently when running RSpec dry run. For example, you could control what should not be loaded to make the dry run faster. Thanks to that, you could generate the JSON report with test examples for your slow test files more quickly.

* Use a command that boots the program (`$PROGRAM_NAME`) instead of the hardcoded `bundle exec` prefix.

Previously the `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX` had the `bundle exec` default value  which was added as prefix to the `rake knapsack_pro:rspec_test_example_detector` command. But sometimes it did not work so we recommended to users to set `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX=""` to remove `bundle exec` prefix.

Now `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX` is `nil` by default and we use `$PROGRAM_NAME` to run a proper rake command instead of `bundle exec`. This should not break anything for users (even if they set `KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX=""`) upgrading to the new knapsack_pro gem version using this PR code.

# story

https://trello.com/c/LeVgVlTa

# support thread

https://groups.google.com/a/knapsackpro.com/g/support/c/IyMUAsapG9E/m/rtMOq3QEAQAJ