### PR TITLE
Fix handling signals for non-RSpec test runners

### DIFF
--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -59,10 +59,13 @@ module KnapsackPro
             Signal.trap(signal) {
               puts "#{signal} signal has been received. Terminating Knapsack Pro..."
               @@terminate_process = true
-              RSpec.world.wants_to_quit = true
+              post_trap_signals
               log_threads
             }
           end
+        end
+
+        def post_trap_signals
         end
 
         def log_threads

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -117,6 +117,10 @@ module KnapsackPro
 
         private
 
+        def post_trap_signals
+          RSpec.world.wants_to_quit = true
+        end
+
         def pre_run_setup
           ENV['KNAPSACK_PRO_QUEUE_RECORDING_ENABLED'] = 'true'
           ENV['KNAPSACK_PRO_QUEUE_ID'] = KnapsackPro::Config::EnvGenerator.set_queue_id


### PR DESCRIPTION
# Story

N/A

# Description

Fix handling signals for non-RSpec test runners.

# Changes

* fix(bug): we should set RSpec wants to quite value in the RSpec only. Remove it from the queue base runner which breaks handling signals for non RSpec test runners.

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
