### PR TITLE
fix(timecop gem): add support for Timecop 0.9.9 so that we  could track proper tests' execution time when `Process.clock_gettime` is mocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### UNRELEASED
 
+### 7.6.1
+
+* Add support for the Timecop 0.9.9 gem version so that we could track proper tests' execution time when `Process.clock_gettime` is mocked.
+
+  https://github.com/KnapsackPro/knapsack_pro-ruby/pull/262
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.6.0...v7.6.1
+
 ### 7.6.0
 
 * Avoid starting an unnecessary process in Queue Mode.

--- a/knapsack_pro.gemspec
+++ b/knapsack_pro.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0'
   spec.add_development_dependency 'vcr', '>= 6.0'
   spec.add_development_dependency 'webmock', '>= 3.13'
-  spec.add_development_dependency 'timecop', '>= 0.9.4'
+  spec.add_development_dependency 'timecop', '>= 0.9.9'
 end

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -145,7 +145,7 @@ module KnapsackPro
       end
 
       def now
-        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        KnapsackPro::Utils.now
       end
     end
   end

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -145,7 +145,7 @@ module KnapsackPro
       end
 
       def now
-        KnapsackPro::Utils.now
+        KnapsackPro::Utils.time_now
       end
     end
   end

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -155,7 +155,7 @@ module KnapsackPro
     end
 
     def now_without_mock_time
-      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      KnapsackPro::Utils.now
     end
   end
 end

--- a/lib/knapsack_pro/tracker.rb
+++ b/lib/knapsack_pro/tracker.rb
@@ -155,7 +155,7 @@ module KnapsackPro
     end
 
     def now_without_mock_time
-      KnapsackPro::Utils.now
+      KnapsackPro::Utils.time_now
     end
   end
 end

--- a/lib/knapsack_pro/utils.rb
+++ b/lib/knapsack_pro/utils.rb
@@ -7,7 +7,7 @@ module KnapsackPro
     end
 
     def self.now
-      # support for timecop 0.9.9
+      # support for timecop >= 0.9.9
       if defined?(Timecop) && Process.respond_to?(:clock_gettime_without_mock)
         Process.clock_gettime_without_mock(Process::CLOCK_MONOTONIC)
       else

--- a/lib/knapsack_pro/utils.rb
+++ b/lib/knapsack_pro/utils.rb
@@ -6,7 +6,7 @@ module KnapsackPro
       JSON.parse(obj.to_json)
     end
 
-    def self.now
+    def self.time_now
       if defined?(Timecop) && Process.respond_to?(:clock_gettime_without_mock)
         Process.clock_gettime_without_mock(Process::CLOCK_MONOTONIC)
       else

--- a/lib/knapsack_pro/utils.rb
+++ b/lib/knapsack_pro/utils.rb
@@ -7,7 +7,6 @@ module KnapsackPro
     end
 
     def self.now
-      # support for timecop >= 0.9.9
       if defined?(Timecop) && Process.respond_to?(:clock_gettime_without_mock)
         Process.clock_gettime_without_mock(Process::CLOCK_MONOTONIC)
       else

--- a/lib/knapsack_pro/utils.rb
+++ b/lib/knapsack_pro/utils.rb
@@ -5,5 +5,14 @@ module KnapsackPro
     def self.unsymbolize(obj)
       JSON.parse(obj.to_json)
     end
+
+    def self.now
+      # support for timecop 0.9.9
+      if defined?(Timecop) && Process.respond_to?(:clock_gettime_without_mock)
+        Process.clock_gettime_without_mock(Process::CLOCK_MONOTONIC)
+      else
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
   end
 end

--- a/spec/knapsack_pro/utils_spec.rb
+++ b/spec/knapsack_pro/utils_spec.rb
@@ -17,8 +17,8 @@ describe KnapsackPro::Utils do
     end
   end
 
-  describe '.now' do
-    subject { described_class.now }
+  describe '.time_now' do
+    subject { described_class.time_now }
 
     context 'when Timecop does not mock the time' do
       it do

--- a/spec/knapsack_pro/utils_spec.rb
+++ b/spec/knapsack_pro/utils_spec.rb
@@ -33,11 +33,15 @@ describe KnapsackPro::Utils do
           raise 'Timecop >= 0.9.9 is required to run this test. Please run: bundle update'
         end
 
-        Timecop.mock_process_clock = true if Timecop.respond_to?(:mock_process_clock=)
+        if Gem::Version.new(Timecop::VERSION) >= Gem::Version.new('0.9.10')
+          Timecop.mock_process_clock = true
+        end
       end
 
       after do
-        Timecop.mock_process_clock = false if Timecop.respond_to?(:mock_process_clock=)
+        if Gem::Version.new(Timecop::VERSION) >= Gem::Version.new('0.9.10')
+          Timecop.mock_process_clock = false
+        end
       end
 
       it do

--- a/spec/knapsack_pro/utils_spec.rb
+++ b/spec/knapsack_pro/utils_spec.rb
@@ -16,4 +16,38 @@ describe KnapsackPro::Utils do
       ])
     end
   end
+
+  describe '.now' do
+    subject { described_class.now }
+
+    context 'when Timecop does not mock the time' do
+      it do
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        expect(subject).to be_within(0.001).of(now)
+      end
+    end
+
+    context 'when Timecop does mock the process clock' do
+      before do
+        unless Gem::Version.new(Timecop::VERSION) >= Gem::Version.new('0.9.10')
+          raise 'Timecop >= 0.9.10 is required to run this test. Please run: bundle update'
+        end
+
+        Timecop.mock_process_clock = true
+      end
+
+      after do
+        Timecop.mock_process_clock = false
+      end
+
+      it do
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        time = Time.local(2020, 1, 31)
+        Timecop.travel(time) do
+          expect(subject).to be_within(0.001).of(now)
+        end
+      end
+    end
+  end
 end

--- a/spec/knapsack_pro/utils_spec.rb
+++ b/spec/knapsack_pro/utils_spec.rb
@@ -29,15 +29,15 @@ describe KnapsackPro::Utils do
 
     context 'when Timecop does mock the process clock' do
       before do
-        unless Gem::Version.new(Timecop::VERSION) >= Gem::Version.new('0.9.10')
-          raise 'Timecop >= 0.9.10 is required to run this test. Please run: bundle update'
+        unless Gem::Version.new(Timecop::VERSION) >= Gem::Version.new('0.9.9')
+          raise 'Timecop >= 0.9.9 is required to run this test. Please run: bundle update'
         end
 
-        Timecop.mock_process_clock = true
+        Timecop.mock_process_clock = true if Timecop.respond_to?(:mock_process_clock=)
       end
 
       after do
-        Timecop.mock_process_clock = false
+        Timecop.mock_process_clock = false if Timecop.respond_to?(:mock_process_clock=)
       end
 
       it do

--- a/spec/knapsack_pro/utils_spec.rb
+++ b/spec/knapsack_pro/utils_spec.rb
@@ -28,19 +28,17 @@ describe KnapsackPro::Utils do
     end
 
     context 'when Timecop does mock the process clock' do
-      before do
+      around(:example) do |ex|
         unless Gem::Version.new(Timecop::VERSION) >= Gem::Version.new('0.9.9')
           raise 'Timecop >= 0.9.9 is required to run this test. Please run: bundle update'
         end
 
         if Gem::Version.new(Timecop::VERSION) >= Gem::Version.new('0.9.10')
           Timecop.mock_process_clock = true
-        end
-      end
-
-      after do
-        if Gem::Version.new(Timecop::VERSION) >= Gem::Version.new('0.9.10')
+          ex.run
           Timecop.mock_process_clock = false
+        else
+          ex.run
         end
       end
 


### PR DESCRIPTION
# Story

[link to the internal story](https://trello.com/c/EVsS01sV)

## Related

Changes introduced by Timecop 0.9.9:

Process.clock_gettime is mocked.

* https://github.com/travisjeffery/timecop/pull/419

Timecop 0.9.10 makes `Process.clock_gettime` optionally mocked. The default is `Timecop.mock_process_clock = false`.

* https://github.com/travisjeffery/timecop/pull/427

Our old PRs related to time tracking and mocking time:

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/132
* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/38

# Description

Add support for Timecop 0.9.9 so that we could track proper tests' execution time when `Process.clock_gettime` is mocked.

# Changes

* Knapsack Pro ignores the `Process.clock_gettime` mocked by the Timecop gem.

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
