### PR TITLE
fix(specs): require ostruct explicitly to make the spec work in Ruby 3.4

### DIFF
--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1,6 +1,7 @@
 require 'open3'
 require 'json'
 require 'nokogiri'
+require 'ostruct'
 
 describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :clear_tmp do
   SPEC_DIRECTORY = 'spec_integration'


### PR DESCRIPTION
# Story

TODO: [link to the internal story](https://trello.com/c/cAGLlpjL)

# Changes

* fix(specs): require ostruct explicitly to make the spec work in Ruby 3.4

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
