### PR TITLE
fix(RSpec split by examples): properly disable split by test examples on a single node to speed up tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,17 @@ jobs:
       - run:
           working_directory: ~/rails-app-with-knapsack_pro
           command: |
+            # split by test examples above the slow test file threshold AND a single CI node ||
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--split-above-slow-test-file-threshold--single-node"
+            export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
+            export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
+            export KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD=1
+            export KNAPSACK_PRO_CI_NODE_TOTAL=1
+            export KNAPSACK_PRO_CI_NODE_INDEX=0
+            bundle exec rake knapsack_pro:queue:rspec
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          command: |
             # turnip ||
             export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--turnip"
             export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,11 +280,10 @@ jobs:
       - run:
           working_directory: ~/rails-app-with-knapsack_pro
           command: |
-            # split by test examples above the slow test file threshold AND a single CI node ||
-            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--split-above-slow-test-file-threshold--single-node"
+            # split by test examples AND a single CI node ||
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--split--single-node"
             export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
             export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
-            export KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD=1
             export KNAPSACK_PRO_CI_NODE_TOTAL=1
             export KNAPSACK_PRO_CI_NODE_INDEX=0
             bundle exec rake knapsack_pro:queue:rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 7.12.1
+
+* fix(RSpec split by examples): properly disable split by test examples on a single node to speed up tests
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/283
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.12.0...v7.12.1
+
 ### 7.12.0
 
 * Add `KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD` to improve the RSpec split by examples feature with many skipped tests

--- a/lib/knapsack_pro/base_allocator_builder.rb
+++ b/lib/knapsack_pro/base_allocator_builder.rb
@@ -36,11 +36,6 @@ module KnapsackPro
       test_files_to_run = all_test_files_to_run
 
       if adapter_class.split_by_test_cases_enabled?
-        if KnapsackPro::Config::Env.ci_node_total < 2
-          KnapsackPro.logger.warn('Skipping split of test files by test cases because you are running tests on a single CI node (no parallelism)')
-          return test_files_to_run
-        end
-
         slow_test_files = get_slow_test_files
         return test_files_to_run if slow_test_files.empty?
 

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -189,7 +189,16 @@ module KnapsackPro
         end
 
         def rspec_split_by_test_examples
-          ENV.fetch('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES', false)
+          return @rspec_split_by_test_examples if defined?(@rspec_split_by_test_examples)
+
+          @rspec_split_by_test_examples = ENV.fetch('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES', false)
+
+          if @rspec_split_by_test_examples.to_s == 'true' && ci_node_total < 2
+            KnapsackPro.logger.debug('Skipping split of test files by test cases because you are running tests on a single CI node (no parallelism)')
+            @rspec_split_by_test_examples = false
+          end
+
+          @rspec_split_by_test_examples
         end
 
         def rspec_split_by_test_examples?

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -189,18 +189,16 @@ module KnapsackPro
         end
 
         def rspec_split_by_test_examples?
+          return @rspec_split_by_test_examples if defined?(@rspec_split_by_test_examples)
+
           split = ENV.fetch('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES', false).to_s == 'true'
 
           if split && ci_node_total < 2
-            @logged_rspec_split_by_test_examples_message ||=
-              begin
-                KnapsackPro.logger.debug('Skipping split of test files by test examples because you are running tests on a single CI node (no parallelism)')
-                true
-              end
-            return false
+            KnapsackPro.logger.debug('Skipping split of test files by test examples because you are running tests on a single CI node (no parallelism)')
+            @rspec_split_by_test_examples = false
+          else
+            @rspec_split_by_test_examples = split
           end
-
-          split
         end
 
         def rspec_test_example_detector_prefix

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -189,9 +189,9 @@ module KnapsackPro
         end
 
         def rspec_split_by_test_examples?
-          split = ENV.fetch('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES', false)
+          split = ENV.fetch('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES', false).to_s == 'true'
 
-          if split.to_s == 'true' && ci_node_total < 2
+          if split && ci_node_total < 2
             @logged_rspec_split_by_test_examples_message ||=
               begin
                 KnapsackPro.logger.debug('Skipping split of test files by test examples because you are running tests on a single CI node (no parallelism)')
@@ -200,7 +200,7 @@ module KnapsackPro
             return false
           end
 
-          split.to_s == 'true'
+          split
         end
 
         def rspec_test_example_detector_prefix

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -188,21 +188,19 @@ module KnapsackPro
           ENV.fetch('KNAPSACK_PRO_CUCUMBER_QUEUE_PREFIX', 'bundle exec')
         end
 
-        def rspec_split_by_test_examples
-          return @rspec_split_by_test_examples if defined?(@rspec_split_by_test_examples)
+        def rspec_split_by_test_examples?
+          split = ENV.fetch('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES', false)
 
-          @rspec_split_by_test_examples = ENV.fetch('KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES', false)
-
-          if @rspec_split_by_test_examples.to_s == 'true' && ci_node_total < 2
-            KnapsackPro.logger.debug('Skipping split of test files by test cases because you are running tests on a single CI node (no parallelism)')
-            @rspec_split_by_test_examples = false
+          if split.to_s == 'true' && ci_node_total < 2
+            @logged_rspec_split_by_test_examples_message ||=
+              begin
+                KnapsackPro.logger.debug('Skipping split of test files by test examples because you are running tests on a single CI node (no parallelism)')
+                true
+              end
+            return false
           end
 
-          @rspec_split_by_test_examples
-        end
-
-        def rspec_split_by_test_examples?
-          rspec_split_by_test_examples.to_s == 'true'
+          split.to_s == 'true'
         end
 
         def rspec_test_example_detector_prefix

--- a/spec/knapsack_pro/base_allocator_builder_spec.rb
+++ b/spec/knapsack_pro/base_allocator_builder_spec.rb
@@ -134,57 +134,39 @@ describe KnapsackPro::BaseAllocatorBuilder do
 
       before  do
         expect(adapter_class).to receive(:split_by_test_cases_enabled?).and_return(true)
-        expect(KnapsackPro::Config::Env).to receive(:ci_node_total).and_return(node_total)
 
         test_file_pattern = double
         expect(KnapsackPro::TestFilePattern).to receive(:call).with(adapter_class).and_return(test_file_pattern)
 
         expect(KnapsackPro::TestFileFinder).to receive(:call).with(test_file_pattern).and_return(test_files_to_run)
+
+        expect(allocator_builder).to receive(:get_slow_test_files).and_return(slow_test_files)
       end
 
-      context 'when less than 2 CI nodes' do
-        let(:node_total) { 1 }
+      context 'when slow test files are detected' do
+        let(:slow_test_files) do
+          [
+            '1_spec.rb',
+            '2_spec.rb',
+          ]
+        end
+
+        it 'returns test files with test cases' do
+          test_file_cases = double
+          expect(adapter_class).to receive(:test_file_cases_for).with(slow_test_files).and_return(test_file_cases)
+
+          test_files_with_test_cases = double
+          expect(KnapsackPro::TestFilesWithTestCasesComposer).to receive(:call).with(test_files_to_run, slow_test_files, test_file_cases).and_return(test_files_with_test_cases)
+
+          expect(subject).to eq test_files_with_test_cases
+        end
+      end
+
+      context 'when slow test files are not detected' do
+        let(:slow_test_files) { [] }
 
         it 'returns test files without test cases' do
-          logger = instance_double(Logger)
-          expect(KnapsackPro).to receive(:logger).and_return(logger)
-          expect(logger).to receive(:warn).with('Skipping split of test files by test cases because you are running tests on a single CI node (no parallelism)')
           expect(subject).to eq test_files_to_run
-        end
-      end
-
-      context 'when at least 2 CI nodes' do
-        let(:node_total) { 2 }
-
-        before do
-          expect(allocator_builder).to receive(:get_slow_test_files).and_return(slow_test_files)
-        end
-
-        context 'when slow test files are detected' do
-          let(:slow_test_files) do
-            [
-              '1_spec.rb',
-              '2_spec.rb',
-            ]
-          end
-
-          it 'returns test files with test cases' do
-            test_file_cases = double
-            expect(adapter_class).to receive(:test_file_cases_for).with(slow_test_files).and_return(test_file_cases)
-
-            test_files_with_test_cases = double
-            expect(KnapsackPro::TestFilesWithTestCasesComposer).to receive(:call).with(test_files_to_run, slow_test_files, test_file_cases).and_return(test_files_with_test_cases)
-
-            expect(subject).to eq test_files_with_test_cases
-          end
-        end
-
-        context 'when slow test files are not detected' do
-          let(:slow_test_files) { [] }
-
-          it 'returns test files without test cases' do
-            expect(subject).to eq test_files_to_run
-          end
         end
       end
     end

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -1045,7 +1045,7 @@ describe KnapsackPro::Config::Env do
       it { should be false }
 
       context 'when called twice' do
-        it 'logs debug message only once' do
+        it 'logs a debug message only once' do
           logger = instance_double(Logger)
           expect(KnapsackPro).to receive(:logger).and_return(logger)
           expect(logger).to receive(:debug).with('Skipping split of test files by test examples because you are running tests on a single CI node (no parallelism)')

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -1016,6 +1016,11 @@ describe KnapsackPro::Config::Env do
   describe '.rspec_split_by_test_examples?' do
     subject { described_class.rspec_split_by_test_examples? }
 
+    before do
+      described_class.remove_instance_variable(:@rspec_split_by_test_examples)
+    rescue NameError
+    end
+
     context 'when KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true AND KNAPSACK_PRO_CI_NODE_TOTAL >= 2' do
       before do
         stub_const("ENV", { 'KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES' => 'true', 'KNAPSACK_PRO_CI_NODE_TOTAL' => '2' })
@@ -1036,10 +1041,6 @@ describe KnapsackPro::Config::Env do
 
     context 'when KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true AND KNAPSACK_PRO_CI_NODE_TOTAL < 2' do
       before { stub_const("ENV", { 'KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES' => 'true', 'KNAPSACK_PRO_CI_NODE_TOTAL' => '1' }) }
-
-      before do
-        described_class.instance_variable_set(:@logged_rspec_split_by_test_examples_message, nil)
-      end
 
       it { should be false }
 


### PR DESCRIPTION
# Description

Fix for a bug introduced in the following PR when you run tests on a single CI node and use `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true`.

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/282

```
vendor/bundle/ruby/3.2.0/gems/knapsack_pro-7.12.0/lib/knapsack_pro/slow_test_file_determiner.rb:29:in `read_from_json_report'
/home/betterment/for_business/impersonate/vendor/bundle/ruby/3.2.0/gems/knapsack_pro-7.12.0/lib/knapsack_pro/adapters/base_adapter.rb:30:in `slow_test_file?'
/home/betterment/for_business/impersonate/vendor/bundle/ruby/3.2.0/gems/knapsack_pro-7.12.0/lib/knapsack_pro/formatters/time_tracker.rb:123:in `rspec_split_by_test_example?'
/home/betterment/for_business/impersonate/vendor/bundle/ruby/3.2.0/gems/knapsack_pro-7.12.0/lib/knapsack_pro/formatters/time_tracker.rb:117:in `path_for'
/home/betterment/for_business/impersonate/vendor/bundle/ruby/3.2.0/gems/knapsack_pro-7.12.0/lib/knapsack_pro/formatters/time_tracker.rb:102:in `record_example'
/home/betterment/for_business/impersonate/vendor/bundle/ruby/3.2.0/gems/knapsack_pro-7.12.0/lib/knapsack_pro/formatters/time_tracker.rb:38:in `example_finished'
```

# changes

* fix(RSpec split by examples): properly disable split by test examples on a single node to speed up tests

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
