### PR TITLE
 fix(RSpec split by examples): Properly determine slow test files when test example execution times and full test file execution time are both known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 7.11.0
+
+* fix(RSpec split by examples): Properly determine slow test files when test example execution times and full test file execution time are both known
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/281
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.10.0...v7.11.0
+
 ### 7.10.0
 
 * Improve the RSpec split by examples feature. Use test file execution times for existing test files on the disk to determine slow test files. This fixes issue with detecting slow test files when API token is shared between multiple test suites.

--- a/lib/knapsack_pro/test_case_mergers/rspec_merger.rb
+++ b/lib/knapsack_pro/test_case_mergers/rspec_merger.rb
@@ -4,17 +4,27 @@ module KnapsackPro
   module TestCaseMergers
     class RSpecMerger < BaseMerger
       def call
-        merged_test_files_hash = {}
-        test_files.each do |test_file|
-          test_file_path = extract_test_file_path(test_file.fetch('path'))
+        all_test_files_hash = {}
+        merged_test_file_examples_hash = {}
 
-          # must be float (default type for time execution from API)
-          merged_test_files_hash[test_file_path] ||= 0.0
-          merged_test_files_hash[test_file_path] += test_file.fetch('time_execution')
+        test_files.each do |test_file|
+          path = test_file.fetch('path')
+          test_file_path = extract_test_file_path(path)
+
+          if rspec_id_path?(path)
+            merged_test_file_examples_hash[test_file_path] ||= 0.0
+            merged_test_file_examples_hash[test_file_path] += test_file.fetch('time_execution')
+          else
+            all_test_files_hash[test_file_path] = test_file.fetch('time_execution')
+          end
+        end
+
+        merged_test_file_examples_hash.each do |path, time_execution|
+          all_test_files_hash[path] = [time_execution, all_test_files_hash[path]].compact.max
         end
 
         merged_test_files = []
-        merged_test_files_hash.each do |path, time_execution|
+        all_test_files_hash.each do |path, time_execution|
           merged_test_files << {
             'path' => path,
             'time_execution' => time_execution
@@ -30,6 +40,12 @@ module KnapsackPro
       # or test example path: spec/a_spec.rb[1:1]
       def extract_test_file_path(path)
         path.gsub(/\.rb\[.+\]$/, '.rb')
+      end
+
+      def rspec_id_path?(path)
+        path_with_id_regex = /.+_spec\.rb\[.+\]$/
+
+        path&.match?(path_with_id_regex)
       end
     end
   end

--- a/spec/knapsack_pro/test_case_mergers/rspec_merger_spec.rb
+++ b/spec/knapsack_pro/test_case_mergers/rspec_merger_spec.rb
@@ -2,7 +2,7 @@ describe KnapsackPro::TestCaseMergers::RSpecMerger do
   describe '#call' do
     subject { described_class.new(test_files).call }
 
-    context 'when all test files are not test example paths' do
+    context 'when test files are regular file paths (not test example paths)' do
       let(:test_files) do
         [
           { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
@@ -10,7 +10,7 @@ describe KnapsackPro::TestCaseMergers::RSpecMerger do
         ]
       end
 
-      it do
+      it 'returns the test files unchanged' do
         expect(subject).to eq([
           { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
           { 'path' => 'spec/b_spec.rb', 'time_execution' => 2.2 },
@@ -28,7 +28,7 @@ describe KnapsackPro::TestCaseMergers::RSpecMerger do
         ]
       end
 
-      it 'returns merged paths for test examples and sum of their time_execution' do
+      it 'merges the test example paths and sums their execution times' do
         expect(subject).to eq([
           { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
           { 'path' => 'spec/test_case_spec.rb', 'time_execution' => 3.0 },
@@ -36,11 +36,11 @@ describe KnapsackPro::TestCaseMergers::RSpecMerger do
       end
     end
 
-    context 'when test files have test example paths and at the same time test file path for test example path is present as full test file path' do
+    context 'when test files have test example paths and the full test file path exists simultaneously' do
       let(:test_files) do
         [
           { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
-          # full test file path is present despite existing test example paths
+          # full test file path exists alongside test example paths
           { 'path' => 'spec/test_case_spec.rb', 'time_execution' => 1.0 },
           # test example paths
           { 'path' => 'spec/test_case_spec.rb[1:1]', 'time_execution' => 2.2 },
@@ -48,7 +48,7 @@ describe KnapsackPro::TestCaseMergers::RSpecMerger do
         ]
       end
 
-      it 'returns merged paths for test examples and sum of their time_execution' do
+      it 'merges the paths and sums their execution times' do
         expect(subject).to eq([
           { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
           { 'path' => 'spec/test_case_spec.rb', 'time_execution' => 4.0 },

--- a/spec/knapsack_pro/test_case_mergers/rspec_merger_spec.rb
+++ b/spec/knapsack_pro/test_case_mergers/rspec_merger_spec.rb
@@ -37,22 +37,44 @@ describe KnapsackPro::TestCaseMergers::RSpecMerger do
     end
 
     context 'when test files have test example paths and the full test file path exists simultaneously' do
-      let(:test_files) do
-        [
-          { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
-          # full test file path exists alongside test example paths
-          { 'path' => 'spec/test_case_spec.rb', 'time_execution' => 1.0 },
-          # test example paths
-          { 'path' => 'spec/test_case_spec.rb[1:1]', 'time_execution' => 2.2 },
-          { 'path' => 'spec/test_case_spec.rb[1:2]', 'time_execution' => 0.8 },
-        ]
+      context 'when the full test file path has a higher execution time than the sum of test example paths' do
+        let(:test_files) do
+          [
+            { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
+            # full test file path exists alongside test example paths
+            { 'path' => 'spec/test_case_spec.rb', 'time_execution' => 3.1 },
+            # test example paths
+            { 'path' => 'spec/test_case_spec.rb[1:1]', 'time_execution' => 2.2 },
+            { 'path' => 'spec/test_case_spec.rb[1:2]', 'time_execution' => 0.8 },
+          ]
+        end
+
+        it 'returns the full test file path execution time' do
+          expect(subject).to eq([
+            { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
+            { 'path' => 'spec/test_case_spec.rb', 'time_execution' => 3.1 },
+          ])
+        end
       end
 
-      it 'merges the paths and sums their execution times' do
-        expect(subject).to eq([
-          { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
-          { 'path' => 'spec/test_case_spec.rb', 'time_execution' => 4.0 },
-        ])
+      context 'when the full test file path has a lower execution time than the sum of test example paths' do
+        let(:test_files) do
+          [
+            { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
+            # full test file path exists alongside test example paths
+            { 'path' => 'spec/test_case_spec.rb', 'time_execution' => 2.9 },
+            # test example paths
+            { 'path' => 'spec/test_case_spec.rb[1:1]', 'time_execution' => 2.2 },
+            { 'path' => 'spec/test_case_spec.rb[1:2]', 'time_execution' => 0.8 },
+          ]
+        end
+
+        it "returns the sum of test example paths' execution times" do
+          expect(subject).to eq([
+            { 'path' => 'spec/a_spec.rb', 'time_execution' => 1.1 },
+            { 'path' => 'spec/test_case_spec.rb', 'time_execution' => 3.0 },
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
# Story

TODO: [link to the internal story](https://trello.com/c/f8uD3QC0)

## Related

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/277

# Description

About the problem:

We add up a spec file execution time and all test example execution times to determine the time of a test file, which doubles the execution time of a spec in the worst-case scenario. This leads to some tests not being split by test examples and unbalanced builds.

# Changes

Use whichever execution time is larger:

* The execution time of the entire test file
* The sum of execution times of the test file examples

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
