### PR TITLE
Set `RSpec.world.wants_to_quit` to true when any signal is received by the knapsack_pro gem to allow graceful exit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 7.8.2
+
+* Set `RSpec.world.wants_to_quit` to true when any signal is received by the knapsack_pro gem to allow graceful exit.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/273
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.8.1...v7.8.2
+
 ### 7.8.1
 
 * Handle `nil` in `Thread#backtrace` and `Exception#backtrace`.

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -59,6 +59,7 @@ module KnapsackPro
             Signal.trap(signal) {
               puts "#{signal} signal has been received. Terminating Knapsack Pro..."
               @@terminate_process = true
+              RSpec.world.wants_to_quit = true if signal == 'INT'
               log_threads
             }
           end

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -59,7 +59,7 @@ module KnapsackPro
             Signal.trap(signal) {
               puts "#{signal} signal has been received. Terminating Knapsack Pro..."
               @@terminate_process = true
-              RSpec.world.wants_to_quit = true if signal == 'INT'
+              RSpec.world.wants_to_quit = true
               log_threads
             }
           end

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1383,8 +1383,8 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       expect(actual.stdout).to include('B1.1.1 test example (PENDING: Temporarily skipped with xit)')
       expect(actual.stdout).to include('INT signal has been received. Terminating Knapsack Pro...')
       expect(actual.stdout).to include('B1.1.2 test example')
-      expect(actual.stdout).to include('B1.1.3 test example (FAILED - 1)')
-      expect(actual.stdout).to include('B1.2.1 test example')
+      expect(actual.stdout).to_not include('B1.1.3 test example (FAILED - 1)')
+      expect(actual.stdout).to_not include('B1.2.1 test example')
 
       # next ExampleGroup within the same b_spec.rb is not executed
       expect(actual.stdout).to_not include('B2.1 test example')
@@ -1401,14 +1401,6 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
         Pending: (Failures listed here are expected and do not affect your suite's status)
 
           1) B1_describe B1.1_describe B1.1.1 test example
-        OUTPUT
-      )
-
-      expect(actual.stdout).to include(
-        <<~OUTPUT
-        Failures:
-
-          1) B1_describe B1.1_describe B1.1.3 test example
         OUTPUT
       )
 


### PR DESCRIPTION
# Story

TODO:  N/A

## Related

* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/270#issuecomment-2401539528

# Description

Set `RSpec.world.wants_to_quit` to true when any signal is received by the knapsack_pro gem. This allows RSpec to gracefully exit as soon as the signal is received, instead of waiting for the test file to finish running.

This also ensures that external libraries, like datadog-ci, behave properly when RSpec is quitting.

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
