### PR TITLE
Performance improvement: don't run `rake knapsack_pro:rspec_test_example_detector` when no slow test files are detected for RSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 5.7.0
+
+* Performance improvement: don't run `rake knapsack_pro:rspec_test_example_detector` when no slow test files are detected for RSpec.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/225
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v5.6.0...v5.7.0
+
 ### 5.6.0
 
 * Use `frozen_string_literal: true` to reduce memory usage

--- a/lib/knapsack_pro/adapters/base_adapter.rb
+++ b/lib/knapsack_pro/adapters/base_adapter.rb
@@ -11,6 +11,14 @@ module KnapsackPro
         "#{KnapsackPro::Config::TempFiles::TEMP_DIRECTORY_PATH}/#{adapter_name}-bind_method_called_for_node_#{KnapsackPro::Config::Env.ci_node_index}.txt"
       end
 
+      def self.split_by_test_cases_enabled?
+        false
+      end
+
+      def self.test_file_cases_for(slow_test_files)
+        raise NotImplementedError
+      end
+
       def self.slow_test_file?(adapter_class, test_file_path)
         @slow_test_file_paths ||=
           begin

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -17,7 +17,7 @@ module KnapsackPro
       end
 
       def self.test_file_cases_for(slow_test_files)
-        KnapsackPro.logger.info("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual 'it's. Thanks to that a single slow test file can be split across parallel CI nodes). Analyzing #{slow_test_files.size} slow test files.")
+        KnapsackPro.logger.info("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual test cases). Thanks to that, a single slow test file can be split across parallel CI nodes. Analyzing #{slow_test_files.size} slow test files.")
 
         # generate the RSpec JSON report in a separate process to not pollute the RSpec state
         cmd = [

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -5,6 +5,35 @@ module KnapsackPro
     class RSpecAdapter < BaseAdapter
       TEST_DIR_PATTERN = 'spec/**{,/*/**}/*_spec.rb'
 
+      def self.split_by_test_cases_enabled?
+        return false unless KnapsackPro::Config::Env.rspec_split_by_test_examples?
+
+        require 'rspec/core/version'
+        unless Gem::Version.new(::RSpec::Core::Version::STRING) >= Gem::Version.new('3.3.0')
+          raise "RSpec >= 3.3.0 is required to split test files by test examples. Learn more: #{KnapsackPro::Urls::SPLIT_BY_TEST_EXAMPLES}"
+        end
+
+        true
+      end
+
+      def self.test_file_cases_for(slow_test_files)
+        KnapsackPro.logger.info("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual 'it's. Thanks to that a single slow test file can be split across parallel CI nodes). Analyzing #{slow_test_files.size} slow test files.")
+
+        # generate the RSpec JSON report in a separate process to not pollute the RSpec state
+        cmd = [
+          'RACK_ENV=test',
+          'RAILS_ENV=test',
+          KnapsackPro::Config::Env.rspec_test_example_detector_prefix,
+          'rake knapsack_pro:rspec_test_example_detector',
+        ].join(' ')
+        unless Kernel.system(cmd)
+          raise "Could not generate JSON report for RSpec. Rake task failed when running #{cmd}"
+        end
+
+        # read the JSON report
+        KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector.new.test_file_example_paths
+      end
+
       def self.ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!(cli_args)
         if KnapsackPro::Config::Env.rspec_split_by_test_examples? && has_tag_option?(cli_args)
           error_message = "It is not allowed to use the RSpec tag option together with the RSpec split by test examples feature. Please see: #{KnapsackPro::Urls::RSPEC__SPLIT_BY_TEST_EXAMPLES__TAG}"

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -42,28 +42,14 @@ module KnapsackPro
         end
 
         slow_test_files = get_slow_test_files
+        return test_files_to_run if slow_test_files.empty?
 
-        KnapsackPro.logger.info("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual 'it's. Thanks to that a single slow test file can be split across parallel CI nodes). Analyzing #{slow_test_files.size} slow test files.")
+        test_file_example_paths = rspec_test_file_example_paths_for_slow_test_files(slow_test_files)
 
-        # generate RSpec JSON report in separate process to not pollute RSpec state
-        cmd = [
-          'RACK_ENV=test',
-          'RAILS_ENV=test',
-          KnapsackPro::Config::Env.rspec_test_example_detector_prefix,
-          'rake knapsack_pro:rspec_test_example_detector',
-        ].join(' ')
-        unless Kernel.system(cmd)
-          raise "Could not generate JSON report for RSpec. Rake task failed when running #{cmd}"
-        end
-
-        # read JSON report
-        detector = KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector.new
-        test_file_example_paths = detector.test_file_example_paths
-
-        KnapsackPro::TestFilesWithTestCasesComposer.call(test_files_to_run, slow_test_files, test_file_example_paths)
-      else
-        test_files_to_run
+        return KnapsackPro::TestFilesWithTestCasesComposer.call(test_files_to_run, slow_test_files, test_file_example_paths)
       end
+
+      test_files_to_run
     end
 
     private
@@ -100,6 +86,25 @@ module KnapsackPro
         end
       KnapsackPro.logger.debug("Detected #{slow_test_files.size} slow test files: #{slow_test_files.inspect}")
       slow_test_files
+    end
+
+    def rspec_test_file_example_paths_for_slow_test_files(slow_test_files)
+      KnapsackPro.logger.info("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual 'it's. Thanks to that a single slow test file can be split across parallel CI nodes). Analyzing #{slow_test_files.size} slow test files.")
+
+      # generate the RSpec JSON report in a separate process to not pollute the RSpec state
+      cmd = [
+        'RACK_ENV=test',
+        'RAILS_ENV=test',
+        KnapsackPro::Config::Env.rspec_test_example_detector_prefix,
+        'rake knapsack_pro:rspec_test_example_detector',
+      ].join(' ')
+      unless Kernel.system(cmd)
+        raise "Could not generate JSON report for RSpec. Rake task failed when running #{cmd}"
+      end
+
+      # read the JSON report
+      detector = KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector.new
+      test_file_example_paths = detector.test_file_example_paths
     end
   end
 end

--- a/spec/knapsack_pro/adapters/base_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/base_adapter_spec.rb
@@ -42,6 +42,18 @@ describe KnapsackPro::Adapters::BaseAdapter do
     end
   end
 
+  describe '.split_by_test_cases_enabled?' do
+    subject { described_class.split_by_test_cases_enabled? }
+
+    it { expect(subject).to be false }
+  end
+
+  describe '.test_file_cases_for' do
+    subject { described_class.test_file_cases_for([]) }
+
+    it { expect { subject }.to raise_error NotImplementedError }
+  end
+
   describe '.slow_test_file?' do
     let(:adapter_class) { double }
     let(:slow_test_files) do

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -42,6 +42,37 @@ describe KnapsackPro::Adapters::RSpecAdapter do
     end
   end
 
+  describe '.test_file_cases_for' do
+    let(:slow_test_files) do
+      [
+        '1_spec.rb',
+        '2_spec.rb',
+        '3_spec.rb',
+        '4_spec.rb',
+        '5_spec.rb',
+      ]
+    end
+
+    subject { described_class.test_file_cases_for(slow_test_files) }
+
+    it 'returns test example paths for slow test files' do
+      logger = instance_double(Logger)
+      expect(KnapsackPro).to receive(:logger).and_return(logger)
+      expect(logger).to receive(:info).with("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual 'it's. Thanks to that a single slow test file can be split across parallel CI nodes). Analyzing 5 slow test files.")
+
+      cmd = 'RACK_ENV=test RAILS_ENV=test bundle exec rake knapsack_pro:rspec_test_example_detector'
+      expect(Kernel).to receive(:system).with(cmd).and_return(true)
+
+      rspec_test_example_detector = instance_double(KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector)
+      expect(KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector).to receive(:new).and_return(rspec_test_example_detector)
+
+      test_file_example_paths = double
+      expect(rspec_test_example_detector).to receive(:test_file_example_paths).and_return(test_file_example_paths)
+
+      expect(subject).to eq test_file_example_paths
+    end
+  end
+
   describe '.ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!' do
     let(:cli_args) { double }
 

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -24,7 +24,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
 
       it { expect(subject).to be true }
 
-      context 'when RSpec version < 3.3.0' do
+      context 'when the RSpec version is < 3.3.0' do
         before do
           stub_const('RSpec::Core::Version::STRING', '3.2.0')
         end
@@ -58,7 +58,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
     before do
       logger = instance_double(Logger)
       expect(KnapsackPro).to receive(:logger).and_return(logger)
-      expect(logger).to receive(:info).with("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual 'it's. Thanks to that a single slow test file can be split across parallel CI nodes). Analyzing 5 slow test files.")
+      expect(logger).to receive(:info).with("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual test cases). Thanks to that, a single slow test file can be split across parallel CI nodes. Analyzing 5 slow test files.")
 
       cmd = 'RACK_ENV=test RAILS_ENV=test bundle exec rake knapsack_pro:rspec_test_example_detector'
       expect(Kernel).to receive(:system).with(cmd).and_return(cmd_result)

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -12,6 +12,36 @@ describe KnapsackPro::Adapters::RSpecAdapter do
     it_behaves_like 'adapter'
   end
 
+  describe '.split_by_test_cases_enabled?' do
+    subject { described_class.split_by_test_cases_enabled? }
+
+    before do
+      expect(KnapsackPro::Config::Env).to receive(:rspec_split_by_test_examples?).and_return(rspec_split_by_test_examples_enabled)
+    end
+
+    context 'when RSpec split by test examples enabled' do
+      let(:rspec_split_by_test_examples_enabled) { true }
+
+      it { expect(subject).to be true }
+
+      context 'when RSpec version < 3.3.0' do
+        before do
+          stub_const('RSpec::Core::Version::STRING', '3.2.0')
+        end
+
+        it do
+          expect { subject }.to raise_error RuntimeError, 'RSpec >= 3.3.0 is required to split test files by test examples. Learn more: https://knapsackpro.com/perma/ruby/split-by-test-examples'
+        end
+      end
+    end
+
+    context 'when RSpec split by test examples disabled' do
+      let(:rspec_split_by_test_examples_enabled) { false }
+
+      it { expect(subject).to be false }
+    end
+  end
+
   describe '.ensure_no_tag_option_when_rspec_split_by_test_examples_enabled!' do
     let(:cli_args) { double }
 

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -19,7 +19,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
       expect(KnapsackPro::Config::Env).to receive(:rspec_split_by_test_examples?).and_return(rspec_split_by_test_examples_enabled)
     end
 
-    context 'when RSpec split by test examples enabled' do
+    context 'when the RSpec split by test examples is enabled' do
       let(:rspec_split_by_test_examples_enabled) { true }
 
       it { expect(subject).to be true }
@@ -35,7 +35,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
       end
     end
 
-    context 'when RSpec split by test examples disabled' do
+    context 'when the RSpec split by test examples is disabled' do
       let(:rspec_split_by_test_examples_enabled) { false }
 
       it { expect(subject).to be false }

--- a/spec/knapsack_pro/base_allocator_builder_spec.rb
+++ b/spec/knapsack_pro/base_allocator_builder_spec.rb
@@ -165,66 +165,8 @@ describe KnapsackPro::BaseAllocatorBuilder do
       context 'when slow test files are not detected' do
         let(:slow_test_files) { [] }
 
-        it 'returns test files to run based on test files on the disk' do
+        it 'returns test files without test cases' do
           expect(subject).to eq test_files_to_run
-        end
-      end
-    end
-
-    context 'when RSpec adapter AND rspec split by test examples is enabled' do
-      let(:adapter_class) { KnapsackPro::Adapters::RSpecAdapter }
-      let(:test_files_to_run) { double }
-      let(:cmd) { 'RACK_ENV=test RAILS_ENV=test bundle exec rake knapsack_pro:rspec_test_example_detector' }
-
-      before do
-        expect(KnapsackPro::Config::Env).to receive(:rspec_split_by_test_examples?).and_return(true)
-
-        test_file_pattern = double
-        expect(KnapsackPro::TestFilePattern).to receive(:call).with(adapter_class).and_return(test_file_pattern)
-
-        expect(KnapsackPro::TestFileFinder).to receive(:call).with(test_file_pattern).and_return(test_files_to_run)
-      end
-
-      context 'when rake task to detect RSpec test examples works' do
-        let(:slow_test_files) { double(size: 5, empty?: false) }
-        let(:cmd_result) { true }
-        let(:test_file_example_paths) { double }
-        let(:logger) { instance_double(Logger) }
-        let(:test_files_with_test_cases) { double }
-
-        before do
-          expect(allocator_builder).to receive(:get_slow_test_files).and_return(slow_test_files)
-
-          expect(KnapsackPro).to receive(:logger).and_return(logger)
-
-          expect(Kernel).to receive(:system).with(cmd).and_return(cmd_result)
-
-          rspec_test_example_detector = instance_double(KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector)
-          expect(KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector).to receive(:new).and_return(rspec_test_example_detector)
-          expect(rspec_test_example_detector).to receive(:test_file_example_paths).and_return(test_file_example_paths)
-
-          expect(KnapsackPro::TestFilesWithTestCasesComposer).to receive(:call).with(test_files_to_run, slow_test_files, test_file_example_paths).and_return(test_files_with_test_cases)
-        end
-
-        it do
-          expect(logger).to receive(:info).with("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual 'it's. Thanks to that a single slow test file can be split across parallel CI nodes). Analyzing 5 slow test files.")
-
-          expect(subject).to eq test_files_with_test_cases
-        end
-      end
-
-      context 'when rake task to detect RSpec test examples failed' do
-        let(:slow_test_files) { double(size: 5, empty?: false) }
-        let(:cmd_result) { false }
-
-        before do
-          expect(allocator_builder).to receive(:get_slow_test_files).and_return(slow_test_files)
-
-          expect(Kernel).to receive(:system).with(cmd).and_return(cmd_result)
-        end
-
-        it do
-          expect { subject }.to raise_error(RuntimeError, 'Could not generate JSON report for RSpec. Rake task failed when running RACK_ENV=test RAILS_ENV=test bundle exec rake knapsack_pro:rspec_test_example_detector')
         end
       end
     end

--- a/spec/knapsack_pro/base_allocator_builder_spec.rb
+++ b/spec/knapsack_pro/base_allocator_builder_spec.rb
@@ -154,7 +154,7 @@ describe KnapsackPro::BaseAllocatorBuilder do
       end
 
       context 'when rake task to detect RSpec test examples works' do
-        let(:slow_test_files) { double(size: 5) }
+        let(:slow_test_files) { double(size: 5, empty?: false) }
         let(:cmd_result) { true }
         let(:test_file_example_paths) { double }
         let(:logger) { instance_double(Logger) }
@@ -182,7 +182,7 @@ describe KnapsackPro::BaseAllocatorBuilder do
       end
 
       context 'when rake task to detect RSpec test examples failed' do
-        let(:slow_test_files) { double(size: 5) }
+        let(:slow_test_files) { double(size: 5, empty?: false) }
         let(:cmd_result) { false }
 
         before do

--- a/spec/knapsack_pro/base_allocator_builder_spec.rb
+++ b/spec/knapsack_pro/base_allocator_builder_spec.rb
@@ -143,16 +143,6 @@ describe KnapsackPro::BaseAllocatorBuilder do
         expect(KnapsackPro::TestFileFinder).to receive(:call).with(test_file_pattern).and_return(test_files_to_run)
       end
 
-      context 'when RSpec version < 3.3.0' do
-        before do
-          stub_const('RSpec::Core::Version::STRING', '3.2.0')
-        end
-
-        it do
-          expect { subject }.to raise_error RuntimeError, 'RSpec >= 3.3.0 is required to split test files by test examples. Learn more: https://knapsackpro.com/perma/ruby/split-by-test-examples'
-        end
-      end
-
       context 'when rake task to detect RSpec test examples works' do
         let(:slow_test_files) { double(size: 5, empty?: false) }
         let(:cmd_result) { true }


### PR DESCRIPTION
Performance improvement: don't run `rake knapsack_pro:rspec_test_example_detector` when no slow test files are detected for RSpec. 

Thanks to that, we improve performance and save a few or a dozen seconds (depending on the project's complexity).

# Related issues

* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/223
* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/224

# development testing

This PR change was tested with a [bin script](https://github.com/KnapsackPro/rails-app-with-knapsack_pro/blob/0e84152883167e4bb197ebc4c05bb9bde5e3b811/bin/knapsack_pro_queue_rspec_split_by_test_examples_unique_build#L5).