### PR TITLE
A more readable error message for the RSpec split by examples JSON report (remove ANSI codes that are not human-readable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 7.9.0
+
+* A more readable error message for the RSpec split by examples JSON report (remove ANSI codes that are not human-readable)
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/275
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.8.2...v7.9.0
+
 ### 7.8.2
 
 * Set `RSpec.world.wants_to_quit` to true when any signal is received by the knapsack_pro gem to allow graceful exit.

--- a/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
+++ b/lib/knapsack_pro/test_case_detectors/rspec_test_example_detector.rb
@@ -27,6 +27,7 @@ module KnapsackPro
 
         cli_args = cli_format + [
           '--dry-run',
+          '--no-color',
           '--out', report_path,
           '--default-path', test_dir,
         ] + KnapsackPro::TestFilePresenter.paths(test_file_entities)

--- a/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
+++ b/spec/knapsack_pro/test_case_detectors/rspec_test_example_detector_spec.rb
@@ -48,6 +48,7 @@ describe KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector do
           expect(RSpec::Core::ConfigurationOptions).to receive(:new).with([
             '--format', expected_format,
             '--dry-run',
+            '--no-color',
             '--out', report_path,
             '--default-path', test_dir,
             'spec/a_spec.rb', 'spec/b_spec.rb',


### PR DESCRIPTION
## Related

RSpec split by examples feature: https://docs.knapsackpro.com/ruby/split-by-test-examples/

Issue:

* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/274

# Description

When an error occurs while loading slow test files, the RSpec JSON report contains errors mixed with ANSI codes. By default, RSpec produces colored output.

We use the `--no-color` option to remove the ANSI codes and make the error message more readable.

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
