### PR TITLE
Avoid unnecessary process in queue mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ### UNRELEASED
 
+### 7.6.0
+
+* Avoid starting an unnecessary process in Queue Mode.
+  * Fix: the terminal is returned to the user correctly (output looks good) when you use CTRL+C
+  * Improvement: the backtrace looks better when something fails (for example, the gem handles an OS signal)
+
+  https://github.com/KnapsackPro/knapsack_pro-ruby/pull/260
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.5.1...v7.6.0
+
 ### 7.5.1
 
 * Revert to 7.4.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### 7.5.1
 
-Revert to 7.4.0.
+* Revert to 7.4.0.
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.5.0...v7.5.1
 
 ### 7.5.0
 

--- a/lib/tasks/queue/cucumber.rake
+++ b/lib/tasks/queue/cucumber.rake
@@ -5,14 +5,7 @@ require 'knapsack_pro'
 namespace :knapsack_pro do
   namespace :queue do
     task :cucumber, [:cucumber_args] do |_, args|
-      Kernel.system("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:cucumber_go[#{args[:cucumber_args]}]'")
-      exitstatus = $?.exitstatus
-      if exitstatus.nil?
-        puts 'Something went wrong. Most likely, the process has been killed. Knapsack Pro has been terminated.'
-        Kernel.exit(1)
-      else
-        Kernel.exit(exitstatus)
-      end
+      Kernel.exec("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:cucumber_go[#{args[:cucumber_args]}]'")
     end
 
     task :cucumber_go, [:cucumber_args] do |_, args|

--- a/lib/tasks/queue/minitest.rake
+++ b/lib/tasks/queue/minitest.rake
@@ -5,14 +5,7 @@ require 'knapsack_pro'
 namespace :knapsack_pro do
   namespace :queue do
     task :minitest, [:minitest_args] do |_, args|
-      Kernel.system("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:minitest_go[#{args[:minitest_args]}]'")
-      exitstatus = $?.exitstatus
-      if exitstatus.nil?
-        puts 'Something went wrong. Most likely, the process has been killed. Knapsack Pro has been terminated.'
-        Kernel.exit(1)
-      else
-        Kernel.exit(exitstatus)
-      end
+      Kernel.exec("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:minitest_go[#{args[:minitest_args]}]'")
     end
 
     task :minitest_go, [:minitest_args] do |_, args|

--- a/lib/tasks/queue/rspec.rake
+++ b/lib/tasks/queue/rspec.rake
@@ -5,14 +5,7 @@ require 'knapsack_pro'
 namespace :knapsack_pro do
   namespace :queue do
     task :rspec, [:rspec_args] do |_, args|
-      Kernel.system("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:rspec_go[#{args[:rspec_args]}]'")
-      exitstatus = $?.exitstatus
-      if exitstatus.nil?
-        puts 'Something went wrong. Most likely, the process has been killed. Knapsack Pro has been terminated.'
-        Kernel.exit(1)
-      else
-        Kernel.exit(exitstatus)
-      end
+      Kernel.exec("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:rspec_go[#{args[:rspec_args]}]'")
     end
 
     task :rspec_go, [:rspec_args] do |_, args|


### PR DESCRIPTION
# Story

[Ticket](https://trello.com/c/sZx3WBZ0/391-improve-terminal-ux-for-the-gem-use-kernelexec-instead-of-kernelsystem-when-starting-queue-mode-in-ruby-to-use-a-single-ruby-pro)

[`#system`](https://rubydoc.info/stdlib/core/Kernel#system-instance_method) executes the passed command into a subshell. It pretty much executes fork, exec, and wait.

[`#exec`](https://rubydoc.info/stdlib/core/Kernel#exec-instance_method) replaces the current process avoiding a fork/wait.

Also, using `exec` delegates the exit/error handling to the replacing process making the code introduced in https://github.com/KnapsackPro/knapsack_pro-ruby/commit/7862c5e6 unneeded:

```ruby
      exitstatus = $?.exitstatus
      if exitstatus.nil?
        puts 'Something went wrong. Most likely, the process has been killed. Knapsack Pro has been terminated.'
        Kernel.exit(1)
      else
        Kernel.exit(exitstatus)
      end
```

Also the following form seems to work:

```ruby
Kernel.exec({ "RAILS_ENV" => "test", "RACK_ENV" => "test" }, "#{$PROGRAM_NAME} 'knapsack_pro:queue:rspec_go[#{args[:rspec_args]}]'")
```

See the [`#spawn`](https://rubydoc.info/stdlib/core/Kernel#spawn-instance_method) docs for more on that.

**Reference**:
- Definition of [metacharacter](https://www.gnu.org/software/bash/manual/html_node/Definitions.html#index-metacharacter)
- [Subshell vs subprocess](https://jitpaul.blog/2018/09/16/shell-scripting-sub-shell-vs-sub-process/)
- https://github.com/KnapsackPro/knapsack_pro-ruby/pull/199

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] More testing (including `bin/knapsack_pro_all`)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.

# Manual Tests

```ruby
namespace :knapsack_pro do
  namespace :queue do
    task :rspec, [:rspec_args] do |_, args|
      Kernel.exec("RAILS_ENV=test RACK_ENV=test RAILS_X=something #{$PROGRAM_NAME} 'knapsack_pro:queue:rspec_go[#{args[:rspec_args]}]'")
      raise "err"
    end

    task :rspec_go, [:rspec_args] do |_, args|
      puts ENV.filter { |k, v| k.include?("RAILS_") }
      exit 10
    end
  end
end
```

```bash
$ bin/knapsack_pro_queue_rspec 1 2 20240601-01
{"RAILS_X"=>"something", "RAILS_ENV"=>"test"}

$ echo $?
10
```

```ruby
namespace :knapsack_pro do
  namespace :queue do
    task :rspec, [:rspec_args] do |_, args|
      Kernel.exec("RAILS_ENV=test RACK_ENV=test RAILS_X=something #{$PROGRAM_NAME} 'knapsack_pro:queue:rspec_go[#{args[:rspec_args]}]'")
      raise "err"
    end

    task :rspec_go, [:rspec_args] do |_, args|
      puts ENV.filter { |k, v| k.include?("RAILS_") }
      raise StandardError
    end
  end
end
```

```bash
$ bin/knapsack_pro_queue_rspec 1 2 20240601-01
{"RAILS_X"=>"something", "RAILS_ENV"=>"test"}
rake aborted!
StandardError: StandardError (StandardError)
/Users/3v0k4/code/knapsack/knapsack_pro-ruby/lib/tasks/queue/rspec.rake:14:in `block (3 levels) in <top (required)>'
/Users/3v0k4/.rvm/gems/ruby-3.2.2/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/Users/3v0k4/.rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `eval'
/Users/3v0k4/.rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `<main>'
Tasks: TOP => knapsack_pro:queue:rspec_go
(See full trace by running task with --trace)
```