### PR TITLE
Fix Turnip and UNKNOWN_PATH error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 6.0.3
+
+* fix(Turnip): make sure `.feature` files are recorded
+* fix(RSpec): stop recording `UNKNOWN_PATH` that would generate an error in case of a CI node retry
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/233
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v6.0.2...v6.0.3
+
 ### 6.0.2
 
 * fix(RSpec): allow using `TimeTracker` in RSpec < 3.10.2 when formatters were required to expose `#output`

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -65,7 +65,7 @@ module KnapsackPro
         ]
           .each do |path|
             p = path.call
-            return p if p.include?('_spec.rb')
+            return p if p.include?('_spec.rb') || p.include?('.feature')
           end
 
         return ''

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -115,8 +115,9 @@ module KnapsackPro
 
       def record_example(accumulator, example, started_at)
         path = path_for(example)
-        time_execution = time_execution_for(example, started_at)
+        return if path.nil?
 
+        time_execution = time_execution_for(example, started_at)
         if accumulator.key?(path)
           accumulator[path][:time_execution] += time_execution
         else
@@ -126,7 +127,8 @@ module KnapsackPro
 
       def path_for(example)
         file = file_path_for(example)
-        return "UNKNOWN_PATH" if file == ""
+        return nil if file == ""
+
         path = rspec_split_by_test_example?(file) ? example.id : file
         KnapsackPro::TestFileCleaner.clean(path)
       end

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -305,6 +305,15 @@ describe KnapsackPro::Adapters::RSpecAdapter do
         expect(subject).to eq('')
       end
     end
+
+    context "when id does not end in .feature (nor _spec.rb)" do
+      it "returns the file_path" do
+        allow(current_example).to receive(:id).and_return("./foo.rb")
+        allow(current_example).to receive(:metadata).and_return(file_path: "./foo.feature")
+
+        expect(subject).to eq("./foo.feature")
+      end
+    end
   end
 
   describe 'bind methods' do

--- a/spec/knapsack_pro/formatters/time_tracker_specs.rb
+++ b/spec/knapsack_pro/formatters/time_tracker_specs.rb
@@ -280,9 +280,9 @@ class TestTimeTracker
     SPEC
 
     run_specs(spec) do |spec_paths, times|
-      raise unless times.size == 2
-      raise unless times[0]["path"] == "UNKNOWN_PATH"
-      raise unless times[1]["path"] == spec_paths.first
+      raise unless times.size == 1
+      raise unless times[0]["path"] == spec_paths.first
+      raise unless times[0]["time_execution"] == 0.0
     end
 
   ensure
@@ -431,7 +431,7 @@ class TestTimeTracker
       .queue(paths)
       .sort_by { |time| time["path"] }
       .filter do |time|
-        paths.any? { |path| time["path"].start_with?(path) || time["path"] == "UNKNOWN_PATH" }
+        paths.any? { |path| time["path"].start_with?(path) }
       end
     yield(paths, times, time_tracker)
 


### PR DESCRIPTION
Turnip specs have a different naming format than RSpec's: `foo.feature` vs `foo_spec.rb`.

This PR makes sure `.feature` files are recorded.

Also, it stops recording `UNKNOWN_PATH` that would generate an error in case of a CI node retry (see below for details).

## Reproduce
- In rails-app-with-knapsack-pro
  - `git commit --allow-empty -m wip`
  - `bin/knapsack_pro_queue_turnip 0 2 20231207-01`
  - `bin/knapsack_pro_queue_turnip 0 2 20231207-01`

You should get:

```
D, [2023-12-07T14:08:19.969425 #14329] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-07T14:08:19.969501 #14329] DEBUG -- : [knapsack_pro] API request UUID: 668869b5-a70d-4261-a624-3f47e31d9971
D, [2023-12-07T14:08:19.969553 #14329] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-07T14:08:19.969650 #14329] DEBUG -- : [knapsack_pro] {"queue_name"=>nil, "build_subset_id"=>"24fcce5d-06b5-4f96-bcff-2e9e4aba3292", "test_files"=>[{"path
"=>"UNKNOWN_PATH", "time_execution"=>0.09200099995359778}, {"path"=>"turnip/acceptance/foo.feature", "time_execution"=>0.0}]}
D, [2023-12-07T14:08:19.995617 #14329] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.

An error occurred while loading ./UNKNOWN_PATH.
Failure/Error: super

LoadError:
  cannot load such file -- /Users/riccardoodone/code/knapsack/rails-app-with-knapsack_pro/UNKNOWN_PATH
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/turnip-4.4.0/lib/turnip/rspec.rb:20:in `load'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/turnip-4.4.0/lib/turnip/rspec.rb:20:in `load'
# /Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:99:in `run_tests'
# /Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:46:in `run'
# /Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/tasks/queue/rspec.rake:19:in `block (3 levels) in <top (required)>'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/task.rb:279:in `block in execute'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/task.rb:279:in `each'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/task.rb:279:in `execute'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/task.rb:199:in `synchronize'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/task.rb:199:in `invoke_with_call_chain'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/task.rb:188:in `invoke'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/application.rb:182:in `invoke_task'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/application.rb:138:in `block (2 levels) in top_level'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/application.rb:138:in `each'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/application.rb:138:in `block in top_level'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/application.rb:147:in `run_with_threads'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/application.rb:132:in `top_level'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/application.rb:83:in `block in run'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/application.rb:208:in `standard_exception_handling'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/lib/rake/application.rb:80:in `run'
# /Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/exe/rake:27:in `<top (required)>'


W, [2023-12-07T14:08:21.577595 #14329]  WARN -- : [knapsack_pro] RSpec wants to quit.
I, [2023-12-07T14:08:21.580675 #14329]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on you
r machine:
I, [2023-12-07T14:08:21.580760 #14329]  INFO -- : [knapsack_pro] bundle exec rspec -r turnip/rspec --format progress --default-path turnip "UNKNOWN_PATH" "turnip/acc
eptance/foo.feature"
rake aborted!
Knapsack Pro process was terminated!
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/base_runner.rb:45:in `handle_signal!'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:45:in `run'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/tasks/queue/rspec.rake:19:in `block (3 levels) in <top (required)>'
/Users/riccardoodone/.rvm/gems/ruby-3.2.2/gems/rake-13.1.0/exe/rake:27:in `<top (required)>'
/Users/riccardoodone/.rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `eval'
/Users/riccardoodone/.rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `<main>'
Tasks: TOP => knapsack_pro:queue:rspec_go
(See full trace by running task with --trace)

```