### PR TITLE
Make the test suite pass on Ruby 3.4.0-preview2 and keep tests passing on older Ruby versions too.

### DIFF
--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1062,7 +1062,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       expect(actual.stdout).to_not include('C1 test example')
 
       expect(actual.stdout).to include('An error occurred while loading ./spec_integration/failing_spec.rb')
-      expect(actual.stdout).to match(/undefined local variable or method `a_fake_method' for.* RSpec::ExampleGroups::BDescribe/)
+      expect(actual.stdout).to match(/undefined local variable or method .a_fake_method. for.* RSpec::ExampleGroups::BDescribe/)
       expect(actual.stdout).to include('WARN -- : [knapsack_pro] RSpec wants to quit')
       expect(actual.stdout).to include('1 example, 0 failures, 1 error occurred outside of examples')
 

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -2020,7 +2020,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
       actual = subject
 
-      expect(actual.stdout).to include('DEBUG -- : [knapsack_pro] Detected 1 slow test files: [{"path"=>"spec_integration/a_spec.rb"}]')
+      expect(actual.stdout).to match(/DEBUG -- : \[knapsack_pro\] Detected 1 slow test files: \[\{"path".?=>.?"spec_integration\/a_spec\.rb"\}\]/)
 
       expect(actual.stdout).to include(
         <<~OUTPUT

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1105,7 +1105,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       actual = subject
 
       expect(actual.stdout).to include('An error occurred while loading spec_helper.')
-      expect(actual.stdout).to include("undefined local variable or method `a_fake_method' for main")
+      expect(actual.stdout).to match(/undefined local variable or method .a_fake_method. for main/)
       expect(actual.stdout).to include('0 examples, 0 failures, 1 error occurred outside of examples')
 
       expect(actual.exit_code).to eq 1

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1408,9 +1408,9 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
       expect(actual.stdout).to include('Use the following backtrace(s) to find the line of code that got stuck if the CI node hung and terminated your tests.')
       expect(actual.stdout).to include('Main thread backtrace:')
-      expect(actual.stdout).to include("spec_integration/b_spec.rb:7:in `kill'")
+      expect(actual.stdout).to match(/spec_integration\/b_spec\.rb:7:in .*kill/)
       expect(actual.stdout).to include('Non-main thread backtrace:')
-      expect(actual.stdout).to include("spec_integration/a_spec.rb:6:in `sleep'")
+      expect(actual.stdout).to match(/spec_integration\/a_spec\.rb:6:in .*sleep/)
 
 
       expect(actual.exit_code).to eq 1


### PR DESCRIPTION
# Story

TODO: [link to the internal story](https://trello.com/c/cAGLlpjL)

# Description

Make the test suite pass on Ruby 3.4.0-preview2 and keep tests passing on older Ruby versions too.

Tested locally. There is no `cimg/ruby:3.4` docker image available to test on CI yet.


# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
