### PR TITLE
Update publishing readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,30 +74,32 @@ Scripted tests can be found in the [Rails App With Knapsack Pro repository](http
 
 ### Publishing
 
-Update the version in `lib/knapsack_pro/version.rb` and `CHANGELOG.md`:
+1. Update the `CHANGELOG.md` as part of your PR.
+
+2. After your PR has been merged, update the gem version in `lib/knapsack_pro/version.rb` directly on the `master` branch:
 
 ```bash
 git commit -m "Bump version X.X.X"
 git push origin master
 ```
 
-Create a git tag for the release:
+3. Create a git tag for the release:
 
 ```bash
 git tag -a vX.X.X -m "Release vX.X.X"
 git push --tags
 ```
 
-Build the gem and publish it to RubyGems:
+4. Build the gem and publish it to RubyGems:
 
 ```bash
 gem build knapsack_pro.gemspec
 gem push knapsack_pro-X.X.X.gem
 ```
 
-Update the latest available gem version in `TestSuiteClientVersionChecker` for the Knapsack Pro API repository.
+5. Update the latest available gem version in `TestSuiteClientVersionChecker` for the Knapsack Pro API repository.
 
-Update the `knapsack_pro` gem version in:
+6. Update the `knapsack_pro` gem version in:
 
 - [Rails App With Knapsack Pro repository](https://github.com/KnapsackPro/rails-app-with-knapsack_pro)
 - Knapsack Pro API internal repository


### PR DESCRIPTION
# Story

N/A

## Related

N/A

# Description

This PR makes the readme part about publishing the gem a bit less ambiguous.

# Changes

N/A

# Checklist reminder

~~- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):~~
~~- Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.~~
~~- Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.~~
~~- Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.~~
