### PR TITLE
fix: let the user require the rake tasks

### DIFF
--- a/lib/tasks/queue/rspec.rake
+++ b/lib/tasks/queue/rspec.rake
@@ -9,6 +9,7 @@ namespace :knapsack_pro do
     end
 
     task :rspec_go, [:rspec_args] do |_, args|
+      Rake::Task.clear
       KnapsackPro::Runners::Queue::RSpecRunner.run(args[:rspec_args])
     end
   end


### PR DESCRIPTION
# Story

https://trello.com/c/Y4wzIYVr

# Description

fix: let the user require the rake tasks. The same way it's expected with vanilla RSpec or Regular Mode.

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
