### PR TITLE
Fix an error for the `KnapsackPro::Formatters::TimeTracker` formatter in RSpec when using Knapsack Pro Regular Mode and the `.rspec` file is not present.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,16 @@ jobs:
             export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
             export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/features/calculator_spec.rb"
             bundle exec rake knapsack_pro:rspec
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: |
+            # when the .rspec file does not exist
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--regular--no-dot-rspec-file"
+            mv .rspec .rspec.off
+            bundle exec rake knapsack_pro:rspec
+            RSPEC_EXIT_CODE=$?
+            mv .rspec.off .rspec
+            exit $RSPEC_EXIT_CODE
 
   e2e-queue-rspec:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,16 @@ jobs:
       - run:
           working_directory: ~/rails-app-with-knapsack_pro
           command: |
+            # ensures KnapsackPro::Formatters::TimeTracker works when the .rspec file does not exist
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--regular--no-dot-rspec-file"
+            mv .rspec .rspec.off
+            bundle exec rake knapsack_pro:rspec
+            RSPEC_EXIT_CODE=$?
+            mv .rspec.off .rspec
+            exit $RSPEC_EXIT_CODE
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: |
             # split by test examples ||
             export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--regular--split"
             export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
@@ -180,16 +190,6 @@ jobs:
             export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
             export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/features/calculator_spec.rb"
             bundle exec rake knapsack_pro:rspec
-      - run:
-          working_directory: ~/rails-app-with-knapsack_pro
-          command: |
-            # when the .rspec file does not exist
-            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--regular--no-dot-rspec-file"
-            mv .rspec .rspec.off
-            bundle exec rake knapsack_pro:rspec
-            RSPEC_EXIT_CODE=$?
-            mv .rspec.off .rspec
-            exit $RSPEC_EXIT_CODE
 
   e2e-queue-rspec:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,7 @@ jobs:
             # ensures KnapsackPro::Formatters::TimeTracker works when the .rspec file does not exist
             export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--regular--no-dot-rspec-file"
             mv .rspec .rspec.off
+            # load test files that require spec_helper explicitly
             export KNAPSACK_PRO_TEST_FILE_PATTERN="{spec/time_tracker_spec.rb}"
             bundle exec rake knapsack_pro:rspec
             RSPEC_EXIT_CODE=$?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,7 @@ jobs:
             # ensures KnapsackPro::Formatters::TimeTracker works when the .rspec file does not exist
             export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--regular--no-dot-rspec-file"
             mv .rspec .rspec.off
+            export KNAPSACK_PRO_TEST_FILE_PATTERN="{spec/time_tracker_spec.rb}"
             bundle exec rake knapsack_pro:rspec
             RSPEC_EXIT_CODE=$?
             mv .rspec.off .rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### UNRELEASED
 
+### 7.6.2
+
+* Fix an error for the `KnapsackPro::Formatters::TimeTracker` formatter in RSpec when using Knapsack Pro Regular Mode and the `.rspec` file is not present.
+
+  https://github.com/KnapsackPro/knapsack_pro-ruby/pull/265
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.6.1...v7.6.2
+
 ### 7.6.1
 
 * Add support for the Timecop 0.9.9 gem version so that we could track proper tests' execution time when `Process.clock_gettime` is mocked.

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'stringio'
-#require_relative '../utils' # this should cause CI integration test to fail
+require_relative '../utils'
 
 module KnapsackPro
   module Formatters

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'stringio'
-require_relative '../utils'
+#require_relative '../utils' # this should cause CI integration test to fail
 
 module KnapsackPro
   module Formatters

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'stringio'
+require_relative '../utils'
 
 module KnapsackPro
   module Formatters


### PR DESCRIPTION
# Story

[link to the internal story](https://trello.com/c/fJHs1lcE)

## Related

* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/263

# Description

* Fix an error for the `KnapsackPro::Formatters::TimeTracker` formatter in RSpec when using Knapsack Pro Regular Mode and the `.rspec` file is not present.

* Add a test on CI to reproduce the error. It ensures the bug won't happen again.

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
