### PR TITLE
improvement(RSpec): use test file execution times for existing test files on the disk to determine slow test files. This fixes issue with detecting slow test files when API token is shared between multiple test suites.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 7.10.0
+
+* Improve the RSpec split by examples feature. Use test file execution times for existing test files on the disk to determine slow test files. This fixes issue with detecting slow test files when API token is shared between multiple test suites.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/277
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.9.0...v7.10.0
+
 ### 7.9.0
 
 * A more readable error message for the RSpec split by examples JSON report (remove ANSI codes that are not human-readable)

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -5,9 +5,9 @@ module KnapsackPro
     TIME_THRESHOLD_PER_CI_NODE = 0.7 # 70%
 
     # test_files: { 'path' => 'a_spec.rb', 'time_execution' => 0.0 }
-    # time_execution: of build distribution (total time of CI build run)
-    def self.call(test_files, time_execution)
-      time_threshold = (time_execution / KnapsackPro::Config::Env.ci_node_total) * TIME_THRESHOLD_PER_CI_NODE
+    def self.call(test_files)
+      total_execution_time = test_files.sum { |test_file| test_file.fetch('time_execution') }
+      time_threshold = (total_execution_time / KnapsackPro::Config::Env.ci_node_total) * TIME_THRESHOLD_PER_CI_NODE
 
       test_files.select do |test_file|
         time_execution = test_file.fetch('time_execution')

--- a/lib/knapsack_pro/slow_test_file_finder.rb
+++ b/lib/knapsack_pro/slow_test_file_finder.rb
@@ -19,7 +19,7 @@ module KnapsackPro
 
       test_files_existing_on_disk = KnapsackPro::TestFileFinder.select_test_files_that_can_be_run(adapter_class, merged_test_files_from_api)
 
-      slow_test_files = KnapsackPro::SlowTestFileDeterminer.call(test_files_existing_on_disk, build_distribution_entity.time_execution)
+      slow_test_files = KnapsackPro::SlowTestFileDeterminer.call(test_files_existing_on_disk)
 
       KnapsackPro::SlowTestFileDeterminer.save_to_json_report(slow_test_files)
 

--- a/spec/knapsack_pro/slow_test_file_determiner_spec.rb
+++ b/spec/knapsack_pro/slow_test_file_determiner_spec.rb
@@ -6,7 +6,7 @@ describe KnapsackPro::SlowTestFileDeterminer do
       expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(node_total)
     end
 
-    subject { described_class.call(test_files, time_execution) }
+    subject { described_class.call(test_files) }
 
     context 'when test files have recorded time execution' do
       let(:time_execution) { 20.0 }
@@ -14,28 +14,34 @@ describe KnapsackPro::SlowTestFileDeterminer do
         [
           { 'path' => 'a_spec.rb', 'time_execution' => 1.0 },
           { 'path' => 'b_spec.rb', 'time_execution' => 3.4 },
-          # slow tests are above 3.5s threshold (20.0 / 4 * 0.7 = 3.5)
           { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
-          { 'path' => 'd_spec.rb', 'time_execution' => 5.9 },
+          { 'path' => 'd_spec.rb', 'time_execution' => 12.1 },
         ]
       end
 
-      it do
+      it 'detects slow tests above 3.5s threshold (20.0 / 4 nodes * 70% threshold = 3.5)' do
         expect(subject).to eq([
           { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
-          { 'path' => 'd_spec.rb', 'time_execution' => 5.9 },
+          { 'path' => 'd_spec.rb', 'time_execution' => 12.1 },
         ])
       end
     end
 
     context 'when test files have no recorded time execution' do
-      let(:time_execution) { 0.0 }
       let(:test_files) do
         [
           { 'path' => 'a_spec.rb', 'time_execution' => 0.0 },
           { 'path' => 'b_spec.rb', 'time_execution' => 0.0 },
         ]
       end
+
+      it do
+        expect(subject).to eq([])
+      end
+    end
+
+    context 'when there are no test files' do
+      let(:test_files) { [] }
 
       it do
         expect(subject).to eq([])

--- a/spec/knapsack_pro/slow_test_file_finder_spec.rb
+++ b/spec/knapsack_pro/slow_test_file_finder_spec.rb
@@ -13,8 +13,7 @@ describe KnapsackPro::SlowTestFileFinder do
 
       it do
         test_files_from_api = double
-        time_execution = double
-        build_distribution_entity = instance_double(KnapsackPro::BuildDistributionFetcher::BuildDistributionEntity, test_files: test_files_from_api, time_execution: time_execution)
+        build_distribution_entity = instance_double(KnapsackPro::BuildDistributionFetcher::BuildDistributionEntity, test_files: test_files_from_api)
         expect(KnapsackPro::BuildDistributionFetcher).to receive(:call).and_return(build_distribution_entity)
 
         merged_test_files_from_api = double
@@ -24,7 +23,7 @@ describe KnapsackPro::SlowTestFileFinder do
         expect(KnapsackPro::TestFileFinder).to receive(:select_test_files_that_can_be_run).with(adapter_class, merged_test_files_from_api).and_return(test_files_existing_on_disk)
 
         slow_test_files = double
-        expect(KnapsackPro::SlowTestFileDeterminer).to receive(:call).with(test_files_existing_on_disk, time_execution).and_return(slow_test_files)
+        expect(KnapsackPro::SlowTestFileDeterminer).to receive(:call).with(test_files_existing_on_disk).and_return(slow_test_files)
 
         expect(KnapsackPro::SlowTestFileDeterminer).to receive(:save_to_json_report).with(slow_test_files)
 


### PR DESCRIPTION
# Story

TODO: [link to the internal story](https://trello.com/c/Z5nLhYpc)

# Description

Related to the RSpec split by examples feature and when someone uses the same API token for multiple test suites.
https://docs.knapsackpro.com/ruby/split-by-test-examples/

# Changes 

Use test file execution times for existing test files on disk to identify slow test files.

This fixes an issue with detecting slow test files when the API token is shared between multiple test suites.

Related to PR: 

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/276

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
