### PR TITLE
fix(Queue Mode): handle OS signals and RSpec internal `wants_to_quit` and `rspec_is_quitting` states to stop consuming tests from the Queue API when the CI node is terminated

### DIFF
--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -45,6 +45,9 @@ module KnapsackPro
           Signal.trap('TERM') {
             @@terminate_process = true
           }
+          Signal.trap('INT') {
+            @@terminate_process = true
+          }
         end
       end
     end

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -2,7 +2,7 @@ module KnapsackPro
   module Runners
     module Queue
       class BaseRunner
-        SIGNALS = %w(HUP INT QUIT USR1 USR2 TERM ABRT)
+        TERMINATION_SIGNALS = %w(HUP INT TERM ABRT QUIT USR1 USR2)
 
         @@terminate_process = false
 
@@ -48,7 +48,7 @@ module KnapsackPro
         end
 
         def trap_signals
-          SIGNALS.each do |signal|
+          TERMINATION_SIGNALS.each do |signal|
             Signal.trap(signal) {
               puts "#{signal} signal has been received. Terminating Knapsack Pro..."
               @@terminate_process = true

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -2,6 +2,8 @@ module KnapsackPro
   module Runners
     module Queue
       class BaseRunner
+        SIGNALS = %w(HUP INT QUIT USR1 USR2 TERM ABRT)
+
         @@terminate_process = false
 
         def self.run(args)
@@ -42,41 +44,12 @@ module KnapsackPro
         end
 
         def trap_signals
-          Signal.trap('HUP') {
-            puts '+'*100
-            puts 'HUP'
-            @@terminate_process = true
-          }
-          Signal.trap('INT') {
-            puts '+'*100
-            puts 'INT'
-            @@terminate_process = true
-          }
-          Signal.trap('QUIT') {
-            puts '+'*100
-            puts 'QUIT'
-            @@terminate_process = true
-          }
-          Signal.trap('USR1') {
-            puts '+'*100
-            puts 'USR1'
-            @@terminate_process = true
-          }
-          Signal.trap('USR2') {
-            puts '+'*100
-            puts 'USR2'
-            @@terminate_process = true
-          }
-          Signal.trap('TERM') {
-            puts '+'*100
-            puts 'TERM'
-            @@terminate_process = true
-          }
-          Signal.trap('ABRT') {
-            puts '+'*100
-            puts 'ABRT'
-            @@terminate_process = true
-          }
+          SIGNALS.each do |signal|
+            Signal.trap(signal) {
+              KnapsackPro.logger.warn("#{signal} signal has been received. Terminating Knapsack Pro...")
+              @@terminate_process = true
+            }
+          end
         end
       end
     end

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -42,10 +42,39 @@ module KnapsackPro
         end
 
         def trap_signals
-          Signal.trap('TERM') {
+          Signal.trap('HUP') {
+            puts '+'*100
+            puts 'HUP'
             @@terminate_process = true
           }
           Signal.trap('INT') {
+            puts '+'*100
+            puts 'INT'
+            @@terminate_process = true
+          }
+          Signal.trap('QUIT') {
+            puts '+'*100
+            puts 'QUIT'
+            @@terminate_process = true
+          }
+          Signal.trap('USR1') {
+            puts '+'*100
+            puts 'USR1'
+            @@terminate_process = true
+          }
+          Signal.trap('USR2') {
+            puts '+'*100
+            puts 'USR2'
+            @@terminate_process = true
+          }
+          Signal.trap('TERM') {
+            puts '+'*100
+            puts 'TERM'
+            @@terminate_process = true
+          }
+          Signal.trap('ABRT') {
+            puts '+'*100
+            puts 'ABRT'
             @@terminate_process = true
           }
         end

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -2,6 +2,8 @@ module KnapsackPro
   module Runners
     module Queue
       class BaseRunner
+        @@terminate_process = false
+
         def self.run(args)
           raise NotImplementedError
         end
@@ -13,6 +15,7 @@ module KnapsackPro
         def initialize(adapter_class)
           @allocator_builder = KnapsackPro::QueueAllocatorBuilder.new(adapter_class)
           @allocator = allocator_builder.allocator
+          trap_signals
         end
 
         def test_file_paths(args)
@@ -32,6 +35,16 @@ module KnapsackPro
 
         def self.child_status
           $?
+        end
+
+        def self.handle_signal!
+          raise 'Knapsack Pro process was terminated!' if @@terminate_process
+        end
+
+        def trap_signals
+          Signal.trap('TERM') {
+            @@terminate_process = true
+          }
         end
       end
     end

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -43,6 +43,10 @@ module KnapsackPro
           raise 'Knapsack Pro process was terminated!' if @@terminate_process
         end
 
+        def self.set_terminate_process
+          @@terminate_process = true
+        end
+
         def trap_signals
           SIGNALS.each do |signal|
             Signal.trap(signal) {

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -50,7 +50,7 @@ module KnapsackPro
         def trap_signals
           SIGNALS.each do |signal|
             Signal.trap(signal) {
-              KnapsackPro.logger.warn("#{signal} signal has been received. Terminating Knapsack Pro...")
+              puts "#{signal} signal has been received. Terminating Knapsack Pro..."
               @@terminate_process = true
             }
           end

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -22,6 +22,7 @@ module KnapsackPro
             all_test_file_paths: [],
           }
           while accumulator[:status] == :next
+            handle_signal!
             accumulator = run_tests(accumulator)
           end
 

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -29,6 +29,7 @@ module KnapsackPro
             all_test_file_paths: [],
           }
           while accumulator[:status] == :next
+            handle_signal!
             accumulator = run_tests(accumulator)
           end
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -37,6 +37,7 @@ module KnapsackPro
             all_test_file_paths: [],
           }
           while accumulator[:status] == :next
+            handle_signal!
             accumulator = run_tests(accumulator)
           end
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -95,6 +95,15 @@ module KnapsackPro
             exit_code = rspec_runner.run($stderr, $stdout)
             exitstatus = exit_code if exit_code != 0
 
+            if rspec_runner.world.wants_to_quit
+              KnapsackPro.logger.warn('RSpec wants to quit.')
+              set_terminate_process
+            end
+            if rspec_runner.world.rspec_is_quitting
+              KnapsackPro.logger.warn('RSpec is quitting.')
+              set_terminate_process
+            end
+
             printable_args = args_with_seed_option_added_when_viable(args, rspec_runner)
             log_rspec_command(printable_args, test_file_paths, :subset_queue)
 

--- a/lib/tasks/queue/cucumber.rake
+++ b/lib/tasks/queue/cucumber.rake
@@ -4,7 +4,13 @@ namespace :knapsack_pro do
   namespace :queue do
     task :cucumber, [:cucumber_args] do |_, args|
       Kernel.system("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:cucumber_go[#{args[:cucumber_args]}]'")
-      Kernel.exit($?.exitstatus)
+      exitstatus = $?.exitstatus
+      if exitstatus.nil?
+        puts 'Something went wrong. Most likely process has been killed.'
+        Kernel.exit(1)
+      else
+        Kernel.exit(exitstatus)
+      end
     end
 
     task :cucumber_go, [:cucumber_args] do |_, args|

--- a/lib/tasks/queue/cucumber.rake
+++ b/lib/tasks/queue/cucumber.rake
@@ -6,7 +6,7 @@ namespace :knapsack_pro do
       Kernel.system("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:cucumber_go[#{args[:cucumber_args]}]'")
       exitstatus = $?.exitstatus
       if exitstatus.nil?
-        puts 'Something went wrong. Most likely process has been killed.'
+        puts 'Something went wrong. Most likely, the process has been killed. Knapsack Pro has been terminated.'
         Kernel.exit(1)
       else
         Kernel.exit(exitstatus)

--- a/lib/tasks/queue/minitest.rake
+++ b/lib/tasks/queue/minitest.rake
@@ -4,7 +4,13 @@ namespace :knapsack_pro do
   namespace :queue do
     task :minitest, [:minitest_args] do |_, args|
       Kernel.system("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:minitest_go[#{args[:minitest_args]}]'")
-      Kernel.exit($?.exitstatus)
+      exitstatus = $?.exitstatus
+      if exitstatus.nil?
+        puts 'Something went wrong. Most likely process has been killed.'
+        Kernel.exit(1)
+      else
+        Kernel.exit(exitstatus)
+      end
     end
 
     task :minitest_go, [:minitest_args] do |_, args|

--- a/lib/tasks/queue/minitest.rake
+++ b/lib/tasks/queue/minitest.rake
@@ -6,7 +6,7 @@ namespace :knapsack_pro do
       Kernel.system("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:minitest_go[#{args[:minitest_args]}]'")
       exitstatus = $?.exitstatus
       if exitstatus.nil?
-        puts 'Something went wrong. Most likely process has been killed.'
+        puts 'Something went wrong. Most likely, the process has been killed. Knapsack Pro has been terminated.'
         Kernel.exit(1)
       else
         Kernel.exit(exitstatus)

--- a/lib/tasks/queue/rspec.rake
+++ b/lib/tasks/queue/rspec.rake
@@ -6,7 +6,7 @@ namespace :knapsack_pro do
       Kernel.system("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:rspec_go[#{args[:rspec_args]}]'")
       exitstatus = $?.exitstatus
       if exitstatus.nil?
-        puts 'Something went wrong. Most likely process has been killed.'
+        puts 'Something went wrong. Most likely, the process has been killed. Knapsack Pro has been terminated.'
         Kernel.exit(1)
       else
         Kernel.exit(exitstatus)

--- a/lib/tasks/queue/rspec.rake
+++ b/lib/tasks/queue/rspec.rake
@@ -4,7 +4,13 @@ namespace :knapsack_pro do
   namespace :queue do
     task :rspec, [:rspec_args] do |_, args|
       Kernel.system("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:rspec_go[#{args[:rspec_args]}]'")
-      Kernel.exit($?.exitstatus)
+      exitstatus = $?.exitstatus
+      if exitstatus.nil?
+        puts 'Something went wrong. Most likely process has been killed.'
+        Kernel.exit(1)
+      else
+        Kernel.exit(exitstatus)
+      end
     end
 
     task :rspec_go, [:rspec_args] do |_, args|

--- a/spec/knapsack_pro/runners/queue/cucumber_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/cucumber_runner_spec.rb
@@ -41,6 +41,7 @@ describe KnapsackPro::Runners::Queue::CucumberRunner do
           exitstatus: 0,
           all_test_file_paths: [],
         }
+        expect(described_class).to receive(:handle_signal!)
         expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
 
         expect(Kernel).to receive(:exit).with(expected_exitstatus)
@@ -66,6 +67,7 @@ describe KnapsackPro::Runners::Queue::CucumberRunner do
           exitstatus: 0,
           all_test_file_paths: [],
         }
+        expect(described_class).to receive(:handle_signal!)
         expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
 
         expect(Kernel).to receive(:exit).with(expected_exitstatus)

--- a/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/minitest_runner_spec.rb
@@ -43,6 +43,7 @@ describe KnapsackPro::Runners::Queue::MinitestRunner do
           exitstatus: 0,
           all_test_file_paths: [],
         }
+        expect(described_class).to receive(:handle_signal!)
         expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
 
         expect(Kernel).to receive(:exit).with(expected_exitstatus)
@@ -68,6 +69,7 @@ describe KnapsackPro::Runners::Queue::MinitestRunner do
           exitstatus: 0,
           all_test_file_paths: [],
         }
+        expect(described_class).to receive(:handle_signal!)
         expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
 
         expect(Kernel).to receive(:exit).with(expected_exitstatus)

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -49,6 +49,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
             exitstatus: 0,
             all_test_file_paths: [],
           }
+          expect(described_class).to receive(:handle_signal!)
           expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
 
           expect(Kernel).to receive(:exit).with(expected_exitstatus)
@@ -74,6 +75,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
             exitstatus: 0,
             all_test_file_paths: [],
           }
+          expect(described_class).to receive(:handle_signal!)
           expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
 
           expect(Kernel).to receive(:exit).with(expected_exitstatus)
@@ -99,6 +101,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
             exitstatus: 0,
             all_test_file_paths: [],
           }
+          expect(described_class).to receive(:handle_signal!)
           expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
 
           expect(Kernel).to receive(:exit).with(expected_exitstatus)
@@ -124,6 +127,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
             exitstatus: 0,
             all_test_file_paths: [],
           }
+          expect(described_class).to receive(:handle_signal!)
           expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
 
           expect(Kernel).to receive(:exit).with(expected_exitstatus)
@@ -165,6 +169,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
           exitstatus: 0,
           all_test_file_paths: [],
         }
+        expect(described_class).to receive(:handle_signal!)
         expect(described_class).to receive(:run_tests).with(accumulator).and_return(expected_accumulator)
 
         expect(Kernel).to receive(:exit).with(expected_exitstatus)


### PR DESCRIPTION
# problem

When you use AWS Spot Instances, and your CI node is terminated, then it could happen that the RSpec process is somehow stopped and it does not execute tests, but the knapsack_pro gem keeps running and trying to fetch more tests from Queue API and assigns it to RSpec but RSpec does not execute it. Knapsack Pro thinks that you executed tests, and it asks for more tests from Queue API. This leads to allocating too many tests to the terminated CI node.

When the CI node is retried, it will rerun the tests that were assigned in the first place to the terminated CI node index. The retried CI node would get too many tests which lead to very slow tests execution on the CI node index.

# solution

* Let's handle the OS signals like `TERM` signal and stop consuming more tests from Queue API when it happens.

* handle RSpec internal `wants_to_quit` and `rspec_is_quitting` states to stop consuming tests from the Queue API when the CI node is terminated

# story

https://trello.com/c/1UJnbWQG

# how to reproduce the problem and fix on the local project

Run tests with bin script [`bin/knapsack_pro_queue_rspec_record_first_run`](https://github.com/KnapsackPro/rails-app-with-knapsack_pro/blob/master/bin/knapsack_pro_queue_rspec_record_first_run).

You can add a slow test example to one of the spec files like `spec/rake_tasks/dummy_rake_spec.rb` so that your tests would run slow enough and you will be able to perform all the following steps.

```ruby
it 'a slow test example' do
  puts 'SLOW '*40
  sleep 10
end
```

Now when you run `bin/knapsack_pro_queue_rspec_record_first_run` please run also in another terminal:

```
watch -n 3 'ps aux|grep rspec'
```

You will see a PID `29939` of the process, look for something like, please note `rspec_go` in the process name.

```
artur            29939   0.0  0.3 409492640 171088 s023  S+    5:17PM   0:01.65 ruby /Users/artur/.rvm/rubies/ruby-3.2.2/bin/rake knapsack_pro:queue:rspec_go[--format d]
```

Then run:

```
kill -s TERM 29939
```

After you do it, we expect to see the batch of tests fetched from Queue API to be completed and then you see an exception `Knapsack Pro process was terminated!`.

Please note in the Knapsack Pro API logs that there is no more requests to Queue API to fetch more tests because after the batch of tests completed we raised the exception and stopped consuming tests from Queue API. Knapsack Pro can handle the `TERM` signal gracefully.
