### PR TITLE
Improve debugging for hanging CI node. Show hanging spec files in the RSpec output and a command to reproduce the current batch of tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 7.14.0
 
-* Improve debugging for hanging CI node. Show hanging spec files in the RSpec output and a command to reproduce the current batch of tests.
+* Improve debugging for hanging CI nodes: show hanging spec files in the RSpec output and a command to reproduce the current batch of tests.
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/287
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 7.14.0
+
+* Improve debugging for hanging CI node. Show hanging spec files in the RSpec output and a command to reproduce the current batch of tests.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/287
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v7.13.1...v7.14.0
+
 ### 7.13.1
 
 * Fix handling signals for non-RSpec test runners

--- a/lib/knapsack_pro/extensions/rspec_extension.rb
+++ b/lib/knapsack_pro/extensions/rspec_extension.rb
@@ -13,15 +13,6 @@ module KnapsackPro
         RSpec::Core::Configuration.prepend(Configuration)
       end
 
-      # Based on:
-      # https://github.com/rspec/rspec/blob/5946b3c9aa61279bf52363bfde4d850810daaa3a/rspec-core/lib/rspec/core/notifications.rb#L283
-      def self.print_seed(seed)
-        puts '+'*50
-        puts seed.inspect
-        return unless seed.used?
-        puts "\nRandomized with seed #{seed.value}\n"
-      end
-
       module World
         # Based on:
         # https://github.com/rspec/rspec-core/blob/f8c8880dabd8f0544a6f91d8d4c857c1bd8df903/lib/rspec/core/world.rb#L171

--- a/lib/knapsack_pro/extensions/rspec_extension.rb
+++ b/lib/knapsack_pro/extensions/rspec_extension.rb
@@ -13,6 +13,15 @@ module KnapsackPro
         RSpec::Core::Configuration.prepend(Configuration)
       end
 
+      # Based on:
+      # https://github.com/rspec/rspec/blob/5946b3c9aa61279bf52363bfde4d850810daaa3a/rspec-core/lib/rspec/core/notifications.rb#L283
+      def self.print_seed(seed)
+        puts '+'*50
+        puts seed.inspect
+        return unless seed.used?
+        puts "\nRandomized with seed #{seed.value}\n"
+      end
+
       module World
         # Based on:
         # https://github.com/rspec/rspec-core/blob/f8c8880dabd8f0544a6f91d8d4c857c1bd8df903/lib/rspec/core/world.rb#L171

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -77,6 +77,8 @@ module KnapsackPro
           puts 'Use the following backtrace(s) to find the line of code that got stuck if the CI node hung and terminated your tests.'
           puts 'How to read the backtrace: https://knapsackpro.com/perma/ruby/backtrace-debugging'
 
+          post_log_threads(threads)
+
           threads.each do |thread|
             puts
             if thread == Thread.main
@@ -94,6 +96,9 @@ module KnapsackPro
           puts '=' * 80
 
           $stdout.flush
+        end
+
+        def post_log_threads
         end
       end
     end

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -98,7 +98,8 @@ module KnapsackPro
           $stdout.flush
         end
 
-        def post_log_threads
+        def post_log_threads(threads)
+          # implement in a child class if you need to log more info
         end
       end
     end

--- a/lib/knapsack_pro/runners/queue/base_runner.rb
+++ b/lib/knapsack_pro/runners/queue/base_runner.rb
@@ -77,7 +77,7 @@ module KnapsackPro
           puts 'Use the following backtrace(s) to find the line of code that got stuck if the CI node hung and terminated your tests.'
           puts 'How to read the backtrace: https://knapsackpro.com/perma/ruby/backtrace-debugging'
 
-          post_log_threads(threads)
+          log_current_tests(threads)
 
           threads.each do |thread|
             puts
@@ -98,7 +98,7 @@ module KnapsackPro
           $stdout.flush
         end
 
-        def post_log_threads(threads)
+        def log_current_tests(threads)
           # implement in a child class if you need to log more info
         end
       end

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -120,7 +120,7 @@ module KnapsackPro
         def post_trap_signals
           RSpec.world.wants_to_quit = true
 
-          print_current_batch_rspec_command
+          log_current_batch_rspec_command
         end
 
         def log_current_tests(threads)
@@ -186,7 +186,7 @@ module KnapsackPro
           test_file_paths
         end
 
-        def print_current_batch_rspec_command
+        def log_current_batch_rspec_command
           test_file_paths = @queue.current_batch&.test_file_paths
           return unless test_file_paths
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -123,7 +123,7 @@ module KnapsackPro
           print_current_rspec_batch_command
         end
 
-        def post_log_threads(threads)
+        def log_current_tests(threads)
           threads.each do |thread|
             next unless thread.backtrace
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -132,10 +132,10 @@ module KnapsackPro
 
             puts
             if thread == Thread.main
-              puts "Hanging specs in the main thread:"
+              puts "Running specs in the main thread:"
             else
               puts "Non-main thread inspect: #{thread.inspect}"
-              puts "Hanging specs in non-main thread:"
+              puts "Running specs in non-main thread:"
             end
             puts spec_file_lines.join("\n")
             puts

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -128,18 +128,17 @@ module KnapsackPro
             next unless thread.backtrace
 
             spec_file_lines = thread.backtrace.select { |line| line.include?('_spec.rb') }
+            next if spec_file_lines.empty?
 
-            unless spec_file_lines.empty?
-              puts
-              if thread == Thread.main
-                puts "Hanging specs in the main thread:"
-              else
-                puts "Non-main thread inspect: #{thread.inspect}"
-                puts "Hanging specs in non-main thread:"
-              end
-              puts spec_file_lines.join("\n")
-              puts
+            puts
+            if thread == Thread.main
+              puts "Hanging specs in the main thread:"
+            else
+              puts "Non-main thread inspect: #{thread.inspect}"
+              puts "Hanging specs in non-main thread:"
             end
+            puts spec_file_lines.join("\n")
+            puts
           end
         end
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -120,7 +120,7 @@ module KnapsackPro
         def post_trap_signals
           RSpec.world.wants_to_quit = true
 
-          print_current_rspec_batch_command
+          print_current_batch_rspec_command
         end
 
         def log_current_tests(threads)
@@ -186,7 +186,7 @@ module KnapsackPro
           test_file_paths
         end
 
-        def print_current_rspec_batch_command
+        def print_current_batch_rspec_command
           test_file_paths = @queue.current_batch&.test_file_paths
           return unless test_file_paths
 

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -121,6 +121,26 @@ module KnapsackPro
           RSpec.world.wants_to_quit = true
         end
 
+        def post_log_threads(threads)
+          threads.each do |thread|
+            next unless thread.backtrace
+
+            spec_file_lines = thread.backtrace.select { |line| line.include?('_spec.rb') }
+
+            unless spec_file_lines.empty?
+              puts
+              if thread == Thread.main
+                puts "Hanging specs in the main thread:"
+              else
+                puts "Non-main thread inspect: #{thread.inspect}"
+                puts "Hanging specs in non-main thread:"
+              end
+              puts spec_file_lines.join("\n")
+              puts
+            end
+          end
+        end
+
         def pre_run_setup
           ENV['KNAPSACK_PRO_QUEUE_RECORDING_ENABLED'] = 'true'
           ENV['KNAPSACK_PRO_QUEUE_ID'] = KnapsackPro::Config::EnvGenerator.set_queue_id

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -157,8 +157,6 @@ module KnapsackPro
           @rspec_runner.knapsack__setup(@stream_error, @stream_out)
 
           ensure_no_deprecated_run_all_when_everything_filtered_option!
-
-          KnapsackPro::Extensions::RSpecExtension.print_seed(@rspec_runner.knapsack__seed)
         end
 
         def post_run_tasks(exit_code)

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -157,6 +157,8 @@ module KnapsackPro
           @rspec_runner.knapsack__setup(@stream_error, @stream_out)
 
           ensure_no_deprecated_run_all_when_everything_filtered_option!
+
+          KnapsackPro::Extensions::RSpecExtension.print_seed(@rspec_runner.knapsack__seed)
         end
 
         def post_run_tasks(exit_code)

--- a/lib/knapsack_pro/runners/queue/rspec_runner.rb
+++ b/lib/knapsack_pro/runners/queue/rspec_runner.rb
@@ -119,6 +119,8 @@ module KnapsackPro
 
         def post_trap_signals
           RSpec.world.wants_to_quit = true
+
+          print_current_rspec_batch_command
         end
 
         def post_log_threads(threads)
@@ -183,6 +185,21 @@ module KnapsackPro
           )
           @node_test_file_paths += test_file_paths
           test_file_paths
+        end
+
+        def print_current_rspec_batch_command
+          test_file_paths = @queue.current_batch&.test_file_paths
+          return unless test_file_paths
+
+          puts
+          puts '=' * 80
+
+          order_option = @adapter_class.order_option(@cli_args)
+          printable_args = @rspec_pure.args_with_seed_option_added_when_viable(order_option, @rspec_runner.knapsack__seed, @cli_args)
+          messages = @rspec_pure.rspec_command(printable_args, test_file_paths, :batch_finished)
+          messages.each do |message|
+            puts message
+          end
         end
 
         def log_rspec_batch_command(test_file_paths)

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1405,10 +1405,13 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
 
       expect(actual.stdout).to include('Use the following backtrace(s) to find the line of code that got stuck if the CI node hung and terminated your tests.')
+      expect(actual.stdout).to include('Hanging specs in the main thread:')
+      expect(actual.stdout).to include('Hanging specs in non-main thread:')
       expect(actual.stdout).to include('Main thread backtrace:')
-      expect(actual.stdout).to match(/spec_integration\/b_spec\.rb:7:in .*kill/)
+      expect(actual.stdout.scan(/spec_integration\/b_spec\.rb:7:in .*kill/).size).to eq 2
+      expect(actual.stdout).to include('Hanging specs in the main thread:')
       expect(actual.stdout).to include('Non-main thread backtrace:')
-      expect(actual.stdout).to match(/spec_integration\/a_spec\.rb:6:in .*sleep/)
+      expect(actual.stdout.scan(/spec_integration\/a_spec\.rb:6:in .*sleep/).size).to eq 2
 
 
       expect(actual.exit_code).to eq 1

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -90,7 +90,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
     ENV['KNAPSACK_PRO_LOG_LEVEL'] = 'debug'
     # Useful when creating or editing a test:
-    # ENV['TEST__SHOW_DEBUG_LOG'] = 'true'
+     ENV['TEST__SHOW_DEBUG_LOG'] = 'true'
   end
   after do
     FileUtils.rm_rf(SPEC_DIRECTORY)
@@ -914,7 +914,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
       actual = subject
 
-      expect(actual.stdout).to include('Randomized with seed 123')
+      expect(actual.stdout.scan(/Randomized with seed 123/).size).to eq 2
 
       # 1st batch
       expect(actual.stdout).to include('INFO -- : [knapsack_pro] bundle exec rspec --order rand:123 --format progress --default-path spec_integration "spec_integration/a_spec.rb" "spec_integration/b_spec.rb"')

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1407,11 +1407,10 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       expect(actual.stdout).to include('bundle exec rspec --format documentation --default-path spec_integration "spec_integration/b_spec.rb" "spec_integration/c_spec.rb"')
 
       expect(actual.stdout).to include('Use the following backtrace(s) to find the line of code that got stuck if the CI node hung and terminated your tests.')
-      expect(actual.stdout).to include('Hanging specs in the main thread:')
-      expect(actual.stdout).to include('Hanging specs in non-main thread:')
+      expect(actual.stdout).to include('Running specs in the main thread:')
+      expect(actual.stdout).to include('Running specs in non-main thread:')
       expect(actual.stdout).to include('Main thread backtrace:')
       expect(actual.stdout.scan(/spec_integration\/b_spec\.rb:7:in .*kill/).size).to eq 2
-      expect(actual.stdout).to include('Hanging specs in the main thread:')
       expect(actual.stdout).to include('Non-main thread backtrace:')
       expect(actual.stdout.scan(/spec_integration\/a_spec\.rb:6:in .*sleep/).size).to eq 2
 

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1410,9 +1410,9 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
       expect(actual.stdout).to include('Running specs in the main thread:')
       expect(actual.stdout).to include('Running specs in non-main thread:')
       expect(actual.stdout).to include('Main thread backtrace:')
-      expect(actual.stdout).to match(/spec_integration\/b_spec\.rb:7:in .*kill/).twice
+      expect(actual.stdout.scan(/spec_integration\/b_spec\.rb:7:in .*kill/).size).to eq 2
       expect(actual.stdout).to include('Non-main thread backtrace:')
-      expect(actual.stdout).to match(/spec_integration\/a_spec\.rb:6:in .*sleep/).twice
+      expect(actual.stdout.scan(/spec_integration\/a_spec\.rb:6:in .*sleep/).size).to eq 2
 
 
       expect(actual.exit_code).to eq 1

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -1403,6 +1403,8 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
         OUTPUT
       )
 
+      expect(actual.stdout).to include('To retry the last batch of tests fetched from the Queue API, please run the following command on your machine:')
+      expect(actual.stdout).to include('bundle exec rspec --format documentation --default-path spec_integration "spec_integration/b_spec.rb" "spec_integration/c_spec.rb"')
 
       expect(actual.stdout).to include('Use the following backtrace(s) to find the line of code that got stuck if the CI node hung and terminated your tests.')
       expect(actual.stdout).to include('Hanging specs in the main thread:')

--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -90,7 +90,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
     ENV['KNAPSACK_PRO_LOG_LEVEL'] = 'debug'
     # Useful when creating or editing a test:
-     ENV['TEST__SHOW_DEBUG_LOG'] = 'true'
+    # ENV['TEST__SHOW_DEBUG_LOG'] = 'true'
   end
   after do
     FileUtils.rm_rf(SPEC_DIRECTORY)
@@ -914,7 +914,7 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
       actual = subject
 
-      expect(actual.stdout.scan(/Randomized with seed 123/).size).to eq 2
+      expect(actual.stdout).to include('Randomized with seed 123')
 
       # 1st batch
       expect(actual.stdout).to include('INFO -- : [knapsack_pro] bundle exec rspec --order rand:123 --format progress --default-path spec_integration "spec_integration/a_spec.rb" "spec_integration/b_spec.rb"')


### PR DESCRIPTION
# Story

https://trello.com/c/xvarNSRi

## Related

Issue:

* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/285

Related PR:

* https://github.com/KnapsackPro/docs.knapsackpro.com/pull/229

# Description

Improve debugging for hanging CI node. 

* Show hanging spec files in the RSpec output.
* Show a command to reproduce the current batch of tests. It includes seed if the RSpec tests were running in random order.

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
