### PR TITLE
Use frozen_string_literal: true

### DIFF
--- a/lib/knapsack_pro.rb
+++ b/lib/knapsack_pro.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'singleton'
 require 'net/http'

--- a/lib/knapsack_pro/adapters/base_adapter.rb
+++ b/lib/knapsack_pro/adapters/base_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Adapters
     class BaseAdapter

--- a/lib/knapsack_pro/adapters/cucumber_adapter.rb
+++ b/lib/knapsack_pro/adapters/cucumber_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Adapters
     class CucumberAdapter < BaseAdapter

--- a/lib/knapsack_pro/adapters/minitest_adapter.rb
+++ b/lib/knapsack_pro/adapters/minitest_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Adapters
     class MinitestAdapter < BaseAdapter

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Adapters
     class RSpecAdapter < BaseAdapter

--- a/lib/knapsack_pro/adapters/spinach_adapter.rb
+++ b/lib/knapsack_pro/adapters/spinach_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Adapters
     class SpinachAdapter < BaseAdapter

--- a/lib/knapsack_pro/adapters/test_unit_adapter.rb
+++ b/lib/knapsack_pro/adapters/test_unit_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Adapters
     class TestUnitAdapter < BaseAdapter

--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class Allocator
     def initialize(args)

--- a/lib/knapsack_pro/allocator_builder.rb
+++ b/lib/knapsack_pro/allocator_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class AllocatorBuilder < BaseAllocatorBuilder
     def allocator

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class BaseAllocatorBuilder
     TEST_RUNNER_MAP = {

--- a/lib/knapsack_pro/build_distribution_fetcher.rb
+++ b/lib/knapsack_pro/build_distribution_fetcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class BuildDistributionFetcher
     class BuildDistributionEntity

--- a/lib/knapsack_pro/client/api/action.rb
+++ b/lib/knapsack_pro/client/api/action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Client
     module API

--- a/lib/knapsack_pro/client/api/v1/base.rb
+++ b/lib/knapsack_pro/client/api/v1/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Client
     module API

--- a/lib/knapsack_pro/client/api/v1/build_distributions.rb
+++ b/lib/knapsack_pro/client/api/v1/build_distributions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Client
     module API

--- a/lib/knapsack_pro/client/api/v1/build_subsets.rb
+++ b/lib/knapsack_pro/client/api/v1/build_subsets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Client
     module API

--- a/lib/knapsack_pro/client/api/v1/queues.rb
+++ b/lib/knapsack_pro/client/api/v1/queues.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Client
     module API

--- a/lib/knapsack_pro/client/connection.rb
+++ b/lib/knapsack_pro/client/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Client
     class Connection

--- a/lib/knapsack_pro/config/ci/app_veyor.rb
+++ b/lib/knapsack_pro/config/ci/app_veyor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # https://www.appveyor.com/docs/environment-variables/
 module KnapsackPro
   module Config

--- a/lib/knapsack_pro/config/ci/base.rb
+++ b/lib/knapsack_pro/config/ci/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     module CI

--- a/lib/knapsack_pro/config/ci/buildkite.rb
+++ b/lib/knapsack_pro/config/ci/buildkite.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     module CI

--- a/lib/knapsack_pro/config/ci/circle.rb
+++ b/lib/knapsack_pro/config/ci/circle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     module CI

--- a/lib/knapsack_pro/config/ci/cirrus_ci.rb
+++ b/lib/knapsack_pro/config/ci/cirrus_ci.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     module CI

--- a/lib/knapsack_pro/config/ci/codefresh.rb
+++ b/lib/knapsack_pro/config/ci/codefresh.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # https://codefresh.io/docs/docs/codefresh-yaml/variables/#system-provided-variables
 module KnapsackPro
   module Config

--- a/lib/knapsack_pro/config/ci/codeship.rb
+++ b/lib/knapsack_pro/config/ci/codeship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     module CI

--- a/lib/knapsack_pro/config/ci/github_actions.rb
+++ b/lib/knapsack_pro/config/ci/github_actions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
 module KnapsackPro
   module Config

--- a/lib/knapsack_pro/config/ci/gitlab_ci.rb
+++ b/lib/knapsack_pro/config/ci/gitlab_ci.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # https://docs.gitlab.com/ce/ci/variables/
 module KnapsackPro
   module Config

--- a/lib/knapsack_pro/config/ci/heroku.rb
+++ b/lib/knapsack_pro/config/ci/heroku.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     module CI

--- a/lib/knapsack_pro/config/ci/semaphore.rb
+++ b/lib/knapsack_pro/config/ci/semaphore.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     module CI

--- a/lib/knapsack_pro/config/ci/semaphore2.rb
+++ b/lib/knapsack_pro/config/ci/semaphore2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # https://docs.semaphoreci.com/article/12-environment-variables
 module KnapsackPro
   module Config

--- a/lib/knapsack_pro/config/ci/travis.rb
+++ b/lib/knapsack_pro/config/ci/travis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     module CI

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     class Env

--- a/lib/knapsack_pro/config/env_generator.rb
+++ b/lib/knapsack_pro/config/env_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     class EnvGenerator

--- a/lib/knapsack_pro/config/temp_files.rb
+++ b/lib/knapsack_pro/config/temp_files.rb
@@ -24,10 +24,12 @@ module KnapsackPro
       end
 
       def self.gitignore_file_content
-        "# This directory is used by knapsack_pro gem for storing temporary files during tests runtime.\n" <<
-        "# Ignore all files, and do not commit this directory into your repository.\n" <<
-        "# Learn more at https://knapsackpro.com\n" <<
-        "*"
+        <<~GITIGNORE
+        # This directory is used by knapsack_pro gem for storing temporary files during tests runtime.
+        # Ignore all files, and do not commit this directory into your repository.
+        # Learn more at https://knapsackpro.com
+        *
+        GITIGNORE
       end
 
       def self.create_gitignore_file!

--- a/lib/knapsack_pro/config/temp_files.rb
+++ b/lib/knapsack_pro/config/temp_files.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Config
     class TempFiles

--- a/lib/knapsack_pro/crypto/branch_encryptor.rb
+++ b/lib/knapsack_pro/crypto/branch_encryptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Crypto
     class BranchEncryptor

--- a/lib/knapsack_pro/crypto/decryptor.rb
+++ b/lib/knapsack_pro/crypto/decryptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Crypto
     class Decryptor

--- a/lib/knapsack_pro/crypto/digestor.rb
+++ b/lib/knapsack_pro/crypto/digestor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Crypto
     class Digestor

--- a/lib/knapsack_pro/crypto/encryptor.rb
+++ b/lib/knapsack_pro/crypto/encryptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Crypto
     class Encryptor

--- a/lib/knapsack_pro/extensions/time.rb
+++ b/lib/knapsack_pro/extensions/time.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'time'
 
 class Time

--- a/lib/knapsack_pro/formatters/rspec_json_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_json_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_core('formatters/json_formatter')
 
 # based on https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/formatters/json_formatter.rb

--- a/lib/knapsack_pro/formatters/rspec_queue_profile_formatter_extension.rb
+++ b/lib/knapsack_pro/formatters/rspec_queue_profile_formatter_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_core('formatters/profile_formatter')
 
 module KnapsackPro

--- a/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
+++ b/lib/knapsack_pro/formatters/rspec_queue_summary_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Support.require_rspec_core('formatters/base_formatter')
 RSpec::Support.require_rspec_core('formatters/base_text_formatter')
 

--- a/lib/knapsack_pro/hooks/queue.rb
+++ b/lib/knapsack_pro/hooks/queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Hooks
     class Queue

--- a/lib/knapsack_pro/logger_wrapper.rb
+++ b/lib/knapsack_pro/logger_wrapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class LoggerWrapper
     def initialize(logger)

--- a/lib/knapsack_pro/mask_string.rb
+++ b/lib/knapsack_pro/mask_string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class MaskString
     def self.call(string)

--- a/lib/knapsack_pro/presenter.rb
+++ b/lib/knapsack_pro/presenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class Presenter
     class << self

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class QueueAllocator
     def initialize(args)

--- a/lib/knapsack_pro/queue_allocator_builder.rb
+++ b/lib/knapsack_pro/queue_allocator_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class QueueAllocatorBuilder < BaseAllocatorBuilder
     def allocator

--- a/lib/knapsack_pro/railtie.rb
+++ b/lib/knapsack_pro/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails'
 require 'knapsack_pro'
 

--- a/lib/knapsack_pro/report.rb
+++ b/lib/knapsack_pro/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class Report
     def self.save

--- a/lib/knapsack_pro/repository_adapter_initiator.rb
+++ b/lib/knapsack_pro/repository_adapter_initiator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class RepositoryAdapterInitiator
     def self.call

--- a/lib/knapsack_pro/repository_adapters/base_adapter.rb
+++ b/lib/knapsack_pro/repository_adapters/base_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module RepositoryAdapters
     class BaseAdapter

--- a/lib/knapsack_pro/repository_adapters/env_adapter.rb
+++ b/lib/knapsack_pro/repository_adapters/env_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module RepositoryAdapters
     class EnvAdapter < BaseAdapter

--- a/lib/knapsack_pro/repository_adapters/git_adapter.rb
+++ b/lib/knapsack_pro/repository_adapters/git_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module RepositoryAdapters
     class GitAdapter < BaseAdapter

--- a/lib/knapsack_pro/runners/base_runner.rb
+++ b/lib/knapsack_pro/runners/base_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     class BaseRunner

--- a/lib/knapsack_pro/runners/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/cucumber_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     class CucumberRunner < BaseRunner

--- a/lib/knapsack_pro/runners/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/minitest_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     class MinitestRunner < BaseRunner

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     module Queue

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     module Queue

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     module Queue

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     module Queue

--- a/lib/knapsack_pro/runners/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/rspec_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     class RSpecRunner < BaseRunner

--- a/lib/knapsack_pro/runners/spinach_runner.rb
+++ b/lib/knapsack_pro/runners/spinach_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     class SpinachRunner < BaseRunner

--- a/lib/knapsack_pro/runners/test_unit_runner.rb
+++ b/lib/knapsack_pro/runners/test_unit_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module Runners
     class TestUnitRunner < BaseRunner

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class SlowTestFileDeterminer
     TIME_THRESHOLD_PER_CI_NODE = 0.7 # 70%

--- a/lib/knapsack_pro/slow_test_file_finder.rb
+++ b/lib/knapsack_pro/slow_test_file_finder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class SlowTestFileFinder
     # Get recorded test files from API.

--- a/lib/knapsack_pro/task_loader.rb
+++ b/lib/knapsack_pro/task_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake'
 
 module KnapsackPro

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module TestCaseDetectors
     class RSpecTestExampleDetector

--- a/lib/knapsack_pro/test_case_mergers/base_merger.rb
+++ b/lib/knapsack_pro/test_case_mergers/base_merger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module TestCaseMergers
     class BaseMerger

--- a/lib/knapsack_pro/test_case_mergers/rspec_merger.rb
+++ b/lib/knapsack_pro/test_case_mergers/rspec_merger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   module TestCaseMergers
     class RSpecMerger < BaseMerger

--- a/lib/knapsack_pro/test_file_cleaner.rb
+++ b/lib/knapsack_pro/test_file_cleaner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class TestFileCleaner
     def self.clean(test_file_path)

--- a/lib/knapsack_pro/test_file_finder.rb
+++ b/lib/knapsack_pro/test_file_finder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class TestFileFinder
     def self.call(test_file_pattern, test_file_list_enabled: true)

--- a/lib/knapsack_pro/test_file_pattern.rb
+++ b/lib/knapsack_pro/test_file_pattern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class TestFilePattern
     def self.call(adapter_class)

--- a/lib/knapsack_pro/test_file_presenter.rb
+++ b/lib/knapsack_pro/test_file_presenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class TestFilePresenter
     def self.stringify_paths(test_file_paths)

--- a/lib/knapsack_pro/test_files_with_test_cases_composer.rb
+++ b/lib/knapsack_pro/test_files_with_test_cases_composer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class TestFilesWithTestCasesComposer
     # Args:

--- a/lib/knapsack_pro/test_flat_distributor.rb
+++ b/lib/knapsack_pro/test_flat_distributor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class TestFlatDistributor
     DIR_TYPES = [

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class Tracker
     include Singleton

--- a/lib/knapsack_pro/utils.rb
+++ b/lib/knapsack_pro/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   class Utils
     def self.unsymbolize(obj)

--- a/lib/knapsack_pro/version.rb
+++ b/lib/knapsack_pro/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module KnapsackPro
   VERSION = '5.4.1'
 end

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do

--- a/lib/tasks/encrypted_branch_names.rake
+++ b/lib/tasks/encrypted_branch_names.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do

--- a/lib/tasks/encrypted_test_file_names.rake
+++ b/lib/tasks/encrypted_test_file_names.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do

--- a/lib/tasks/minitest.rake
+++ b/lib/tasks/minitest.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do

--- a/lib/tasks/queue/cucumber.rake
+++ b/lib/tasks/queue/cucumber.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do

--- a/lib/tasks/queue/minitest.rake
+++ b/lib/tasks/queue/minitest.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do

--- a/lib/tasks/queue/rspec.rake
+++ b/lib/tasks/queue/rspec.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do

--- a/lib/tasks/salt.rake
+++ b/lib/tasks/salt.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :knapsack_pro do
   task :salt, [:size] do |_, args|
     default_size = 32

--- a/lib/tasks/spinach.rake
+++ b/lib/tasks/spinach.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do

--- a/lib/tasks/test_unit.rake
+++ b/lib/tasks/test_unit.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'knapsack_pro'
 
 namespace :knapsack_pro do


### PR DESCRIPTION
This can help reduce memory, by making string literals frozen. That means they are only allocated once in the file, instead of each time the code executes.

Noticed this while starting to profile for https://github.com/KnapsackPro/knapsack_pro-ruby/issues/200