### PR TITLE
Improve commit authors tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 5.2.1
+
+* Shallow fetch the last month of commits only on CI
+* Ensure input to `git shortlog`
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/209
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v5.2.0...v5.2.1
+
 ### 5.2.0
 
 * Send authors to the API

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -285,6 +285,11 @@ module KnapsackPro
           ENV['KNAPSACK_PRO_TEST_RUNNER_ADAPTER'] = adapter_class.to_s.split('::').last
         end
 
+        def ci?
+          ENV.fetch('CI', 'false').downcase == 'true' ||
+            detected_ci != KnapsackPro::Config::CI::Base
+        end
+
         private
 
         def required_env(env_name)

--- a/lib/knapsack_pro/repository_adapters/git_adapter.rb
+++ b/lib/knapsack_pro/repository_adapters/git_adapter.rb
@@ -41,7 +41,11 @@ module KnapsackPro
       private
 
       def git_commit_authors
-        `git fetch --shallow-since "1 month ago" --quiet && git shortlog --summary --email --since "one month ago"`
+        if KnapsackPro::Config::Env.ci?
+          `git fetch --shallow-since "one month ago" --quiet`
+        end
+
+        `git shortlog --summary --email --since "one month ago"`
       end
 
       def git_build_author

--- a/lib/knapsack_pro/repository_adapters/git_adapter.rb
+++ b/lib/knapsack_pro/repository_adapters/git_adapter.rb
@@ -41,7 +41,7 @@ module KnapsackPro
       private
 
       def git_commit_authors
-        `git fetch --shallow-since "1 month ago" >/dev/null 2>&1 && git shortlog --summary --email --since "one month ago"`
+        `git fetch --shallow-since "1 month ago" --quiet && git shortlog --summary --email --since "one month ago"`
       end
 
       def git_build_author

--- a/lib/knapsack_pro/repository_adapters/git_adapter.rb
+++ b/lib/knapsack_pro/repository_adapters/git_adapter.rb
@@ -45,7 +45,7 @@ module KnapsackPro
           `git fetch --shallow-since "one month ago" --quiet`
         end
 
-        `git shortlog --summary --email --since "one month ago"`
+        `git log --since "one month ago" | git shortlog --summary --email`
       end
 
       def git_build_author

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -1041,4 +1041,18 @@ describe KnapsackPro::Config::Env do
       end
     end
   end
+
+  describe '.ci?' do
+    [
+      ['CI from env', { 'CI' => 'True' }, true],
+      ['Travis CI', { 'TRAVIS' => 'true' }, true],
+      ['Unsupported', {}, false],
+    ].each do |ci, env, expected|
+      it "detects #{ci}" do
+        stub_const("ENV", env)
+
+        expect(described_class.ci?).to eq(expected)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Tested on:
- CircleCI
- Buildkite
  - this worked also with the previous code
- Github Actions
  - this **did not** work with the previous code
  
More info on the fix: https://stackoverflow.com/questions/73085141/git-shortlog-in-a-github-workflow-for-a-specific-directory
