### PR TITLE
Add ostruct to the list of gems in development environment to ensure it works with Ruby 3.5 and to get rid of the warning in Ruby 3.4

### DIFF
--- a/knapsack_pro.gemspec
+++ b/knapsack_pro.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '>= 6.0'
   spec.add_development_dependency 'webmock', '>= 3.13'
   spec.add_development_dependency 'timecop', '>= 0.9.9'
+  spec.add_development_dependency 'ostruct', '>= 0.6.0'
 end


### PR DESCRIPTION
# Story

TODO: [link to the internal story](https://trello.com/c/cAGLlpjL)

## Related

* https://github.com/KnapsackPro/rails-app-with-knapsack_pro/pull/70

# Description

Add ostruct to the list of gems in development environment to ensure it works with Ruby 3.5 and to get rid of the warning in Ruby 3.4

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
