### PR TITLE
Minitest: avoid installing `at_exit`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run: bundle exec ruby spec/knapsack_pro/formatters/time_tracker_specs.rb
 
   integration-regular-rspec:
-    parallelism: 4
+    parallelism: 2
     working_directory: ~/knapsack_pro-ruby
     parameters:
       ruby:
@@ -129,7 +129,7 @@ jobs:
         type: string
       rspec:
         type: string
-    parallelism: 4
+    parallelism: 2
     working_directory: ~/knapsack_pro-ruby
     docker:
       - image: cimg/ruby:<< parameters.ruby >>-browsers
@@ -217,7 +217,7 @@ jobs:
             bundle exec rake "knapsack_pro:queue:rspec[-r turnip/rspec]"
 
   integration-regular-minitest:
-    parallelism: 4
+    parallelism: 2
     working_directory: ~/knapsack_pro-ruby
     parameters:
       ruby:
@@ -257,7 +257,7 @@ jobs:
     parameters:
       ruby:
         type: string
-    parallelism: 4
+    parallelism: 2
     working_directory: ~/knapsack_pro-ruby
     docker:
       - image: cimg/ruby:<< parameters.ruby >>-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,16 @@ commands:
         type: string
       rspec:
         type: string
+        default: ""
     steps:
       - run:
           working_directory: << parameters.path >>
           command: |
             git clone --depth 1 --branch $CIRCLE_BRANCH --single-branch git@github.com:KnapsackPro/rails-app-with-knapsack_pro.git ./ || git clone --depth 1 git@github.com:KnapsackPro/rails-app-with-knapsack_pro.git ./
-            sed -i 's/.*gem.*rspec-core.*/gem "rspec-core", "<< parameters.rspec >>"/g' ./Gemfile
+            if [[ "<< parameters.rspec >>" != "" ]]; then
+              sed -i 's/.*gem.*rspec-core.*/gem "rspec-core", "<< parameters.rspec >>"/g' ./Gemfile
+              echo "Updated RSpec version in Gemfile"
+            fi
       - restore_cache:
           keys:
           - v1-bundler-rails-{{ checksum "Gemfile.lock" }}-<< parameters.ruby >>
@@ -59,7 +63,7 @@ jobs:
       - run: bundle exec rspec spec
       - run: bundle exec ruby spec/knapsack_pro/formatters/time_tracker_specs.rb
 
-  integration-regular:
+  integration-regular-rspec:
     parallelism: 4
     working_directory: ~/knapsack_pro-ruby
     parameters:
@@ -76,7 +80,6 @@ jobs:
           RACK_ENV: test
           KNAPSACK_PRO_ENDPOINT: https://api-staging.knapsackpro.com
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: $KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC
-          KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST: $KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST
           EXTRA_TEST_FILES_DELAY: 10
       - image: cimg/postgres:14.7
         environment:
@@ -119,11 +122,8 @@ jobs:
             export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--regular--split"
             export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
             bundle exec rake knapsack_pro:rspec
-      - run:
-          working_directory: ~/rails-app-with-knapsack_pro
-          command: bundle exec rake knapsack_pro:minitest[--verbose]
 
-  integration-queue:
+  integration-queue-rspec:
     parameters:
       ruby:
         type: string
@@ -140,7 +140,6 @@ jobs:
           RACK_ENV: test
           KNAPSACK_PRO_ENDPOINT: https://api-staging.knapsackpro.com
           KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: $KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC
-          KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST: $KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST
           EXTRA_TEST_FILES_DELAY: 10
       - image: cimg/postgres:14.7
         environment:
@@ -216,6 +215,77 @@ jobs:
             export KNAPSACK_PRO_TEST_DIR=turnip
             export KNAPSACK_PRO_TEST_FILE_PATTERN="turnip/**/*.feature"
             bundle exec rake "knapsack_pro:queue:rspec[-r turnip/rspec]"
+
+  integration-regular-minitest:
+    parallelism: 4
+    working_directory: ~/knapsack_pro-ruby
+    parameters:
+      ruby:
+        type: string
+    docker:
+      - image: cimg/ruby:<< parameters.ruby >>-browsers
+        environment:
+          PGHOST: 127.0.0.1
+          PGUSER: rails-app-with-knapsack_pro
+          RAILS_ENV: test
+          RACK_ENV: test
+          KNAPSACK_PRO_ENDPOINT: https://api-staging.knapsackpro.com
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST: $KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST
+          EXTRA_TEST_FILES_DELAY: 10
+      - image: cimg/postgres:14.7
+        environment:
+          POSTGRES_DB: rails-app-with-knapsack_pro_test
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: rails-app-with-knapsack_pro
+    steps:
+      - setup_knapsack_pro_ruby
+      - setup_rails_app_with_knapsack_pro:
+          path: ~/rails-app-with-knapsack_pro
+          ruby: << parameters.ruby >>
+      - run: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: ruby --version
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: bin/rails db:setup
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: bundle exec rake knapsack_pro:minitest[--verbose]
+
+  integration-queue-minitest:
+    parameters:
+      ruby:
+        type: string
+    parallelism: 4
+    working_directory: ~/knapsack_pro-ruby
+    docker:
+      - image: cimg/ruby:<< parameters.ruby >>-browsers
+        environment:
+          PGHOST: 127.0.0.1
+          PGUSER: rails-app-with-knapsack_pro
+          RAILS_ENV: test
+          RACK_ENV: test
+          KNAPSACK_PRO_ENDPOINT: https://api-staging.knapsackpro.com
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST: $KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST
+          EXTRA_TEST_FILES_DELAY: 10
+      - image: cimg/postgres:14.7
+        environment:
+          POSTGRES_DB: rails-app-with-knapsack_pro_test
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: rails-app-with-knapsack_pro
+    steps:
+      - setup_knapsack_pro_ruby
+      - setup_rails_app_with_knapsack_pro:
+          path: ~/rails-app-with-knapsack_pro
+          ruby: << parameters.ruby >>
+      - run: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: ruby --version
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: bin/rails db:setup
       - run:
           working_directory: ~/rails-app-with-knapsack_pro
           command: |
@@ -235,15 +305,25 @@ workflows:
   tests:
     jobs:
       - unit
-      - integration-regular:
+      - integration-regular-rspec:
           name: integration-regular__ruby-<< matrix.ruby >>__rspec-<< matrix.rspec >>
           matrix:
             parameters:
               ruby: ["3.0", "3.1", "3.2"]
               rspec: ["3.10.2", "3.11.0", "3.12.2"]
-      - integration-queue:
+      - integration-queue-rspec:
           name: integration-queue__ruby-<< matrix.ruby >>__rspec-<< matrix.rspec >>
           matrix:
             parameters:
               ruby: ["3.0", "3.1", "3.2"]
               rspec: ["3.10.2", "3.11.0", "3.12.2"]
+      - integration-regular-minitest:
+          name: integration-regular__ruby-<< matrix.ruby >>__minitest
+          matrix:
+            parameters:
+              ruby: ["3.0", "3.1", "3.2"]
+      - integration-queue-minitest:
+          name: integration-queue__ruby-<< matrix.ruby >>__minitest
+          matrix:
+            parameters:
+              ruby: ["3.0", "3.1", "3.2"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,8 @@ jobs:
           RAILS_ENV: test
           RACK_ENV: test
           KNAPSACK_PRO_ENDPOINT: https://api-staging.knapsackpro.com
-          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: 3fa64859337f6e56409d49f865d13fd7
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: $KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST: $KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST
           EXTRA_TEST_FILES_DELAY: 10
       - image: cimg/postgres:14.7
         environment:
@@ -118,6 +119,9 @@ jobs:
             export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--regular--split"
             export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
             bundle exec rake knapsack_pro:rspec
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: bundle exec rake knapsack_pro:minitest[--verbose]
 
   integration-queue:
     parameters:
@@ -135,7 +139,8 @@ jobs:
           RAILS_ENV: test
           RACK_ENV: test
           KNAPSACK_PRO_ENDPOINT: https://api-staging.knapsackpro.com
-          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: 3fa64859337f6e56409d49f865d13fd7
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: $KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST: $KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST
           EXTRA_TEST_FILES_DELAY: 10
       - image: cimg/postgres:14.7
         environment:
@@ -211,6 +216,20 @@ jobs:
             export KNAPSACK_PRO_TEST_DIR=turnip
             export KNAPSACK_PRO_TEST_FILE_PATTERN="turnip/**/*.feature"
             bundle exec rake "knapsack_pro:queue:rspec[-r turnip/rspec]"
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: |
+            # minitest ||
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--minitest"
+            export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
+            bundle exec rake knapsack_pro:queue:minitest[--verbose]
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: |
+            # minitest retry ||
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--minitest"
+            export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
+            bundle exec rake knapsack_pro:queue:minitest[--verbose]
 
 workflows:
   tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,9 @@ jobs:
           command: bin/rails db:setup
       - run:
           working_directory: ~/rails-app-with-knapsack_pro
-          command: bundle exec rake knapsack_pro:minitest[--verbose]
+          command: |
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--regular"
+            bundle exec rake knapsack_pro:minitest[--verbose]
 
   integration-queue-minitest:
     parameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased (patch)
+
+* fix(minitest): avoid installing `at_exit` (that would result in an empty run of Minitest after Knapsack Pro is finished in Queue Mode)
+
 ### 6.0.3
 
 * fix(Turnip): make sure `.feature` files are recorded

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -7,6 +7,10 @@ module KnapsackPro
         def self.run(args)
           require 'minitest'
 
+          # Avoid installing `at_exit` since we are calling `Minitest.run` ourselves.
+          # Without this, Minitest would run again (autorun) after `Minitest.run`.
+          ::Minitest.class_variable_set('@@installed_at_exit', true)
+
           ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN'] = KnapsackPro::Config::Env.test_suite_token_minitest
           ENV['KNAPSACK_PRO_QUEUE_RECORDING_ENABLED'] = 'true'
           ENV['KNAPSACK_PRO_QUEUE_ID'] = KnapsackPro::Config::EnvGenerator.set_queue_id


### PR DESCRIPTION
Rails in `test/test_helper.rb` includes:

```
require 'rails/test_help'
```

that contains:

```
require "active_support/testing/autorun"
```

which calls [`Minitest.autorun`](https://github.com/minitest/minitest/blob/43d4efc936ee760dbe2c797adc431c17a3b4afc2/lib/minitest.rb#L67), which, in turn, installs an `at_exit` that will run Minitest tests.

This is useful when you [don't want to call `Minitest.run`](https://blog.arkency.com/2013/06/are-we-abusing-at-exit/) explicitly. But we actually do so in the Knapsack Pro runner.

We forgot to add the `class_variable_set` as part of https://github.com/KnapsackPro/knapsack_pro-ruby/commit/6849d1fd2610d2d7469ae2a7148ab8ef5faab4c7 (make sure to read the link to the Minitest issue in the commit body).

**This change is not needed in Regular Mode because we don't call `Minitest.run` (and we rely on the autorun) in that case.**

## Reproduction steps

- Remove `::Minitest.class_variable_set('@@installed_at_exit', true)`
- `cd rails-app-with-knapsack_pro`
- `bin/knapsack_pro_queue_minitest`
- Notice an empty batch is run after Knapsack Pro executed all the batches

You can also see it [on CI](https://app.circleci.com/pipelines/github/KnapsackPro/knapsack_pro-ruby/1082/workflows/b4133cce-f653-4b5b-bf7c-aea4a0e4298d/jobs/2811/parallel-runs/1/steps/1-119) (notice the last few lines):

```
Finished in 0.623779s, 4.8094 runs/s, 4.8094 assertions/s.
3 runs, 3 assertions, 0 failures, 0 errors, 1 skips
----------After Subset Queue Hook - run after subset of test suite----------D, [2024-01-05T17:10:27.969366 #637] DEBUG -- : [knapsack_pro] POST https://api-staging.knapsackpro.com/v1/queues/queue
D, [2024-01-05T17:10:27.969421 #637] DEBUG -- : [knapsack_pro] API request UUID: 65453812-2682-4694-a544-c5deedc1eceb
D, [2024-01-05T17:10:27.969445 #637] DEBUG -- : [knapsack_pro] API response:
D, [2024-01-05T17:10:27.969474 #637] DEBUG -- : [knapsack_pro] {"queue_name"=>"125:4af5db3e6e2e3c36fcce7b1ca8cae41a", "build_subset_id"=>nil, "test_files"=>[]}
----------After Queue Hook - run after test suite----------D, [2024-01-05T17:10:28.201182 #637] DEBUG -- : [knapsack_pro] POST https://api-staging.knapsackpro.com/v1/build_subsets
D, [2024-01-05T17:10:28.201251 #637] DEBUG -- : [knapsack_pro] API request UUID: b30c32db-1ea9-418c-b5c3-ea6b672b2846
D, [2024-01-05T17:10:28.201276 #637] DEBUG -- : [knapsack_pro] API response:
D, [2024-01-05T17:10:28.201299 #637] DEBUG -- : [knapsack_pro] 
D, [2024-01-05T17:10:28.201329 #637] DEBUG -- : [knapsack_pro] Saved time execution report on Knapsack Pro API server.
Run options: --seed 30553

# Running:



Finished in 0.001104s, 0.0000 runs/s, 0.0000 assertions/s.
0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
D, [2024-01-05T17:10:28.204810 #637] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.6018200909984444s
```