### PR TITLE
Handle RSpec exceptions when running RSpec in Queue mode (improvements)

### DIFF
--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -96,10 +96,11 @@ module KnapsackPro
               exit_code = rspec_runner.run($stderr, $stdout)
               exitstatus = exit_code if exit_code != 0
             rescue Exception => exception
-              KnapsackPro.logger.debug("Having exception when running rspec: #{exception}")
+              KnapsackPro.logger.error("Having exception when running RSpec: #{exception.inspect}")
               KnapsackPro::Formatters::RSpecQueueSummaryFormatter.print_exit_summary
               KnapsackPro::Hooks::Queue.call_after_subset_queue
               KnapsackPro::Hooks::Queue.call_after_queue
+              Kernel.exit(1)
               raise
             else
               if rspec_runner.world.wants_to_quit

--- a/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/queue/rspec_runner_spec.rb
@@ -212,7 +212,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
         double(world: double(wants_to_quit: rspec_wants_to_quit, rspec_is_quitting: rspec_is_quitting))
       end
 
-      context 'having no exception when running rspec' do
+      context 'having no exception when running RSpec' do
         before do
           subset_queue_id = 'fake-subset-queue-id'
           expect(KnapsackPro::Config::EnvGenerator).to receive(:set_subset_queue_id).and_return(subset_queue_id)
@@ -337,7 +337,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
         end
       end
 
-      context 'having exception when running rspec' do
+      context 'having exception when running RSpec' do
         before do
           subset_queue_id = 'fake-subset-queue-id'
           expect(KnapsackPro::Config::EnvGenerator).to receive(:set_subset_queue_id).and_return(subset_queue_id)
@@ -365,6 +365,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
           allow(KnapsackPro::Hooks::Queue).to receive(:call_after_subset_queue)
           allow(KnapsackPro::Hooks::Queue).to receive(:call_after_queue)
           allow(KnapsackPro::Formatters::RSpecQueueSummaryFormatter).to receive(:print_exit_summary)
+          expect(Kernel).to receive(:exit).with(1)
         end
 
         it 'does not call #save_subset_queue_to_file or #rspec_clear_examples' do
@@ -375,7 +376,7 @@ describe KnapsackPro::Runners::Queue::RSpecRunner do
 
         it 'logs the exception' do
           expect(KnapsackPro).to receive(:logger).once.and_return(logger)
-          expect(logger).to receive(:debug).with("Having exception when running rspec: SystemExit")
+          expect(logger).to receive(:error).with("Having exception when running RSpec: #<SystemExit: SystemExit>")
           expect { subject }.to raise_error SystemExit
         end
 

--- a/spec/knapsack_pro/tracker_spec.rb
+++ b/spec/knapsack_pro/tracker_spec.rb
@@ -185,4 +185,21 @@ describe KnapsackPro::Tracker do
       expect(tracker.prerun_tests_loaded).to be false
     end
   end
+
+
+  describe '#unexecuted_test_files' do
+    before do
+      tracker.set_prerun_tests(['a_spec.rb', 'b_spec.rb', 'c_spec.rb'])
+
+      # measure execution time for b_spec.rb
+      tracker.current_test_path = 'b_spec.rb'
+      tracker.start_timer
+      sleep 0.1
+      tracker.stop_timer
+    end
+
+    it 'returns test files without measured time' do
+      expect(tracker.unexecuted_test_files).to eq(['a_spec.rb', 'c_spec.rb'])
+    end
+  end
 end


### PR DESCRIPTION
* fix(Queue Mode): ensure exit code is 1 when RSpec raised an exception
* Add missing spec for KnapsackPro::Tracker#unexecuted_test_files

# related PR

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/214