### PR TITLE
[RSpec] [Queue Mode] Log error message and backtrace when unexpected failure raised in process

### DIFF
--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -56,6 +56,8 @@ module KnapsackPro
             Kernel.exit(exit_code)
           rescue Exception => exception
             KnapsackPro.logger.error("An unexpected exception happened. RSpec cannot handle it. The exception: #{exception.inspect}")
+            KnapsackPro.logger.error("Exception message: #{exception.message}")
+            KnapsackPro.logger.error("Exception backtrace: #{exception.backtrace.join("\n")}")
 
             message = @rspec_pure.exit_summary(unexecuted_test_files)
             KnapsackPro.logger.warn(message) if message

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1115,6 +1115,8 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
       expect(actual.stdout).to include('B_describe')
       expect(actual.stdout).to include('An unexpected exception happened. RSpec cannot handle it. The exception: #<NoMemoryError: NoMemoryError>')
+      expect(actual.stdout).to include('Exception message: ')
+      expect(actual.stdout).to include('Exception backtrace: ')
       expect(actual.stdout).to_not include('B1 test example')
 
       expect(actual.stdout).to_not include('C1 test example')


### PR DESCRIPTION

# Description

Currently when unexpected error raised, we only get the class name from `exception.inspect`, this PR adds details to the logger to be able to trace or debug the cause.

# Changes

Add more logs when unexpected error raised in runner process.

# Checklist reminder

- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
