### PR TITLE
Require rails_helper before configuring RSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 7.0.1
 
-* fix(RSpec): conditionally adds `--require rails_helper` to cli arguments of `KnapsackPro::Runners::Queue::RSpecRunner`. Version 7.0.0 introduced some fundamental changes, namely fetching, loading and running batches of specs **after** executing suite hooks, so that such hooks are only ran once, not before every batch. This results in a situation where if `rails_helper` is only required in spec files, which is the RSpec default, instead of e.g. in `.rspec`, then some `before(:suite)` hooks, e.g. defined by gems, are registered after suite hooks had already been executed by the test suite. To compare, RSpec loads all the spec files **before** executing `before(:suite)` hooks.
+* fix(RSpec): conditionally adds `--require rails_helper` to cli arguments of `KnapsackPro::Runners::Queue::RSpecRunner`. Version 7.0.0 introduced some fundamental changes, namely fetching, loading and running batches of specs **after** executing suite hooks, so that such hooks are only ran once, not before every batch. As a result, if `rails_helper` is only required in spec files, which is the RSpec default, instead of e.g. in `.rspec`, then some `before(:suite)` hooks, e.g. defined by gems, are registered after suite hooks had already been executed by the test suite. By comparison, RSpec loads all the spec files **before** executing `before(:suite)` hooks.
 
 PR with the above changes: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/243
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 7.0.1
+
+* fix(RSpec): conditionally adds `--require rails_helper` to cli arguments of `KnapsackPro::Runners::Queue::RSpecRunner`. Version 7.0.0 introduced some fundamental changes, namely fetching, loading and running batches of specs **after** executing suite hooks, so that such hooks are only ran once, not before every batch. This results in a situation where if `rails_helper` is only required in spec files, which is the RSpec default, instead of e.g. in `.rspec`, then some `before(:suite)` hooks, e.g. defined by gems, are registered after suite hooks had already been executed by the test suite. To compare, RSpec loads all the spec files **before** executing `before(:suite)` hooks.
+
+PR with the above changes: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/243
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.0.0...v7.0.1
+
 ### 7.0.0
 
 * __(breaking change)__ RSpec in Queue Mode:

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -52,6 +52,10 @@ module KnapsackPro
         !!parsed_options(cli_args)&.[](:formatters)
       end
 
+      def self.has_require_rails_helper_option?(cli_args)
+        (parsed_options(cli_args)&.[](:requires) || []).include?("rails_helper")
+      end
+
       def self.order_option(cli_args)
         parsed_options(cli_args)&.[](:order)
       end
@@ -74,6 +78,10 @@ module KnapsackPro
       def self.parse_file_path(id)
         # https://github.com/rspec/rspec-core/blob/1eeadce5aa7137ead054783c31ff35cbfe9d07cc/lib/rspec/core/example.rb#L122
         id.match(/\A(.*?)(?:\[([\d\s:,]+)\])?\z/).captures.first
+      end
+
+      def self.rails_helper_exists?(test_dir)
+        File.exist?("#{test_dir}/rails_helper.rb")
       end
 
       # private

--- a/lib/knapsack_pro/pure/queue/rspec_pure.rb
+++ b/lib/knapsack_pro/pure/queue/rspec_pure.rb
@@ -34,9 +34,10 @@ module KnapsackPro
           args + ['--seed', seed.value]
         end
 
-        def prepare_cli_args(args, has_format_option, test_dir)
+        def prepare_cli_args(args, has_format_option, has_require_rails_helper_option, rails_helper_exists, test_dir)
           (args || '').split
             .yield_self { args_with_at_least_one_formatter(_1, has_format_option) }
+            .yield_self { args_with_require_rails_helper_if_needed(_1, has_require_rails_helper_option, rails_helper_exists) }
             .yield_self { args_with_default_options(_1, test_dir) }
         end
 
@@ -73,6 +74,13 @@ module KnapsackPro
           return cli_args if has_format_option
 
           cli_args + ['--format', 'progress']
+        end
+
+        def args_with_require_rails_helper_if_needed(cli_args, has_require_rails_helper_option, rails_helper_exists)
+          return cli_args if has_require_rails_helper_option
+          return cli_args unless rails_helper_exists
+
+          cli_args + ['--require', 'rails_helper']
         end
 
         def args_with_default_options(cli_args, test_dir)

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -24,8 +24,11 @@ module KnapsackPro
           super(adapter_class)
           @adapter_class = adapter_class
           @rspec_pure = rspec_pure
-          has_format_option = @adapter_class.has_format_option?((args || '').split)
-          @cli_args = rspec_pure.prepare_cli_args(args, has_format_option, test_dir)
+          args_array = (args || '').split
+          has_format_option = @adapter_class.has_format_option?(args_array)
+          has_require_rails_helper_option = @adapter_class.has_require_rails_helper_option?(args_array)
+          rails_helper_exists = @adapter_class.rails_helper_exists?(test_dir)
+          @cli_args = rspec_pure.prepare_cli_args(args, has_format_option, has_require_rails_helper_option, rails_helper_exists, test_dir)
           @stream_error = stream_error
           @stream_out = stream_out
           @node_test_file_paths = []

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -372,7 +372,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
       actual = subject
 
-      expect(actual.stdout.scan(/--require rails_helper/).size).to eq 0
+      expect(actual.stdout).to_not include('--require rails_helper')
 
       expect(actual.exit_code).to eq 0
     end
@@ -431,7 +431,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
       actual = subject
 
-      expect(actual.stdout.scan(/--require rails_helper/).size).to eq 3
+      expect(actual.stdout).to include('--require rails_helper')
       expect(actual.stdout.scan(/RSpec_before_suite_hook_from_rails_helper/).size).to eq 1
       expect(actual.stdout.scan(/RSpec_after_suite_hook_from_rails_helper/).size).to eq 1
 
@@ -465,6 +465,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       SPEC
 
       spec_c = Spec.new('c_spec.rb', <<~SPEC)
+        require 'rails_helper'
         describe 'C_describe' do
           it 'C1 test example' do
             expect(1).to eq 1

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -187,6 +187,60 @@ describe KnapsackPro::Adapters::RSpecAdapter do
     end
   end
 
+  describe '.has_require_rails_helper_option?' do
+    subject { described_class.has_require_rails_helper_option?(cli_args) }
+
+    context 'when require option is provided as -r' do
+      let(:cli_args) { ['-r', 'rails_helper'] }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when require option is provided as --require' do
+      let(:cli_args) { ['--require', 'rails_helper'] }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when require option is provided without delimiter' do
+      let(:cli_args) { ['-rrails_helper'] }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when require option is not provided' do
+      let(:cli_args) { ['--fake', 'value'] }
+
+      it { expect(subject).to be false }
+    end
+  end
+
+  describe '.rails_helper_exists?' do
+    subject { described_class.rails_helper_exists?(test_dir) }
+
+    let(:test_dir) { 'spec_fake' }
+
+    context 'when rails_helper exists' do
+      before do
+        File.open("#{test_dir}/rails_helper.rb", 'w')
+      end
+
+      after do
+        FileUtils.rm("#{test_dir}/rails_helper.rb")
+      end
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when rails_helper does not exist' do
+      before do
+        FileUtils.rm_f("#{test_dir}/rails_helper.rb")
+      end
+
+      it { expect(subject).to be false }
+    end
+  end
+
   describe '.order_option' do
     subject { described_class.order_option(cli_args) }
 

--- a/spec/knapsack_pro/pure/queue/rspec_pure_spec.rb
+++ b/spec/knapsack_pro/pure/queue/rspec_pure_spec.rb
@@ -117,31 +117,52 @@ describe KnapsackPro::Pure::Queue::RSpecPure do
   end
 
   describe '#prepare_cli_args' do
-    subject { rspec_pure.prepare_cli_args(args, has_format_option, test_dir) }
+    subject { rspec_pure.prepare_cli_args(args, has_format_option, has_require_rails_helper_option, rails_helper_exists, test_dir) }
 
     context 'when no args' do
       let(:args) { nil }
       let(:has_format_option) { false }
+      let(:has_require_rails_helper_option) { false }
       let(:test_dir) { 'spec' }
 
-      it 'adds the default progress formatter and the default path and the time tracker formatter' do
-        expect(subject).to eq [
-          '--format', 'progress',
-          '--default-path', 'spec',
-          '--format', 'KnapsackPro::Formatters::TimeTracker',
-        ]
+      context 'when rails_helper does not exist' do
+        let(:rails_helper_exists) { false }
+
+        it 'adds the default progress formatter, the default path and the time tracker formatter, does not add require rails_helper' do
+          expect(subject).to eq [
+            '--format', 'progress',
+            '--default-path', 'spec',
+            '--format', 'KnapsackPro::Formatters::TimeTracker',
+          ]
+        end
+      end
+
+      context 'when rails_helper exists' do
+        let(:rails_helper_exists) { true }
+
+        it 'adds the default progress formatter, require rails_helper, the default path and the time tracker formatter' do
+          expect(subject).to eq [
+            '--format', 'progress',
+            '--require', 'rails_helper',
+            '--default-path', 'spec',
+            '--format', 'KnapsackPro::Formatters::TimeTracker',
+          ]
+        end
       end
     end
 
     context 'when args are present and a custom test directory is set' do
-      let(:args) { '--color --profile' }
+      let(:args) { '--color --profile --require rails_helper' }
       let(:has_format_option) { false }
+      let(:has_require_rails_helper_option) { true }
+      let(:rails_helper_exists) { true }
       let(:test_dir) { 'custom_spec_dir' }
 
       it do
         expect(subject).to eq [
           '--color',
           '--profile',
+          '--require', 'rails_helper',
           '--format', 'progress',
           '--default-path', 'custom_spec_dir',
           '--format', 'KnapsackPro::Formatters::TimeTracker',
@@ -150,8 +171,10 @@ describe KnapsackPro::Pure::Queue::RSpecPure do
     end
 
     context 'when args are present and has format option' do
-      let(:args) { '--color --profile --format d' }
+      let(:args) { '--color --profile --format d --require rails_helper' }
       let(:has_format_option) { true }
+      let(:has_require_rails_helper_option) { true }
+      let(:rails_helper_exists) { true }
       let(:test_dir) { 'spec' }
 
       it 'uses the format option from args instead of the default formatter' do
@@ -159,6 +182,7 @@ describe KnapsackPro::Pure::Queue::RSpecPure do
           '--color',
           '--profile',
           '--format', 'd',
+          '--require', 'rails_helper',
           '--default-path', 'spec',
           '--format', 'KnapsackPro::Formatters::TimeTracker',
         ]


### PR DESCRIPTION
# Story

https://trello.com/c/iyN1GKYS/320-bug-rspec-knapsackpro-700-fails-with-the-dotenv-gem

## Related

https://github.com/KnapsackPro/knapsack_pro-ruby/issues/242

# Description

Version 7.0.0 introduced some fundamental changes, namely fetching, loading and running batches of specs **after** executing suite hooks, so that such hooks are only ran once, not before every batch. As a result, if `rails_helper` is only required in spec files, which is the RSpec default, instead of e.g. in `.rspec`, then some `before(:suite)` hooks, e.g. defined by gems, are registered after suite hooks had already been executed by the test suite. In comparison, RSpec loads all the spec files **before** executing `before(:suite)` hooks.

# Changes

This PR conditionally adds `--require rails_helper` to cli arguments of `KnapsackPro::Runners::Queue::RSpecRunner` so that the Rails app (and its gems) can be loaded before executing `before(:suite)` hooks. That way all the `before(:suite)` hooks are registered properly and can be executed.

# Checklist reminder

- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
