### PR TITLE
Add `KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD` to improve the RSpec split by examples feature with many skipped tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,15 @@ jobs:
       - run:
           working_directory: ~/rails-app-with-knapsack_pro
           command: |
+            # split by test examples above the slow test file threshold ||
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--split-above-slow-test-file-threshold"
+            export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
+            export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
+            export KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD=1
+            bundle exec rake knapsack_pro:queue:rspec
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: |
             # turnip ||
             export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--turnip"
             export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 7.12.0
+
+* Add `KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD` to improve the RSpec split by examples feature with many skipped tests
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/282
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.11.0...v7.12.0
+
 ### 7.11.0
 
 * fix(RSpec split by examples): Properly determine slow test files when test example execution times and full test file execution time are both known

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.12.0
 
 * Add `KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD` to improve the RSpec split by examples feature with many skipped tests
+* Do not split test files by test cases if you run tests on a single CI node to run Knapsack Pro faster.
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/282
 

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -36,6 +36,11 @@ module KnapsackPro
       test_files_to_run = all_test_files_to_run
 
       if adapter_class.split_by_test_cases_enabled?
+        if KnapsackPro::Config::Env.ci_node_total < 2
+          KnapsackPro.logger.warn('Skipping split of test files by test cases because you are running tests on a single CI node (no parallelism)')
+          return test_files_to_run
+        end
+
         slow_test_files = get_slow_test_files
         return test_files_to_run if slow_test_files.empty?
 

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -201,12 +201,11 @@ module KnapsackPro
         end
 
         def slow_test_file_threshold
-          value = ENV.fetch('KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD', nil)
-          value.to_f unless value.nil?
+          ENV.fetch('KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD', nil)&.to_f
         end
 
         def slow_test_file_threshold?
-          !slow_test_file_threshold.nil?
+          !!slow_test_file_threshold
         end
 
         def test_suite_token

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -200,6 +200,15 @@ module KnapsackPro
           ENV.fetch('KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX', 'bundle exec')
         end
 
+        def slow_test_file_threshold
+          value = ENV.fetch('KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD', nil)
+          value.to_f unless value.nil?
+        end
+
+        def slow_test_file_threshold?
+          !slow_test_file_threshold.nil?
+        end
+
         def test_suite_token
           env_name = 'KNAPSACK_PRO_TEST_SUITE_TOKEN'
           ENV[env_name] || raise("Missing environment variable #{env_name}. You should set environment variable like #{env_name}_RSPEC (note there is suffix _RSPEC at the end). knapsack_pro gem will set #{env_name} based on #{env_name}_RSPEC value. If you use other test runner than RSpec then use proper suffix.")

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -10,12 +10,12 @@ module KnapsackPro
       time_threshold = (total_execution_time / KnapsackPro::Config::Env.ci_node_total) * TIME_THRESHOLD_PER_CI_NODE
 
       test_files.select do |test_file|
-        time_execution = test_file.fetch('time_execution')
-        next false if time_execution.zero?
-        next true if time_execution >= time_threshold
+        execution_time = test_file.fetch('time_execution')
+        next false if execution_time.zero?
+        next true if execution_time >= time_threshold
         next false unless KnapsackPro::Config::Env.slow_test_file_threshold?
 
-        time_execution >= KnapsackPro::Config::Env.slow_test_file_threshold
+        execution_time >= KnapsackPro::Config::Env.slow_test_file_threshold
       end
     end
 

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -8,6 +8,12 @@ module KnapsackPro
     def self.call(test_files)
       total_execution_time = test_files.sum { |test_file| test_file.fetch('time_execution') }
       time_threshold = (total_execution_time / KnapsackPro::Config::Env.ci_node_total) * TIME_THRESHOLD_PER_CI_NODE
+      puts '+' * 100
+      puts "Total execution time of tests on the disk: #{total_execution_time}s"
+      puts "Slow test files time threshold: #{time_threshold}s"
+      puts "Test files on the disk with estimated mean execution time:"
+      puts test_files.inspect
+      puts '+' * 100
 
       test_files.select do |test_file|
         time_execution = test_file.fetch('time_execution')

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -11,7 +11,11 @@ module KnapsackPro
 
       test_files.select do |test_file|
         time_execution = test_file.fetch('time_execution')
-        time_execution >= time_threshold && time_execution > 0
+        next false if time_execution.zero?
+        next true if time_execution >= time_threshold
+        next false unless KnapsackPro::Config::Env.slow_test_file_threshold?
+
+        time_execution >= KnapsackPro::Config::Env.slow_test_file_threshold
       end
     end
 

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -6,6 +6,8 @@ module KnapsackPro
 
     # test_files: { 'path' => 'a_spec.rb', 'time_execution' => 0.0 }
     def self.call(test_files)
+      return [] if KnapsackPro::Config::Env.ci_node_total == 1
+
       total_execution_time = test_files.sum { |test_file| test_file.fetch('time_execution') }
       time_threshold = (total_execution_time / KnapsackPro::Config::Env.ci_node_total) * TIME_THRESHOLD_PER_CI_NODE
 

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -8,12 +8,6 @@ module KnapsackPro
     def self.call(test_files)
       total_execution_time = test_files.sum { |test_file| test_file.fetch('time_execution') }
       time_threshold = (total_execution_time / KnapsackPro::Config::Env.ci_node_total) * TIME_THRESHOLD_PER_CI_NODE
-      puts '+' * 100
-      puts "Total execution time of tests on the disk: #{total_execution_time}s"
-      puts "Slow test files time threshold: #{time_threshold}s"
-      puts "Test files on the disk with estimated mean execution time:"
-      puts test_files.inspect
-      puts '+' * 100
 
       test_files.select do |test_file|
         time_execution = test_file.fetch('time_execution')

--- a/lib/knapsack_pro/slow_test_file_determiner.rb
+++ b/lib/knapsack_pro/slow_test_file_determiner.rb
@@ -6,8 +6,6 @@ module KnapsackPro
 
     # test_files: { 'path' => 'a_spec.rb', 'time_execution' => 0.0 }
     def self.call(test_files)
-      return [] if KnapsackPro::Config::Env.ci_node_total == 1
-
       total_execution_time = test_files.sum { |test_file| test_file.fetch('time_execution') }
       time_threshold = (total_execution_time / KnapsackPro::Config::Env.ci_node_total) * TIME_THRESHOLD_PER_CI_NODE
 

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1964,10 +1964,13 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       # remember to stub Queue API batches to include test examples (example: a_spec.rb[1:1])
       # for the following slow test files
       ENV['KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN'] = "#{SPEC_DIRECTORY}/a_spec.rb"
+
+      ENV['KNAPSACK_PRO_CI_NODE_TOTAL'] = '2'
     end
     after do
       ENV.delete('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES')
       ENV.delete('KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN')
+      ENV.delete('KNAPSACK_PRO_CI_NODE_TOTAL')
     end
 
     it 'splits slow test files by examples AND ensures the test examples are executed only once' do
@@ -2060,10 +2063,13 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       # remember to stub Queue API batches to include test examples (example: a_spec.rb[1:1])
       # for the following slow test files
       ENV['KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN'] = "#{SPEC_DIRECTORY}/a_spec.rb"
+
+      ENV['KNAPSACK_PRO_CI_NODE_TOTAL'] = '2'
     end
     after do
       ENV.delete('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES')
       ENV.delete('KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN')
+      ENV.delete('KNAPSACK_PRO_CI_NODE_TOTAL')
     end
 
     it 'sets 1 as exit code AND raises an error (a test example path as a_spec.rb[1:1] would always be executed even when it does not have the tag that is set via the --tag option. We cannot run tests because it could lead to running unintentional tests)' do
@@ -2138,10 +2144,13 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       # remember to stub Queue API batches to include test examples (example: a_spec.rb[1:1])
       # for the following slow test files
       ENV['KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN'] = "#{SPEC_DIRECTORY}/a_spec.rb"
+
+      ENV['KNAPSACK_PRO_CI_NODE_TOTAL'] = '2'
     end
     after do
       ENV.delete('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES')
       ENV.delete('KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN')
+      ENV.delete('KNAPSACK_PRO_CI_NODE_TOTAL')
     end
 
     it 'produces a JSON report' do
@@ -2237,10 +2246,13 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       # remember to stub Queue API batches to include test examples (example: a_spec.rb[1:1])
       # for the following slow test files
       ENV['KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN'] = "#{SPEC_DIRECTORY}/a_spec.rb"
+
+      ENV['KNAPSACK_PRO_CI_NODE_TOTAL'] = '2'
     end
     after do
       ENV.delete('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES')
       ENV.delete('KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN')
+      ENV.delete('KNAPSACK_PRO_CI_NODE_TOTAL')
     end
 
     it 'produces a JUnit XML report' do
@@ -2334,10 +2346,13 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       # remember to stub Queue API batches to include test examples (example: a_spec.rb[1:1])
       # for the following slow test files
       ENV['KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN'] = "#{SPEC_DIRECTORY}/a_spec.rb"
+
+      ENV['KNAPSACK_PRO_CI_NODE_TOTAL'] = '2'
     end
     after do
       ENV.delete('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES')
       ENV.delete('KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN')
+      ENV.delete('KNAPSACK_PRO_CI_NODE_TOTAL')
     end
 
     it 'produces a code coverage report' do

--- a/spec/knapsack_pro/base_allocator_builder_spec.rb
+++ b/spec/knapsack_pro/base_allocator_builder_spec.rb
@@ -134,6 +134,7 @@ describe KnapsackPro::BaseAllocatorBuilder do
 
       before  do
         expect(adapter_class).to receive(:split_by_test_cases_enabled?).and_return(true)
+        expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(node_total)
 
         test_file_pattern = double
         expect(KnapsackPro::TestFilePattern).to receive(:call).with(adapter_class).and_return(test_file_pattern)
@@ -142,9 +143,7 @@ describe KnapsackPro::BaseAllocatorBuilder do
       end
 
       context 'when less than 2 CI nodes' do
-        before do
-          expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(1)
-        end
+        let(:node_total) { 1 }
 
         it 'returns test files without test cases' do
           logger = instance_double(Logger)
@@ -155,8 +154,9 @@ describe KnapsackPro::BaseAllocatorBuilder do
       end
 
       context 'when at least 2 CI nodes' do
+        let(:node_total) { 2 }
+
         before do
-          expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(2)
           expect(allocator_builder).to receive(:get_slow_test_files).and_return(slow_test_files)
         end
 

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -1067,7 +1067,10 @@ describe KnapsackPro::Config::Env do
 
     context 'when ENV exists' do
       before { stub_const("ENV", { 'KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD' => '2' }) }
-      it { should eq 2.0 }
+      it 'returns seconds' do
+        expect(subject).to eq 2.0
+        expect(subject).to be_a Float
+      end
     end
 
     context "when ENV doesn't exist" do

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -1062,6 +1062,34 @@ describe KnapsackPro::Config::Env do
     end
   end
 
+  describe '.slow_test_file_threshold' do
+    subject { described_class.slow_test_file_threshold }
+
+    context 'when ENV exists' do
+      before { stub_const("ENV", { 'KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD' => '2' }) }
+      it { should eq 2.0 }
+    end
+
+    context "when ENV doesn't exist" do
+      before { stub_const("ENV", {}) }
+      it { should be_nil }
+    end
+  end
+
+  describe '.slow_test_file_threshold?' do
+    subject { described_class.slow_test_file_threshold? }
+
+    context 'when ENV exists' do
+      before { stub_const("ENV", { 'KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD' => '2' }) }
+      it { should be true }
+    end
+
+    context "when ENV doesn't exist" do
+      before { stub_const("ENV", {}) }
+      it { should be false }
+    end
+  end
+
   describe '.test_suite_token' do
     subject { described_class.test_suite_token }
 

--- a/spec/knapsack_pro/slow_test_file_determiner_spec.rb
+++ b/spec/knapsack_pro/slow_test_file_determiner_spec.rb
@@ -3,7 +3,7 @@ describe KnapsackPro::SlowTestFileDeterminer do
     let(:node_total) { 4 }
 
     before do
-      expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(node_total)
+      expect(KnapsackPro::Config::Env).to receive(:ci_node_total).at_least(:once).and_return(node_total)
     end
 
     subject { described_class.call(test_files) }
@@ -46,6 +46,22 @@ describe KnapsackPro::SlowTestFileDeterminer do
           { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
           { 'path' => 'd_spec.rb', 'time_execution' => 12.1 },
         ])
+      end
+    end
+
+    context 'when test files have recorded execution time AND a single CI node' do
+      let(:node_total) { 1 }
+      let(:test_files) do
+        [
+          { 'path' => 'a_spec.rb', 'time_execution' => 1.0 },
+          { 'path' => 'b_spec.rb', 'time_execution' => 3.4 },
+          { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
+          { 'path' => 'd_spec.rb', 'time_execution' => 12.1 },
+        ]
+      end
+
+      it 'returns an empty array because there is only a single CI node, so there is no point in splitting by test cases' do
+        expect(subject).to eq([])
       end
     end
 

--- a/spec/knapsack_pro/slow_test_file_determiner_spec.rb
+++ b/spec/knapsack_pro/slow_test_file_determiner_spec.rb
@@ -8,8 +8,7 @@ describe KnapsackPro::SlowTestFileDeterminer do
 
     subject { described_class.call(test_files) }
 
-    context 'when test files have recorded time execution' do
-      let(:time_execution) { 20.0 }
+    context 'when test files have recorded execution time' do
       let(:test_files) do
         [
           { 'path' => 'a_spec.rb', 'time_execution' => 1.0 },
@@ -27,7 +26,30 @@ describe KnapsackPro::SlowTestFileDeterminer do
       end
     end
 
-    context 'when test files have no recorded time execution' do
+    context 'when test files have recorded execution time AND slow test files threshold is set' do
+      let(:test_files) do
+        [
+          { 'path' => 'a_spec.rb', 'time_execution' => 1.0 },
+          { 'path' => 'b_spec.rb', 'time_execution' => 3.4 },
+          { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
+          { 'path' => 'd_spec.rb', 'time_execution' => 12.1 },
+        ]
+      end
+
+      before do
+        stub_const("ENV", { 'KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD' => '2' })
+      end
+
+      it 'detects slow tests above 2.0s threshold' do
+        expect(subject).to eq([
+          { 'path' => 'b_spec.rb', 'time_execution' => 3.4 },
+          { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
+          { 'path' => 'd_spec.rb', 'time_execution' => 12.1 },
+        ])
+      end
+    end
+
+    context 'when test files have no recorded execution time' do
       let(:test_files) do
         [
           { 'path' => 'a_spec.rb', 'time_execution' => 0.0 },

--- a/spec/knapsack_pro/slow_test_file_determiner_spec.rb
+++ b/spec/knapsack_pro/slow_test_file_determiner_spec.rb
@@ -3,7 +3,7 @@ describe KnapsackPro::SlowTestFileDeterminer do
     let(:node_total) { 4 }
 
     before do
-      expect(KnapsackPro::Config::Env).to receive(:ci_node_total).at_least(:once).and_return(node_total)
+      expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(node_total)
     end
 
     subject { described_class.call(test_files) }
@@ -46,22 +46,6 @@ describe KnapsackPro::SlowTestFileDeterminer do
           { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
           { 'path' => 'd_spec.rb', 'time_execution' => 12.1 },
         ])
-      end
-    end
-
-    context 'when test files have recorded execution time AND a single CI node' do
-      let(:node_total) { 1 }
-      let(:test_files) do
-        [
-          { 'path' => 'a_spec.rb', 'time_execution' => 1.0 },
-          { 'path' => 'b_spec.rb', 'time_execution' => 3.4 },
-          { 'path' => 'c_spec.rb', 'time_execution' => 3.5 },
-          { 'path' => 'd_spec.rb', 'time_execution' => 12.1 },
-        ]
-      end
-
-      it 'returns an empty array because there is only a single CI node, so there is no point in splitting by test cases' do
-        expect(subject).to eq([])
       end
     end
 


### PR DESCRIPTION
# Story

TODO: [link to the internal story](https://trello.com/c/f8uD3QC0)

## Related

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/281

# Description

Relate to the RSpec split by examples feature:
https://docs.knapsackpro.com/ruby/split-by-test-examples/

If a user skips some test files, for example, using the RSpec `--tag` option, then RSpec might still load a file but not run it or only run some of the test examples from it.

If a lot of test files are skipped, then the actual average CI node execution time would be much smaller than the estimated time (Knapsack Pro does not know how many test files are filtered out by `--tag`).  This can lead to not determining enough test files as slow, which examples should split. As a result, CI build is unbalanced.

To solve that problem, we added a new environment variable (`KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD`). You define a threshold (a number of seconds) for slow test files. Any test file above the threshold would be split by test examples.
For example, you expect your CI node to run no longer than 3 minutes, then set `KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD=180` (180 seconds == 3 minutes)

## changes

* Add the `KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD` option
* do not split test files by test cases if you run tests on a single CI node to run Knapsack Pro faster


# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
