### PR TITLE
Use KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true as default value in Queue Mode for GitLab CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 5.1.1
+
+* Use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` as default value in Queue Mode for GitLab CI
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/206
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v5.1.0...v5.1.1
+
 ### 5.1.0
 
 * Mask user seats data instead of hashing it

--- a/lib/knapsack_pro/config/ci/gitlab_ci.rb
+++ b/lib/knapsack_pro/config/ci/gitlab_ci.rb
@@ -43,7 +43,7 @@ module KnapsackPro
         end
 
         def fixed_queue_split
-          false
+          true
         end
       end
     end

--- a/lib/knapsack_pro/version.rb
+++ b/lib/knapsack_pro/version.rb
@@ -1,3 +1,3 @@
 module KnapsackPro
-  VERSION = '5.1.0'
+  VERSION = '5.1.1'
 end

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -728,7 +728,7 @@ describe KnapsackPro::Config::Env do
         ['Codefresh', { 'CF_BUILD_ID' => '123' }, false],
         ['Codeship', { 'CI_NAME' => 'codeship' }, true],
         ['GitHub Actions', { 'GITHUB_ACTIONS' => 'true' }, true],
-        ['GitLab CI', { 'GITLAB_CI' => 'true' }, false],
+        ['GitLab CI', { 'GITLAB_CI' => 'true' }, true],
         ['Heroku CI', { 'HEROKU_TEST_RUN_ID' => '123' }, false],
         ['Semaphore CI 1.0', { 'SEMAPHORE_BUILD_NUMBER' => '123' }, false],
         ['Semaphore CI 2.0', { 'SEMAPHORE' => 'true', 'SEMAPHORE_WORKFLOW_ID' => '123' }, false],


### PR DESCRIPTION
- fix: use fixed queue split for gitlab
- Bump version 5.1.1
