### PR TITLE
fix(RSpec): allow to use Queue Mode for RSpec <= 3.10 when the `rspec_is_quitting` method is not present for RSpec World object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 6.0.1
+
+* fix(RSpec): allow to use Queue Mode for RSpec <= 3.10 when the `rspec_is_quitting` method is not present for RSpec World object
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/231
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v6.0.0...v6.0.1
+
 ### 6.0.0
 
 * __(breaking change)__ Dropped support for Turnip < 2.0.0

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -110,7 +110,7 @@ module KnapsackPro
                 KnapsackPro.logger.warn('RSpec wants to quit.')
                 set_terminate_process
               end
-              if rspec_runner.world.rspec_is_quitting
+              if rspec_runner.world.respond_to?(:rspec_is_quitting) && rspec_runner.world.rspec_is_quitting
                 KnapsackPro.logger.warn('RSpec is quitting.')
                 set_terminate_process
               end


### PR DESCRIPTION
# story

https://trello.com/c/0ZISAmYr

# bug in RSpec 3.10

RSpec 3.10 has no method `rspec_is_quitting` and it fails when you use Queue Mode in the knapsack_pro gem.

RSpec 3.10 - the `rspec_is_quitting` method is missing: https://github.com/rspec/rspec-core/blob/v3.10.0/lib/rspec/core/world.rb

RSpec 3.12 - [has the method](https://github.com/rspec/rspec-core/blob/1eeadce5aa7137ead054783c31ff35cbfe9d07cc/lib/rspec/core/world.rb#L18)

# fix

Call the `rspec_is_quitting` method only if it exists on RSpec World object.