### PR TITLE
slow test split patch

### DIFF
--- a/lib/knapsack_pro/adapters/base_adapter.rb
+++ b/lib/knapsack_pro/adapters/base_adapter.rb
@@ -22,14 +22,12 @@ module KnapsackPro
       def self.slow_test_file?(adapter_class, test_file_path)
         @slow_test_file_paths ||=
           begin
-            slow_test_files =
-              if KnapsackPro::Config::Env.slow_test_file_pattern
-                KnapsackPro::TestFileFinder.slow_test_files_by_pattern(adapter_class)
-              else
-                # get slow test files from JSON file based on data from API
-                KnapsackPro::SlowTestFileDeterminer.read_from_json_report
-              end
-            KnapsackPro::TestFilePresenter.paths(slow_test_files)
+            slow_test_files = []
+            if KnapsackPro::Config::Env.slow_test_file_pattern
+              slow_test_files << KnapsackPro::TestFileFinder.slow_test_files_by_pattern(adapter_class)
+            end
+            slow_test_files << KnapsackPro::SlowTestFileDeterminer.read_from_json_report
+            KnapsackPro::TestFilePresenter.paths(slow_test_files.flatten.uniq)
           end
         clean_path = KnapsackPro::TestFileCleaner.clean(test_file_path)
         @slow_test_file_paths.include?(clean_path)

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -67,6 +67,10 @@ module KnapsackPro
           ENV['KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN']
         end
 
+        def slow_test_time_threshold_per_ci_node
+          ENV.fetch('KNAPSACK_PRO_SLOW_TEST_TIME_THRESHOLD_PER_CI_NODE', 0.7).to_f
+        end
+
         def test_file_exclude_pattern
           ENV['KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN']
         end

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -2,12 +2,10 @@
 
 module KnapsackPro
   class SlowTestFileDeterminer
-    TIME_THRESHOLD_PER_CI_NODE = 0.7 # 70%
-
     # test_files: { 'path' => 'a_spec.rb', 'time_execution' => 0.0 }
     # time_execution: of build distribution (total time of CI build run)
     def self.call(test_files, time_execution)
-      time_threshold = (time_execution / KnapsackPro::Config::Env.ci_node_total) * TIME_THRESHOLD_PER_CI_NODE
+      time_threshold = (time_execution / KnapsackPro::Config::Env.ci_node_total) * KnapsackPro::Config::Env.slow_test_time_threshold_per_ci_node
 
       test_files.select do |test_file|
         time_execution = test_file.fetch('time_execution')

--- a/spec/knapsack_pro/adapters/base_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/base_adapter_spec.rb
@@ -4,6 +4,10 @@ describe KnapsackPro::Adapters::BaseAdapter do
   end
 
   shared_examples '.slow_test_file? method' do
+    before do
+      allow(KnapsackPro::SlowTestFileDeterminer).to receive(:read_from_json_report).and_return(slow_test_files)
+    end
+
     context 'when test_file_path is in slow test file paths' do
       # add ./ before path to ensure KnapsackPro::TestFileCleaner.clean will clean it
       let(:test_file_path) { './spec/models/user_spec.rb' }
@@ -76,6 +80,7 @@ describe KnapsackPro::Adapters::BaseAdapter do
           'KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN' => '{spec/models/*_spec.rb}',
         })
         expect(KnapsackPro::TestFileFinder).to receive(:slow_test_files_by_pattern).with(adapter_class).and_return(slow_test_files)
+        expect(KnapsackPro::SlowTestFileDeterminer).to receive(:read_from_json_report).and_return(slow_test_files)
       end
 
       it_behaves_like '.slow_test_file? method'

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -1,6 +1,20 @@
 describe KnapsackPro::Config::Env do
   before { stub_const("ENV", {}) }
 
+  describe '.slow_test_time_threshold_per_ci_node' do
+    subject { described_class.slow_test_time_threshold_per_ci_node }
+
+    context 'when KNAPSACK_PRO_SLOW_TEST_TIME_THRESHOLD_PER_CI_NODE has value' do
+      before { stub_const("ENV", { 'KNAPSACK_PRO_SLOW_TEST_TIME_THRESHOLD_PER_CI_NODE' => '0.9' }) }
+
+      it { should eq 0.9 }
+    end
+
+    context 'when KNAPSACK_PRO_SLOW_TEST_TIME_THRESHOLD_PER_CI_NODE does not have value' do
+      it { should eq 0.7 }
+    end
+  end
+
   describe '.ci_node_total' do
     subject { described_class.ci_node_total }
 

--- a/spec/knapsack_pro/slow_test_file_finder_spec.rb
+++ b/spec/knapsack_pro/slow_test_file_finder_spec.rb
@@ -23,6 +23,15 @@ describe KnapsackPro::SlowTestFileFinder do
         test_files_existing_on_disk = double
         expect(KnapsackPro::TestFileFinder).to receive(:select_test_files_that_can_be_run).with(adapter_class, merged_test_files_from_api).and_return(test_files_existing_on_disk)
 
+        test_file_paths_existing_on_disk = double
+        expect(KnapsackPro::TestFilePresenter).to receive(:paths).with(test_files_existing_on_disk).and_return(test_file_paths_existing_on_disk)
+
+        test_files_in_subset = double
+        expect(test_files_from_api).to receive(:select).and_return(test_files_in_subset)
+
+        time_execution = double
+        expect(test_files_in_subset).to receive(:sum).and_return(time_execution)
+
         slow_test_files = double
         expect(KnapsackPro::SlowTestFileDeterminer).to receive(:call).with(test_files_existing_on_disk, time_execution).and_return(slow_test_files)
 


### PR DESCRIPTION
# Story

TODO: link to the internal story

## Related

TODO: links to related PRs or issues

# Description

I tried using `KNAPSACK_PRO_BRANCH` to uniquely set branch names so that a KNAPSACK_TOKEN can be shared across multiple projects. I noticed an issue where because of this, `BuildDistributions.last` returns every recorded test, and the cumulative time execution is too great for the `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES` feature to continue to work correctly. 

# Changes

I used this change to monkey patch that functionality to only consider the cumulative time execution of only the tests on disk instead of the entire recorded set of tests returned by the build distributions API. Not married to this approach, but if it makes it easier to reason about a more permanent fix, please consider this as a starting point. Feel free to edit and build from this.

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
