### PR TITLE
Log threads when the OS signal is received to simplify debugging, especially when a CI node hangs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### UNRELEASED
 
+### 7.7.0
+
+* Log threads when the OS signal is received to simplify debugging, especially when a CI node hangs.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/266
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.6.2...v7.7.0
+
 ### 7.6.2
 
 * Fix an error for the `KnapsackPro::Formatters::TimeTracker` formatter in RSpec when using Knapsack Pro Regular Mode and the `.rspec` file is not present.

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -69,7 +69,6 @@ module KnapsackPro
 
           puts
           puts '=' * 80
-          puts "Process pid: #{Process.pid}"
           puts "Start logging #{threads.count} detected threads."
           puts 'See the following backtrace and the line of code that is stuck if your CI node hangs.'
 

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -75,7 +75,7 @@ module KnapsackPro
           threads.each do |thread|
             puts
             if thread == Thread.main
-              puts "Main thread and its backtrace:"
+              puts "Main thread backtrace:"
             else
               puts "Non-main thread inspect: #{thread.inspect}"
               puts "Non-main thread backtrace:"

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -72,15 +72,15 @@ module KnapsackPro
           puts "Start logging #{threads.count} detected threads."
           puts 'Use the following backtrace to find the line of code that got stuck if the CI node hung and terminated your tests.'
 
-          threads.each do |thr|
+          threads.each do |thread|
             puts
-            if thr == Thread.main
+            if thread == Thread.main
               puts "Main thread and its backtrace:"
             else
-              puts "Non-main thread inspect: #{thr.inspect}"
+              puts "Non-main thread inspect: #{thread.inspect}"
               puts "Non-main thread backtrace:"
             end
-            puts thr.backtrace.join("\n")
+            puts thread.backtrace.join("\n")
             puts
           end
 

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -70,7 +70,7 @@ module KnapsackPro
           puts
           puts '=' * 80
           puts "Start logging #{threads.count} detected threads."
-          puts 'Use the following backtrace to find the line of code that got stuck if the CI node hung and terminated your tests.'
+          puts 'Use the following backtrace(s) to find the line of code that got stuck if the CI node hung and terminated your tests.'
 
           threads.each do |thread|
             puts

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -59,8 +59,37 @@ module KnapsackPro
             Signal.trap(signal) {
               puts "#{signal} signal has been received. Terminating Knapsack Pro..."
               @@terminate_process = true
+              log_threads
             }
           end
+        end
+
+        def log_threads
+          threads = Thread.list
+
+          puts
+          puts '=' * 80
+          puts "Process pid: #{Process.pid}"
+          puts "Start logging #{threads.count} detected threads."
+          puts 'See the following backtrace and the line of code that is stuck if your CI node hangs.'
+
+          threads.each do |thr|
+            puts
+            if thr == Thread.main
+              puts "Main thread and its backtrace:"
+            else
+              puts "Non-main thread inspect: #{thr.inspect}"
+              puts "Non-main thread backtrace:"
+            end
+            puts thr.backtrace.join("\n")
+            puts
+          end
+
+          puts
+          puts 'End logging threads.'
+          puts '=' * 80
+
+          $stdout.flush
         end
       end
     end

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -70,7 +70,7 @@ module KnapsackPro
           puts
           puts '=' * 80
           puts "Start logging #{threads.count} detected threads."
-          puts 'See the following backtrace and the line of code that is stuck if your CI node hangs.'
+          puts 'Use the following backtrace to find the line of code that got stuck if the CI node hung and terminated your tests.'
 
           threads.each do |thr|
             puts

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1414,8 +1414,8 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       )
 
 
-      expect(actual.stdout).to include('Use the following backtrace to find the line of code that got stuck if the CI node hung and terminated your tests.')
-      expect(actual.stdout).to include('Main thread and its backtrace:')
+      expect(actual.stdout).to include('Use the following backtrace(s) to find the line of code that got stuck if the CI node hung and terminated your tests.')
+      expect(actual.stdout).to include('Main thread backtrace:')
       expect(actual.stdout).to include("spec_integration/b_spec.rb:7:in `kill'")
       expect(actual.stdout).to include('Non-main thread backtrace:')
       expect(actual.stdout).to include("spec_integration/a_spec.rb:8:in `sleep'")

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1318,6 +1318,13 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
         describe 'A_describe' do
           it 'A1 test example' do
             expect(1).to eq 1
+
+            Thread.new do
+              10.times do |i|
+                puts "Non-main thread counter: " + i.to_s
+                sleep 1
+              end
+            end
           end
         end
       SPEC
@@ -1405,6 +1412,14 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
           1) B1_describe B1.1_describe B1.1.3 test example
         OUTPUT
       )
+
+
+      expect(actual.stdout).to include('Use the following backtrace to find the line of code that got stuck if the CI node hung and terminated your tests.')
+      expect(actual.stdout).to include('Main thread and its backtrace:')
+      expect(actual.stdout).to include("spec_integration/b_spec.rb:7:in `kill'")
+      expect(actual.stdout).to include('Non-main thread backtrace:')
+      expect(actual.stdout).to include("spec_integration/a_spec.rb:8:in `sleep'")
+
 
       expect(actual.exit_code).to eq 1
     end

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1320,10 +1320,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
             expect(1).to eq 1
 
             Thread.new do
-              10.times do |i|
-                puts "Non-main thread counter: " + i.to_s
-                sleep 1
-              end
+              sleep 10
             end
           end
         end
@@ -1418,7 +1415,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       expect(actual.stdout).to include('Main thread backtrace:')
       expect(actual.stdout).to include("spec_integration/b_spec.rb:7:in `kill'")
       expect(actual.stdout).to include('Non-main thread backtrace:')
-      expect(actual.stdout).to include("spec_integration/a_spec.rb:8:in `sleep'")
+      expect(actual.stdout).to include("spec_integration/a_spec.rb:6:in `sleep'")
 
 
       expect(actual.exit_code).to eq 1


### PR DESCRIPTION
# Story

https://trello.com/c/oQCHRpec

## Related

https://docs.knapsackpro.com/ruby/troubleshooting/#why-does-the-ci-node-hang-backtrace-debugging

# Description

Log threads when the OS signal is received to simplify debugging, especially when a CI node hangs.

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
