### PR TITLE
fix: handle nil backtrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-### UNRELEASED
+### UNRELEASED (7.8.1)
+
+* Handle `nil` in `Thread#backtrace` and `Exception#backtrace`.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/272
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.8.0...v7.8.1
 
 ### 7.8.0
 

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -81,7 +81,7 @@ module KnapsackPro
               puts "Non-main thread inspect: #{thread.inspect}"
               puts "Non-main thread backtrace:"
             end
-            puts thread.backtrace.join("\n")
+            puts thread.backtrace&.join("\n")
             puts
           end
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -58,7 +58,7 @@ module KnapsackPro
           rescue Exception => exception
             KnapsackPro.logger.error("An unexpected exception happened. RSpec cannot handle it. The exception: #{exception.inspect}")
             KnapsackPro.logger.error("Exception message: #{exception.message}")
-            KnapsackPro.logger.error("Exception backtrace: #{exception.backtrace.join("\n")}")
+            KnapsackPro.logger.error("Exception backtrace: #{exception.backtrace&.join("\n")}")
 
             message = @rspec_pure.exit_summary(unexecuted_test_files)
             KnapsackPro.logger.warn(message) if message


### PR DESCRIPTION
- **Story**: https://trello.com/c/fRBnccqI/486-bugknapsackpro-gem-fix-an-error-when-a-backtrace-is-nil-in-log-threads
- **Issue**: https://github.com/KnapsackPro/knapsack_pro-ruby/issues/270

# Description

`#backtrace` could be `nil` in:
- [Exception](https://github.com/ruby/ruby/blob/638b4468b8826a34d7e513b56153ef4363d5bcf4/error.c#L1838)
- [Thread](https://github.com/ruby/ruby/blob/dd4677cf0654a7512df0809a31f5eac6bce5b97d/thread.c#L5339)

Better to look at the c source as the docs may not be always clear on what the return values are (as in this case).

I don't think we need additional test coverage because we are not dealing with a bug that could cause a regression.

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
