### PR TITLE
Custom exit code for fallback mode error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Unreleased (minor)
+
+* Add `KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE` to specify a custom exit code whenever Knapsack Pro fails because Fallback Mode cannot be used
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/284
+
 ### 7.12.1
 
 * fix(RSpec split by examples): properly disable split by test examples on a single node to speed up tests

--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -29,7 +29,7 @@ module KnapsackPro
       elsif !KnapsackPro::Config::Env.fallback_mode_enabled?
         message = "Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to #{KnapsackPro::Urls::REGULAR_MODE__CONNECTION_ERROR_WITH_FALLBACK_ENABLED_FALSE}"
         KnapsackPro.logger.error(message)
-        exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+        exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code
         Kernel.exit(exit_code)
       elsif KnapsackPro::Config::Env.ci_node_retry_count > 0
         message = "knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more #{KnapsackPro::Urls::REGULAR_MODE__CONNECTION_ERROR_WITH_FALLBACK_ENABLED_TRUE_AND_POSITIVE_RETRY_COUNT}"
@@ -37,7 +37,7 @@ module KnapsackPro
           message += " Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more #{KnapsackPro::Urls::FIXED_TEST_SUITE_SPLIT}"
         end
         KnapsackPro.logger.error(message)
-        exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+        exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code
         Kernel.exit(exit_code)
       else
         KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. Read more about fallback mode at #{KnapsackPro::Urls::FALLBACK_MODE}")

--- a/lib/knapsack_pro/allocator.rb
+++ b/lib/knapsack_pro/allocator.rb
@@ -29,14 +29,16 @@ module KnapsackPro
       elsif !KnapsackPro::Config::Env.fallback_mode_enabled?
         message = "Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to #{KnapsackPro::Urls::REGULAR_MODE__CONNECTION_ERROR_WITH_FALLBACK_ENABLED_FALSE}"
         KnapsackPro.logger.error(message)
-        raise message
+        exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+        Kernel.exit(exit_code)
       elsif KnapsackPro::Config::Env.ci_node_retry_count > 0
         message = "knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more #{KnapsackPro::Urls::REGULAR_MODE__CONNECTION_ERROR_WITH_FALLBACK_ENABLED_TRUE_AND_POSITIVE_RETRY_COUNT}"
         unless KnapsackPro::Config::Env.fixed_test_suite_split?
           message += " Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more #{KnapsackPro::Urls::FIXED_TEST_SUITE_SPLIT}"
         end
         KnapsackPro.logger.error(message)
-        raise message
+        exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+        Kernel.exit(exit_code)
       else
         KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. Read more about fallback mode at #{KnapsackPro::Urls::FALLBACK_MODE}")
         fallback_test_files

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -284,9 +284,8 @@ module KnapsackPro
             detected_ci != KnapsackPro::Config::CI::Base
         end
 
-        def fallback_mode_error_exit_code_or(default)
-          env_value = ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE']
-          (env_value || default).to_i
+        def fallback_mode_error_exit_code
+          ENV.fetch('KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE', 1).to_i
         end
 
         private

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -284,6 +284,11 @@ module KnapsackPro
             detected_ci != KnapsackPro::Config::CI::Base
         end
 
+        def fallback_mode_error_exit_code_or(default)
+          env_value = ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE']
+          (env_value || default).to_i
+        end
+
         private
 
         def required_env(env_name)

--- a/lib/knapsack_pro/queue_allocator.rb
+++ b/lib/knapsack_pro/queue_allocator.rb
@@ -2,6 +2,8 @@
 
 module KnapsackPro
   class QueueAllocator
+    FallbackModeError = Class.new(StandardError)
+
     def initialize(args)
       @fast_and_slow_test_files_to_run = args.fetch(:fast_and_slow_test_files_to_run)
       @fallback_mode_test_files = args.fetch(:fallback_mode_test_files)
@@ -31,14 +33,14 @@ module KnapsackPro
       elsif !KnapsackPro::Config::Env.fallback_mode_enabled?
         message = "Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to #{KnapsackPro::Urls::QUEUE_MODE__CONNECTION_ERROR_WITH_FALLBACK_ENABLED_FALSE}"
         KnapsackPro.logger.error(message)
-        raise message
+        raise FallbackModeError.new(message)
       elsif KnapsackPro::Config::Env.ci_node_retry_count > 0
         message = "knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more #{KnapsackPro::Urls::QUEUE_MODE__CONNECTION_ERROR_WITH_FALLBACK_ENABLED_TRUE_AND_POSITIVE_RETRY_COUNT}"
         unless KnapsackPro::Config::Env.fixed_queue_split?
           message += " Please ensure you have set KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more #{KnapsackPro::Urls::FIXED_QUEUE_SPLIT}"
         end
         KnapsackPro.logger.error(message)
-        raise message
+        raise FallbackModeError.new(message)
       else
         @fallback_activated = true
         KnapsackPro.logger.warn("Fallback mode started. We could not connect with Knapsack Pro API. Your tests will be executed based on directory names. If other CI nodes were able to connect with Knapsack Pro API then you may notice that some of the test files will be executed twice across CI nodes. The most important thing is to guarantee each of test files is run at least once! Read more about fallback mode at #{KnapsackPro::Urls::FALLBACK_MODE}")

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -29,6 +29,9 @@ module KnapsackPro
           end
 
           Kernel.exit(accumulator[:exitstatus])
+        rescue KnapsackPro::QueueAllocator::FallbackModeError
+          exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+          Kernel.exit(exit_code)
         end
 
         def self.run_tests(accumulator)

--- a/lib/knapsack_pro/runners/queue/cucumber_runner.rb
+++ b/lib/knapsack_pro/runners/queue/cucumber_runner.rb
@@ -30,7 +30,7 @@ module KnapsackPro
 
           Kernel.exit(accumulator[:exitstatus])
         rescue KnapsackPro::QueueAllocator::FallbackModeError
-          exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+          exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code
           Kernel.exit(exit_code)
         end
 

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -40,6 +40,9 @@ module KnapsackPro
           end
 
           Kernel.exit(accumulator[:exitstatus])
+        rescue KnapsackPro::QueueAllocator::FallbackModeError
+          exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+          Kernel.exit(exit_code)
         end
 
         def self.run_tests(accumulator)

--- a/lib/knapsack_pro/runners/queue/minitest_runner.rb
+++ b/lib/knapsack_pro/runners/queue/minitest_runner.rb
@@ -41,7 +41,7 @@ module KnapsackPro
 
           Kernel.exit(accumulator[:exitstatus])
         rescue KnapsackPro::QueueAllocator::FallbackModeError
-          exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+          exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code
           Kernel.exit(exit_code)
         end
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -55,6 +55,9 @@ module KnapsackPro
           rescue KnapsackPro::Runners::Queue::BaseRunner::TerminationError
             exit_code = @rspec_pure.error_exit_code(@rspec_runner.knapsack__error_exit_code)
             Kernel.exit(exit_code)
+          rescue KnapsackPro::QueueAllocator::FallbackModeError
+            exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+            Kernel.exit(exit_code)
           rescue Exception => exception
             KnapsackPro.logger.error("An unexpected exception happened. RSpec cannot handle it. The exception: #{exception.inspect}")
             KnapsackPro.logger.error("Exception message: #{exception.message}")

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -56,7 +56,7 @@ module KnapsackPro
             exit_code = @rspec_pure.error_exit_code(@rspec_runner.knapsack__error_exit_code)
             Kernel.exit(exit_code)
           rescue KnapsackPro::QueueAllocator::FallbackModeError
-            exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code_or(1)
+            exit_code = KnapsackPro::Config::Env.fallback_mode_error_exit_code
             Kernel.exit(exit_code)
           rescue Exception => exception
             KnapsackPro.logger.error("An unexpected exception happened. RSpec cannot handle it. The exception: #{exception.inspect}")

--- a/spec/integration/runners/fallback_spec.rb
+++ b/spec/integration/runners/fallback_spec.rb
@@ -1,0 +1,131 @@
+require 'open3'
+require 'ostruct'
+require 'tempfile'
+
+['RSpec', 'Minitest', 'Cucumber'].each do |runner|
+  describe "#{Object.const_get("KnapsackPro::Runners::#{runner}Runner")} Fallback - Integration tests" do
+    def log(stdout, stderr, status)
+      puts '='*50
+      puts 'STDOUT:'
+      puts stdout
+      puts
+
+      puts '='*50
+      puts 'STDERR:'
+      puts stderr
+      puts
+
+      puts '='*50
+      puts 'Exit status code:'
+      puts status
+      puts
+    end
+
+    subject do
+      stdout, stderr, status = Open3.capture3("ruby #{@task.path}")
+      log(stdout, stderr, status) if ENV['TEST__SHOW_DEBUG_LOG'] == 'true'
+      OpenStruct.new(stdout: stdout, stderr: stderr, exit_code: status.exitstatus)
+    end
+
+    before(:each) do
+      ENV['KNAPSACK_PRO_ENDPOINT'] = 'https://fail.knapsackpro.com' # ensure the API is not reachable
+      ENV['KNAPSACK_PRO_MAX_REQUEST_RETRIES'] = '1' # only try once to reach the API
+    end
+
+    around(:each) do |example|
+      Tempfile.create do |file|
+        file.write(<<~CONTENT)
+          require 'knapsack_pro'
+
+          ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN_#{runner.upcase}'] = SecureRandom.hex
+          ENV['KNAPSACK_PRO_CI_NODE_BUILD_ID'] = SecureRandom.uuid
+
+          #{Object.const_get("KnapsackPro::Runners::#{runner}Runner")}.run('')
+        CONTENT
+        file.rewind
+
+        @task = file
+        example.run
+      end
+    end
+
+    after(:each) do
+      ENV.delete('KNAPSACK_PRO_ENDPOINT')
+      ENV.delete('KNAPSACK_PRO_MAX_REQUEST_RETRIES')
+    end
+
+    context 'with fallback mode disabled' do
+      before(:each) do
+        ENV['KNAPSACK_PRO_FALLBACK_MODE_ENABLED'] = 'false'
+      end
+
+      after(:each) do
+        ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ENABLED')
+      end
+
+      it 'exits with 1 and logs the error' do
+        actual = subject
+
+        expect(actual.exit_code).to eq 1
+
+        expect(actual.stdout).to include('ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-false')
+      end
+
+      context 'with a user defined exit code' do
+        before do
+          ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE'] = '123'
+        end
+
+        after do
+          ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE')
+        end
+
+        it 'exits with the passed exit code and logs the error' do
+          actual = subject
+
+          expect(actual.exit_code).to eq 123
+
+          expect(actual.stdout).to include('ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-false')
+        end
+      end
+    end
+
+    context 'with fallback mode enabled and positive node retry count' do
+      before(:each) do
+        ENV['KNAPSACK_PRO_FALLBACK_MODE_ENABLED'] = 'true'
+        ENV['KNAPSACK_PRO_CI_NODE_RETRY_COUNT'] = '1'
+      end
+
+      after(:each) do
+        ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ENABLED')
+        ENV.delete('KNAPSACK_PRO_CI_NODE_RETRY_COUNT')
+      end
+
+      it 'exits with 1 and logs the error' do
+        actual = subject
+
+        expect(actual.exit_code).to eq 1
+
+        expect(actual.stdout).to include('ERROR -- : [knapsack_pro] knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+      end
+
+      context 'with a user defined exit code' do
+        before do
+          ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE'] = '123'
+        end
+
+        after do
+          ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE')
+        end
+
+        it 'exits with the passed exit code and logs the error' do
+          actual = subject
+
+          expect(actual.exit_code).to eq 123
+
+          expect(actual.stdout).to include('ERROR -- : [knapsack_pro] knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/runners/queue/cucumber_runner_fallback_spec.rb
+++ b/spec/integration/runners/queue/cucumber_runner_fallback_spec.rb
@@ -1,0 +1,129 @@
+require 'open3'
+require 'ostruct'
+require 'tempfile'
+
+describe "#{KnapsackPro::Runners::Queue::CucumberRunner} Fallback - Integration tests" do
+  def log(stdout, stderr, status)
+    puts '='*50
+    puts 'STDOUT:'
+    puts stdout
+    puts
+
+    puts '='*50
+    puts 'STDERR:'
+    puts stderr
+    puts
+
+    puts '='*50
+    puts 'Exit status code:'
+    puts status
+    puts
+  end
+
+  subject do
+    stdout, stderr, status = Open3.capture3("ruby #{@task.path}")
+    log(stdout, stderr, status) if ENV['TEST__SHOW_DEBUG_LOG'] == 'true'
+    OpenStruct.new(stdout: stdout, stderr: stderr, exit_code: status.exitstatus)
+  end
+
+  before(:each) do
+    ENV['KNAPSACK_PRO_ENDPOINT'] = 'https://fail.knapsackpro.com' # ensure the API is not reachable
+    ENV['KNAPSACK_PRO_MAX_REQUEST_RETRIES'] = '1' # only try once to reach the API
+  end
+
+  around(:each) do |example|
+    Tempfile.create do |file|
+      file.write(<<~CONTENT)
+        require 'knapsack_pro'
+
+        ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN_CUCUMBER'] = SecureRandom.hex
+        ENV['KNAPSACK_PRO_CI_NODE_BUILD_ID'] = SecureRandom.uuid
+
+        #{KnapsackPro::Runners::Queue::CucumberRunner}.run('')
+      CONTENT
+      file.rewind
+
+      @task = file
+      example.run
+    end
+  end
+
+  after(:each) do
+    ENV.delete('KNAPSACK_PRO_ENDPOINT')
+    ENV.delete('KNAPSACK_PRO_MAX_REQUEST_RETRIES')
+  end
+
+  context 'with fallback mode disabled' do
+    before(:each) do
+      ENV['KNAPSACK_PRO_FALLBACK_MODE_ENABLED'] = 'false'
+    end
+
+    after(:each) do
+      ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ENABLED')
+    end
+
+    it 'exits with 1 and logs the error' do
+      actual = subject
+
+      expect(actual.exit_code).to eq 1
+
+      expect(actual.stdout).to include('ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false')
+    end
+
+    context 'with a user defined exit code' do
+      before do
+        ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE'] = '123'
+      end
+
+      after do
+        ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE')
+      end
+
+      it 'exits with the passed exit code and logs the error' do
+        actual = subject
+
+        expect(actual.exit_code).to eq 123
+
+        expect(actual.stdout).to include('ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false')
+      end
+    end
+  end
+
+  context 'with fallback mode enabled and positive node retry count' do
+    before(:each) do
+      ENV['KNAPSACK_PRO_FALLBACK_MODE_ENABLED'] = 'true'
+      ENV['KNAPSACK_PRO_CI_NODE_RETRY_COUNT'] = '1'
+    end
+
+    after(:each) do
+      ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ENABLED')
+      ENV.delete('KNAPSACK_PRO_CI_NODE_RETRY_COUNT')
+    end
+
+    it 'exits with 1 and logs the error' do
+      actual = subject
+
+      expect(actual.exit_code).to eq 1
+
+      expect(actual.stdout).to include('ERROR -- : [knapsack_pro] knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+    end
+
+    context 'with a user defined exit code' do
+      before do
+        ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE'] = '123'
+      end
+
+      after do
+        ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE')
+      end
+
+      it 'exits with the passed exit code and logs the error' do
+        actual = subject
+
+        expect(actual.exit_code).to eq 123
+
+        expect(actual.stdout).to include('ERROR -- : [knapsack_pro] knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+      end
+    end
+  end
+end

--- a/spec/integration/runners/queue/minitest_runner_fallback_spec.rb
+++ b/spec/integration/runners/queue/minitest_runner_fallback_spec.rb
@@ -1,0 +1,129 @@
+require 'open3'
+require 'ostruct'
+require 'tempfile'
+
+describe "#{KnapsackPro::Runners::Queue::MinitestRunner} Fallback - Integration tests" do
+  def log(stdout, stderr, status)
+    puts '='*50
+    puts 'STDOUT:'
+    puts stdout
+    puts
+
+    puts '='*50
+    puts 'STDERR:'
+    puts stderr
+    puts
+
+    puts '='*50
+    puts 'Exit status code:'
+    puts status
+    puts
+  end
+
+  subject do
+    stdout, stderr, status = Open3.capture3("ruby #{@task.path}")
+    log(stdout, stderr, status) if ENV['TEST__SHOW_DEBUG_LOG'] == 'true'
+    OpenStruct.new(stdout: stdout, stderr: stderr, exit_code: status.exitstatus)
+  end
+
+  before(:each) do
+    ENV['KNAPSACK_PRO_ENDPOINT'] = 'https://fail.knapsackpro.com' # ensure the API is not reachable
+    ENV['KNAPSACK_PRO_MAX_REQUEST_RETRIES'] = '1' # only try once to reach the API
+  end
+
+  around(:each) do |example|
+    Tempfile.create do |file|
+      file.write(<<~CONTENT)
+        require 'knapsack_pro'
+
+        ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST'] = SecureRandom.hex
+        ENV['KNAPSACK_PRO_CI_NODE_BUILD_ID'] = SecureRandom.uuid
+
+        #{KnapsackPro::Runners::Queue::MinitestRunner}.run('')
+      CONTENT
+      file.rewind
+
+      @task = file
+      example.run
+    end
+  end
+
+  after(:each) do
+    ENV.delete('KNAPSACK_PRO_ENDPOINT')
+    ENV.delete('KNAPSACK_PRO_MAX_REQUEST_RETRIES')
+  end
+
+  context 'with fallback mode disabled' do
+    before(:each) do
+      ENV['KNAPSACK_PRO_FALLBACK_MODE_ENABLED'] = 'false'
+    end
+
+    after(:each) do
+      ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ENABLED')
+    end
+
+    it 'exits with 1 and logs the error' do
+      actual = subject
+
+      expect(actual.exit_code).to eq 1
+
+      expect(actual.stdout).to include('ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false')
+    end
+
+    context 'with a user defined exit code' do
+      before do
+        ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE'] = '123'
+      end
+
+      after do
+        ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE')
+      end
+
+      it 'exits with the passed exit code and logs the error' do
+        actual = subject
+
+        expect(actual.exit_code).to eq 123
+
+        expect(actual.stdout).to include('ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false')
+      end
+    end
+  end
+
+  context 'with fallback mode enabled and positive node retry count' do
+    before(:each) do
+      ENV['KNAPSACK_PRO_FALLBACK_MODE_ENABLED'] = 'true'
+      ENV['KNAPSACK_PRO_CI_NODE_RETRY_COUNT'] = '1'
+    end
+
+    after(:each) do
+      ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ENABLED')
+      ENV.delete('KNAPSACK_PRO_CI_NODE_RETRY_COUNT')
+    end
+
+    it 'exits with 1 and logs the error' do
+      actual = subject
+
+      expect(actual.exit_code).to eq 1
+
+      expect(actual.stdout).to include('ERROR -- : [knapsack_pro] knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+    end
+
+    context 'with a user defined exit code' do
+      before do
+        ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE'] = '123'
+      end
+
+      after do
+        ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE')
+      end
+
+      it 'exits with the passed exit code and logs the error' do
+        actual = subject
+
+        expect(actual.exit_code).to eq 123
+
+        expect(actual.stdout).to include('ERROR -- : [knapsack_pro] knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+      end
+    end
+  end
+end

--- a/spec/integration/runners/queue/rspec_runner_fallback_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_fallback_spec.rb
@@ -1,0 +1,137 @@
+require 'open3'
+require 'ostruct'
+require 'tempfile'
+
+describe "#{KnapsackPro::Runners::Queue::RSpecRunner} Fallback - Integration tests" do
+  def log(stdout, stderr, status)
+    puts '='*50
+    puts 'STDOUT:'
+    puts stdout
+    puts
+
+    puts '='*50
+    puts 'STDERR:'
+    puts stderr
+    puts
+
+    puts '='*50
+    puts 'Exit status code:'
+    puts status
+    puts
+  end
+
+  subject do
+    stdout, stderr, status = Open3.capture3("ruby #{@task.path}")
+    log(stdout, stderr, status) if ENV['TEST__SHOW_DEBUG_LOG'] == 'true'
+    OpenStruct.new(stdout: stdout, stderr: stderr, exit_code: status.exitstatus)
+  end
+
+  before(:each) do
+    ENV['KNAPSACK_PRO_ENDPOINT'] = 'https://fail.knapsackpro.com' # ensure the API is not reachable
+    ENV['KNAPSACK_PRO_MAX_REQUEST_RETRIES'] = '1' # only try once to reach the API
+  end
+
+  around(:each) do |example|
+    Tempfile.create do |file|
+      file.write(<<~CONTENT)
+        require 'knapsack_pro'
+
+        ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC'] = SecureRandom.hex
+        ENV['KNAPSACK_PRO_CI_NODE_BUILD_ID'] = SecureRandom.uuid
+
+        #{KnapsackPro::Runners::Queue::RSpecRunner}.run('')
+      CONTENT
+      file.rewind
+
+      @task = file
+      example.run
+    end
+  end
+
+  after(:each) do
+    ENV.delete('KNAPSACK_PRO_ENDPOINT')
+    ENV.delete('KNAPSACK_PRO_MAX_REQUEST_RETRIES')
+  end
+
+  context 'with fallback mode disabled' do
+    before(:each) do
+      ENV['KNAPSACK_PRO_FALLBACK_MODE_ENABLED'] = 'false'
+    end
+
+    after(:each) do
+      ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ENABLED')
+    end
+
+    it 'exits with 1 and logs error and summary' do
+      actual = subject
+
+      expect(actual.exit_code).to eq 1
+
+      expect(actual.stdout).to include('ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false')
+      expect(actual.stdout).to include(/Finished in .* seconds \(files took .* seconds to load\)/)
+      expect(actual.stdout).to include('0 examples, 0 failures')
+    end
+
+    context 'with a user defined exit code' do
+      before do
+        ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE'] = '123'
+      end
+
+      after do
+        ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE')
+      end
+
+      it 'exits with the passed exit code and logs error and summary' do
+        actual = subject
+
+        expect(actual.exit_code).to eq 123
+
+        expect(actual.stdout).to include('ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false')
+        expect(actual.stdout).to include(/Finished in .* seconds \(files took .* seconds to load\)/)
+        expect(actual.stdout).to include('0 examples, 0 failures')
+      end
+    end
+  end
+
+  context 'with fallback mode enabled and positive node retry count' do
+    before(:each) do
+      ENV['KNAPSACK_PRO_FALLBACK_MODE_ENABLED'] = 'true'
+      ENV['KNAPSACK_PRO_CI_NODE_RETRY_COUNT'] = '1'
+    end
+
+    after(:each) do
+      ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ENABLED')
+      ENV.delete('KNAPSACK_PRO_CI_NODE_RETRY_COUNT')
+    end
+
+    it 'exits with 1 and logs error and summary' do
+      actual = subject
+
+      expect(actual.exit_code).to eq 1
+
+      expect(actual.stdout).to include('ERROR -- : [knapsack_pro] knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+      expect(actual.stdout).to include(/Finished in .* seconds \(files took .* seconds to load\)/)
+      expect(actual.stdout).to include('0 examples, 0 failures')
+    end
+
+    context 'with a user defined exit code' do
+      before do
+        ENV['KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE'] = '123'
+      end
+
+      after do
+        ENV.delete('KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE')
+      end
+
+      it 'exits with the passed exit code and logs error and summary' do
+        actual = subject
+
+        expect(actual.exit_code).to eq 123
+
+        expect(actual.stdout).to include('ERROR -- : [knapsack_pro] knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+        expect(actual.stdout).to include(/Finished in .* seconds \(files took .* seconds to load\)/)
+        expect(actual.stdout).to include('0 examples, 0 failures')
+      end
+    end
+  end
+end

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -53,9 +53,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
     ENV['TEST__TEST_FILE_CASES_FOR_SLOW_TEST_FILES'] = test_file_paths.to_json
   end
 
-  def log_command_result(stdout, stderr, status)
-    return if ENV['TEST__SHOW_DEBUG_LOG'] != 'true'
-
+  def log(stdout, stderr, status)
     puts '='*50
     puts 'STDOUT:'
     puts stdout
@@ -83,7 +81,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
   subject do
     stdout, stderr, status = Open3.capture3(command)
-    log_command_result(stdout, stderr, status)
+    log(stdout, stderr, status) if ENV['TEST__SHOW_DEBUG_LOG'] == 'true'
     OpenStruct.new(stdout: stdout, stderr: stderr, exit_code: status.exitstatus)
   end
 

--- a/spec/knapsack_pro/allocator_spec.rb
+++ b/spec/knapsack_pro/allocator_spec.rb
@@ -23,43 +23,63 @@ describe KnapsackPro::Allocator do
 
     shared_examples_for 'when connection to API failed (fallback mode)' do
       context 'when fallback mode is disabled' do
-        before do
+        before(:each) do
           expect(KnapsackPro::Config::Env).to receive(:fallback_mode_enabled?).and_return(false)
         end
 
-        it do
-          expect { subject }.to raise_error(RuntimeError, 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-false')
+        it 'logs the error and exits' do
+          logger = instance_double(Logger)
+          allow(KnapsackPro).to receive(:logger).and_return(logger)
+          expect(logger).to receive(:error).with(
+            'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-false'
+          )
+
+          expect { subject }.to raise_error(SystemExit)
         end
       end
 
       context 'when CI node retry count > 0' do
-        before do
+        before(:each) do
           expect(KnapsackPro::Config::Env).to receive(:ci_node_retry_count).and_return(1)
         end
 
         context 'when fixed_test_suite_split=true' do
-          before do
+          before(:each) do
             expect(KnapsackPro::Config::Env).to receive(:fixed_test_suite_split).and_return(true)
           end
 
-          it do
-            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+          it 'logs the error and exits' do
+            logger = instance_double(Logger)
+            allow(KnapsackPro).to receive(:logger).and_return(logger)
+
+            expect(logger).to receive(:error).with(
+              'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count'
+            )
+
+            expect { subject }.to raise_error(SystemExit)
           end
         end
 
         context 'when fixed_test_suite_split=false' do
-          before do
+          before(:each) do
             expect(KnapsackPro::Config::Env).to receive(:fixed_test_suite_split).and_return(false)
           end
 
-          it do
-            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://knapsackpro.com/perma/ruby/fixed-test-suite-split')
+          it 'logs the error and exits' do
+            logger = instance_double(Logger)
+            allow(KnapsackPro).to receive(:logger).and_return(logger)
+
+            expect(logger).to receive(:error).with(
+              'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count Please ensure you have set KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://knapsackpro.com/perma/ruby/fixed-test-suite-split'
+            )
+
+            expect { subject }.to raise_error(SystemExit)
           end
         end
       end
 
       context 'when fallback mode started' do
-        before do
+        before(:each) do
           test_flat_distributor = instance_double(KnapsackPro::TestFlatDistributor)
           expect(KnapsackPro::TestFlatDistributor).to receive(:new).with(fallback_mode_test_files, ci_node_total).and_return(test_flat_distributor)
           expect(test_flat_distributor).to receive(:test_files_for_node).with(ci_node_index).and_return([
@@ -72,7 +92,7 @@ describe KnapsackPro::Allocator do
       end
     end
 
-    before do
+    before(:each) do
       encrypted_branch = double
       expect(KnapsackPro::Crypto::BranchEncryptor).to receive(:call).with(repository_adapter.branch).and_return(encrypted_branch)
 
@@ -118,7 +138,7 @@ describe KnapsackPro::Allocator do
             }
           end
 
-          before do
+          before(:each) do
             expect(KnapsackPro::Crypto::Decryptor).to receive(:call).with(fast_and_slow_test_files_to_run, response['test_files']).and_call_original
           end
 
@@ -131,7 +151,7 @@ describe KnapsackPro::Allocator do
           end
           let(:api_code) { 'TEST_SUITE_SPLIT_CACHE_MISS' }
 
-          before do
+          before(:each) do
             encrypted_branch = double
             expect(KnapsackPro::Crypto::BranchEncryptor).to receive(:call).with(repository_adapter.branch).and_return(encrypted_branch)
 
@@ -183,7 +203,7 @@ describe KnapsackPro::Allocator do
                   }
                 end
 
-                before do
+                before(:each) do
                   expect(KnapsackPro::Crypto::Decryptor).to receive(:call).with(fast_and_slow_test_files_to_run, response2['test_files']).and_call_original
                 end
 

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -1016,9 +1016,8 @@ describe KnapsackPro::Config::Env do
   describe '.rspec_split_by_test_examples?' do
     subject { described_class.rspec_split_by_test_examples? }
 
-    before do
+    after(:each) do
       described_class.remove_instance_variable(:@rspec_split_by_test_examples)
-    rescue NameError
     end
 
     context 'when KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true AND KNAPSACK_PRO_CI_NODE_TOTAL >= 2' do

--- a/spec/knapsack_pro/queue_allocator_spec.rb
+++ b/spec/knapsack_pro/queue_allocator_spec.rb
@@ -31,7 +31,7 @@ describe KnapsackPro::QueueAllocator do
         end
 
         it do
-          expect { subject }.to raise_error(RuntimeError, 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false')
+          expect { subject }.to raise_error(KnapsackPro::QueueAllocator::FallbackModeError, 'Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false')
         end
       end
 
@@ -46,7 +46,7 @@ describe KnapsackPro::QueueAllocator do
           end
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
+            expect { subject }.to raise_error(KnapsackPro::QueueAllocator::FallbackModeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count')
           end
         end
 
@@ -56,7 +56,7 @@ describe KnapsackPro::QueueAllocator do
           end
 
           it do
-            expect { subject }.to raise_error(RuntimeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count Please ensure you have set KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://knapsackpro.com/perma/ruby/fixed-queue-split')
+            expect { subject }.to raise_error(KnapsackPro::QueueAllocator::FallbackModeError, 'knapsack_pro gem could not connect to Knapsack Pro API and the Fallback Mode cannot be used this time. Running tests in Fallback Mode are not allowed for retried parallel CI node to avoid running the wrong set of tests. Please manually retry this parallel job on your CI server then knapsack_pro gem will try to connect to Knapsack Pro API again and will run a correct set of tests for this CI node. Learn more https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-true-and-positive-retry-count Please ensure you have set KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true to allow Knapsack Pro API remember the recorded CI node tests so when you retry failed tests on the CI node then the same set of tests will be executed. See more https://knapsackpro.com/perma/ruby/fixed-queue-split')
           end
         end
       end

--- a/spec/knapsack_pro/runners/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/rspec_runner_spec.rb
@@ -3,8 +3,6 @@ require 'rspec/core/rake_task'
 describe KnapsackPro::Runners::RSpecRunner do
   subject { described_class.new(KnapsackPro::Adapters::RSpecAdapter) }
 
-  it { should be_kind_of KnapsackPro::Runners::BaseRunner }
-
   describe '.run' do
     let(:args) { '--profile --color' }
 

--- a/spec/knapsack_pro/runners/rspec_runner_spec.rb
+++ b/spec/knapsack_pro/runners/rspec_runner_spec.rb
@@ -3,6 +3,8 @@ require 'rspec/core/rake_task'
 describe KnapsackPro::Runners::RSpecRunner do
   subject { described_class.new(KnapsackPro::Adapters::RSpecAdapter) }
 
+  it { should be_kind_of KnapsackPro::Runners::BaseRunner }
+
   describe '.run' do
     let(:args) { '--profile --color' }
 


### PR DESCRIPTION
# Story

https://trello.com/c/GCRO05YP/513-custom-exit-code-when-cannot-connect-to-the-api-and-fallback-mode-is-disabled

# Description

Allow users to set a custom error exit code (`KNAPSACK_PRO_FALLBACK_MODE_ERROR_EXIT_CODE`) whenever Knapsack Pro fails because Fallback Mode cannot be used.

Since we are catching the error, we don't print the backtraces anymore. This is a plus as you'd expect those only in case of an unhandled error. See below for the actual differences.

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.

# Comparison before/after

I run locally Knapsack Pro with:

```
  KNAPSACK_PRO_ENDPOINT=http://TODOapi.knapsackpro.test:3000 \
  KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
  KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false \
```

And additionally (to check the other failure path):

```
  KNAPSACK_PRO_FALLBACK_MODE_ENABLED=true \
  KNAPSACK_PRO_CI_NODE_RETRY_COUNT=1 \
```

## `bin/knapsack_pro_rspec; echo $?`

### after

```
W, [2024-11-08T16:40:34.478942 #90791]  WARN -- : [knapsack_pro] POST http://TODOapi.knapsackpro.test:3000/v1/build_distributions/subset
W, [2024-11-08T16:40:34.479047 #90791]  WARN -- : [knapsack_pro] Request failed due to:
W, [2024-11-08T16:40:34.479080 #90791]  WARN -- : [knapsack_pro] #<Errno::ECONNREFUSED: Failed to open TCP connection to TODOapi.knapsackpro.test:3000 (Connection refused - connect(2) for "TODOapi.knapsackpro.test" port 3000)>
E, [2024-11-08T16:40:34.479153 #90791] ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-false
1
```

### before

```
W, [2024-11-08T16:44:33.584195 #90992]  WARN -- : [knapsack_pro] POST http://TODOapi.knapsackpro.test:3000/v1/build_distributions/subset
W, [2024-11-08T16:44:33.584308 #90992]  WARN -- : [knapsack_pro] Request failed due to:
W, [2024-11-08T16:44:33.584334 #90992]  WARN -- : [knapsack_pro] #<Errno::ECONNREFUSED: Failed to open TCP connection to TODOapi.knapsackpro.test:3000 (Connection refused - connect(2) for "TODOapi.knapsackpro.test" port 3000)>
E, [2024-11-08T16:44:33.584396 #90992] ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-false
rake aborted!
Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/regular-mode-connection-error-with-fallback-enabled-false
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/allocator.rb:32:in `test_file_paths'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/base_runner.rb:16:in `test_file_paths'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/base_runner.rb:28:in `test_files_to_execute_exist?'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/rspec_runner.rb:16:in `run'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/tasks/rspec.rake:7:in `block (2 levels) in <top (required)>'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/bin/ruby_executable_hooks:22:in `eval'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/bin/ruby_executable_hooks:22:in `<main>'
Tasks: TOP => knapsack_pro:rspec
(See full trace by running task with --trace)
1
```

## `bin/knapsack_pro_queue_rspec; echo $?`

### after

```
I, [2024-11-08T16:40:55.104101 #90819]  INFO -- : [knapsack_pro] KNAPSACK_PRO_FIXED_QUEUE_SPLIT is not set. Using default value: true. Learn more at https://knapsackpro.com/perma/ruby/fixed-queue-split
W, [2024-11-08T16:40:55.109043 #90819]  WARN -- : [knapsack_pro] POST http://TODOapi.knapsackpro.test:3000/v1/queues/queue
W, [2024-11-08T16:40:55.109099 #90819]  WARN -- : [knapsack_pro] Request failed due to:
W, [2024-11-08T16:40:55.109132 #90819]  WARN -- : [knapsack_pro] #<Errno::ECONNREFUSED: Failed to open TCP connection to TODOapi.knapsackpro.test:3000 (Connection refused - connect(2) for "TODOapi.knapsackpro.test" port 3000)>
E, [2024-11-08T16:40:55.109230 #90819] ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false

Finished in 0.08829 seconds (files took 2.85 seconds to load)
0 examples, 0 failures

1
```

It's a bit unfortunate that we print the summary as it seems nothing went wrong. But I think it's not *that* bad.

### before

```
I, [2024-11-08T16:44:55.087071 #91021]  INFO -- : [knapsack_pro] KNAPSACK_PRO_FIXED_QUEUE_SPLIT is not set. Using default value: true. Learn more at https://knapsackpro.com/perma/ruby/fixed-queue-split
W, [2024-11-08T16:44:55.091751 #91021]  WARN -- : [knapsack_pro] POST http://TODOapi.knapsackpro.test:3000/v1/queues/queue
W, [2024-11-08T16:44:55.091798 #91021]  WARN -- : [knapsack_pro] Request failed due to:
W, [2024-11-08T16:44:55.091821 #91021]  WARN -- : [knapsack_pro] #<Errno::ECONNREFUSED: Failed to open TCP connection to TODOapi.knapsackpro.test:3000 (Connection refused - connect(2) for "TODOapi.knapsackpro.test" port 3000)>
E, [2024-11-08T16:44:55.091895 #91021] ERROR -- : [knapsack_pro] Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false

Finished in 0.08774 seconds (files took 2.71 seconds to load)
0 examples, 0 failures

E, [2024-11-08T16:44:55.094315 #91021] ERROR -- : [knapsack_pro] An unexpected exception happened. RSpec cannot handle it. The exception: #<RuntimeError: Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false>
E, [2024-11-08T16:44:55.094358 #91021] ERROR -- : [knapsack_pro] Exception message: Fallback Mode was disabled with KNAPSACK_PRO_FALLBACK_MODE_ENABLED=false. Please restart this CI node to retry tests. Most likely Fallback Mode was disabled due to https://knapsackpro.com/perma/ruby/queue-mode-connection-error-with-fallback-enabled-false
E, [2024-11-08T16:44:55.094463 #91021] ERROR -- : [knapsack_pro] Exception backtrace: /Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/queue_allocator.rb:34:in `test_file_paths'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/base_runner.rb:29:in `test_file_paths'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:153:in `pull_tests_from_queue'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:78:in `block in with_batch'
<internal:kernel>:187:in `loop'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:76:in `with_batch'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/extensions/rspec_extension.rb:93:in `block (2 levels) in knapsack__run_specs'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:2091:in `with_suite_hooks'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/extensions/rspec_extension.rb:92:in `block in knapsack__run_specs'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rspec-core-3.13.0/lib/rspec/core/reporter.rb:74:in `report'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/extensions/rspec_extension.rb:91:in `knapsack__run_specs'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:54:in `run'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:20:in `run'
/Users/riccardoodone/code/knapsack/knapsack_pro-ruby/lib/tasks/queue/rspec.rake:12:in `block (3 levels) in <top (required)>'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/task.rb:279:in `block in execute'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/task.rb:279:in `each'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/task.rb:279:in `execute'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/task.rb:199:in `synchronize'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/task.rb:199:in `invoke_with_call_chain'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/task.rb:188:in `invoke'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/application.rb:188:in `invoke_task'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/application.rb:138:in `block (2 levels) in top_level'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/application.rb:138:in `each'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/application.rb:138:in `block in top_level'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/application.rb:147:in `run_with_threads'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/application.rb:132:in `top_level'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/application.rb:83:in `block in run'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/application.rb:214:in `standard_exception_handling'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/lib/rake/application.rb:80:in `run'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/bin/rake:25:in `load'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/bin/rake:25:in `<main>'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/bin/ruby_executable_hooks:22:in `eval'
/Users/riccardoodone/.rvm/gems/ruby-3.3.5/bin/ruby_executable_hooks:22:in `<main>'

1
```
