### PR TITLE
Detect Turnip id paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 8.0.1
+
+* Fix detection of id paths for Turnip, which resulted in sending to the API both file and id paths timings
+    * Example:
+      * turnip/acceptance/foo.feature[1:1:1] 0 seconds
+      * turnip/acceptance/foo.feature[1:1:2] 0 seconds
+      * turnip/acceptance/foo.feature 30 milliseconds (time recorded for [1:1:1] or [1:1:2])
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/290
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v8.0.0...v8.0.1
+
 ### 8.0.0
 
 * Enable [`KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES`](https://docs.knapsackpro.com/ruby/split-by-test-examples/) by default

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -6,7 +6,8 @@ module KnapsackPro
   module Adapters
     class RSpecAdapter < BaseAdapter
       TEST_DIR_PATTERN = 'spec/**{,/*/**}/*_spec.rb'
-      ID_PATH_REGEX = /.+_spec\.rb\[.+\]$/
+      # https://github.com/rspec/rspec/blob/86b5e4218eece4c1913fe9aad24c0a96d8bc9f40/rspec-core/lib/rspec/core/example.rb#L122
+      REGEX = /^(.*?)(?:\[([\d\s:,]+)\])?$/.freeze
 
       def self.split_by_test_cases_enabled?
         return false unless KnapsackPro::Config::Env.rspec_split_by_test_examples?
@@ -81,7 +82,8 @@ module KnapsackPro
       end
 
       def self.id_path?(path)
-        ID_PATH_REGEX.match?(path)
+        _file, id = path.match(REGEX).captures
+        !id.nil?
       end
 
       def self.rails_helper_exists?(test_dir)

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -148,20 +148,38 @@ describe KnapsackPro::Adapters::RSpecAdapter do
   describe '.id_path?' do
     subject { described_class.id_path?(path) }
 
-    context 'when the path resembles the RSpec path with id' do
+    context 'when the path is an RSpec path with id' do
       let(:path) { 'spec/features/a_spec.rb[1:1:7:1]' }
 
       it { is_expected.to be true }
     end
 
-    context 'when the path resembles the RSpec path with multiple ids' do
+    context 'when the path is an RSpec path with multiple ids' do
       let(:path) { 'spec/features/a_spec.rb[1:1:7:1, 1:2]' }
 
       it { is_expected.to be true }
     end
 
-    context "when the path doesn't resemble the RSpec path with id" do
+    context 'when the path is an RSpec path with no id' do
       let(:path) { 'spec/features/a_spec.rb' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the path is a Turnip path with id' do
+      let(:path) { 'spec/acceptance/a.feature[1:1:7:1]' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the path is a Turnip path with multiple ids' do
+      let(:path) { 'spec/acceptance/a.feature[1:1:7:1,1:2]' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the path is a Turnip path with no id' do
+      let(:path) { 'spec/acceptance/a.feature' }
 
       it { is_expected.to be false }
     end


### PR DESCRIPTION
# Story

https://trello.com/c/RnkCLz1f/83-update-the-idpath-in-rspec-to-detect-turnips-id-paths

Result:
- https://staging.knapsackpro.com/dashboard/organizations/1/projects/55/test_suites/124/builds/0d9d5db2-7238-4dcc-99be-86d6ea877265#tab-test-files
- https://app.circleci.com/pipelines/github/KnapsackPro/knapsack_pro-ruby/1709/workflows/da07c790-6194-4fdc-b6c8-02afcc7b3974/jobs/28293

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
