### PR TITLE
RSpec: Use the same regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Unreleased (patch)
+
+* Use the same regex when parsing file path and id path
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/291
+
 ### 8.0.1
 
 * Fix detection of id paths for Turnip, which resulted in sending to the API both file and id paths timings

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -7,7 +7,7 @@ module KnapsackPro
     class RSpecAdapter < BaseAdapter
       TEST_DIR_PATTERN = 'spec/**{,/*/**}/*_spec.rb'
       # https://github.com/rspec/rspec/blob/86b5e4218eece4c1913fe9aad24c0a96d8bc9f40/rspec-core/lib/rspec/core/example.rb#L122
-      REGEX = /^(.*?)(?:\[([\d\s:,]+)\])?$/.freeze
+      REGEX = /\A(.*?)(?:\[([\d\s:,]+)\])?\z/.freeze
 
       def self.split_by_test_cases_enabled?
         return false unless KnapsackPro::Config::Env.rspec_split_by_test_examples?
@@ -76,9 +76,9 @@ module KnapsackPro
         return ''
       end
 
-      def self.parse_file_path(id)
-        # https://github.com/rspec/rspec-core/blob/1eeadce5aa7137ead054783c31ff35cbfe9d07cc/lib/rspec/core/example.rb#L122
-        id.match(/\A(.*?)(?:\[([\d\s:,]+)\])?\z/).captures.first
+      def self.parse_file_path(path)
+        file, _id = path.match(REGEX).captures
+        file
       end
 
       def self.id_path?(path)


### PR DESCRIPTION
# Description

In the [RSpec code](https://github.com/rspec/rspec/blob/86b5e4218eece4c1913fe9aad24c0a96d8bc9f40/rspec-core/lib/rspec/core/example.rb#L122), the regex is different than the one in the Rubular link.

Let's use the regex from the source code for both cases.

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
