### PR TITLE
Add a link to help you read the backtrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 7.8.0
 
-* Add link to how to read the backtrace.
+* Add a link to help you read the backtrace.
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/267
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### UNRELEASED
 
+### 7.8.0
+
+* Add link to how to read the backtrace.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/267
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.7.0...v7.8.0
+
 ### 7.7.0
 
 * Log threads when the OS signal is received to simplify debugging, especially when a CI node hangs.

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -71,6 +71,7 @@ module KnapsackPro
           puts '=' * 80
           puts "Start logging #{threads.count} detected threads."
           puts 'Use the following backtrace(s) to find the line of code that got stuck if the CI node hung and terminated your tests.'
+          puts 'How to read the backtrace: https://knapsackpro.com/perma/ruby/backtrace-debugging'
 
           threads.each do |thread|
             puts

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1322,6 +1322,8 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
             Thread.new do
               sleep 10
             end
+
+            sleep 1 # wait for the above async thread to start
           end
         end
       SPEC


### PR DESCRIPTION
## Related

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/266

# Description

* Add link to how to read the backtrace:
https://knapsackpro.com/perma/ruby/backtrace-debugging

* fix a flaky test


# Changes

TODO: changes introduced by this PR

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
