### PR TITLE
Semaphore: Fix branch name and user seat detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 * (patch) Semaphore: Detect the correct branch name in the context of a PR
+* (patch) Semaphore: Detect user seat (committer)
 
 * (patch) RSpec: Use the same regex when parsing file path and id path
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-### Unreleased (patch)
+### Unreleased
 
-* Use the same regex when parsing file path and id path
+* (patch) Semaphore: Detect the correct branch name in the context of a PR
+
+* (patch) RSpec: Use the same regex when parsing file path and id path
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/291
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * (patch) Semaphore: Detect the correct branch name in the context of a PR
 * (patch) Semaphore: Detect user seat (committer)
 
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/294
+
 * (patch) RSpec: Use the same regex when parsing file path and id path
 
     https://github.com/KnapsackPro/knapsack_pro-ruby/pull/291

--- a/lib/knapsack_pro/config/ci/semaphore2.rb
+++ b/lib/knapsack_pro/config/ci/semaphore2.rb
@@ -34,7 +34,7 @@ module KnapsackPro
         end
 
         def user_seat
-          # not provided
+          ENV['SEMAPHORE_GIT_COMMITTER']
         end
 
         def detected

--- a/lib/knapsack_pro/config/ci/semaphore2.rb
+++ b/lib/knapsack_pro/config/ci/semaphore2.rb
@@ -23,7 +23,8 @@ module KnapsackPro
         end
 
         def branch
-          ENV['SEMAPHORE_GIT_BRANCH']
+          ENV['SEMAPHORE_GIT_WORKING_BRANCH'] || # nil when workflow is triggered by pushing a Git tag
+            ENV['SEMAPHORE_GIT_BRANCH']
         end
 
         def project_dir

--- a/spec/knapsack_pro/config/ci/semaphore2_spec.rb
+++ b/spec/knapsack_pro/config/ci/semaphore2_spec.rb
@@ -117,4 +117,17 @@ describe KnapsackPro::Config::CI::Semaphore2 do
       it { should be nil }
     end
   end
+
+  describe '#user_seat' do
+    subject { described_class.new.user_seat }
+
+    context 'when SEMAPHORE_GIT_COMMITTER is set' do
+      let(:env) { { 'SEMAPHORE_GIT_COMMITTER' => 'jane_doe' } }
+      it { should eql 'jane_doe' }
+    end
+
+    context "when no ENVs are set" do
+      it { should be nil }
+    end
+  end
 end

--- a/spec/knapsack_pro/config/ci/semaphore2_spec.rb
+++ b/spec/knapsack_pro/config/ci/semaphore2_spec.rb
@@ -62,12 +62,22 @@ describe KnapsackPro::Config::CI::Semaphore2 do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when the environment exists' do
+    context 'when SEMAPHORE_GIT_WORKING_BRANCH is set' do
+      let(:env) { { 'SEMAPHORE_GIT_WORKING_BRANCH' => 'feature' } }
+      it { should eql 'feature' }
+    end
+
+    context 'when both SEMAPHORE_GIT_WORKING_BRANCH and SEMAPHORE_GIT_BRANCH are set' do
+      let(:env) { { 'SEMAPHORE_GIT_WORKING_BRANCH' => 'feature', 'SEMAPHORE_GIT_BRANCH' => 'master' } }
+      it { should eql 'feature' }
+    end
+
+    context 'when SEMAPHORE_GIT_BRANCH is set' do
       let(:env) { { 'SEMAPHORE_GIT_BRANCH' => 'master' } }
       it { should eql 'master' }
     end
 
-    context "when the environment doesn't exist" do
+    context "when no ENVs are set" do
       it { should be nil }
     end
   end


### PR DESCRIPTION
# Story

https://trello.com/c/ov3beE5i/657-fix-commit-hash-branch-name-and-user-seat-detection-for-semaphore

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
