### PR TITLE
Avoid needing a shell for rspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Unreleased
+
+* (patch) RSpec: allow tests to run in a distroless environment
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/296
+
 ### 8.1.0
 
 * Improve the performance of the [RSpec split by test examples](https://docs.knapsackpro.com/ruby/split-by-test-examples/).

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -25,12 +25,10 @@ module KnapsackPro
 
         # generate the RSpec JSON report in a separate process to not pollute the RSpec state
         cmd = [
-          'RACK_ENV=test',
-          'RAILS_ENV=test',
           KnapsackPro::Config::Env.rspec_test_example_detector_prefix,
-          'rake knapsack_pro:rspec_test_example_detector',
+          'rake knapsack_pro:rspec_test_example_detector'
         ].join(' ')
-        unless Kernel.system(cmd)
+        unless Kernel.system(ENV.to_h.merge({ 'RACK_ENV' => 'test', 'RAILS_ENV' => 'test' }), cmd)
           raise "Could not generate JSON report for RSpec. Rake task failed when running #{cmd}"
         end
 

--- a/lib/knapsack_pro/adapters/rspec_adapter.rb
+++ b/lib/knapsack_pro/adapters/rspec_adapter.rb
@@ -28,7 +28,7 @@ module KnapsackPro
           KnapsackPro::Config::Env.rspec_test_example_detector_prefix,
           'rake knapsack_pro:rspec_test_example_detector'
         ].join(' ')
-        unless Kernel.system(ENV.to_h.merge({ 'RACK_ENV' => 'test', 'RAILS_ENV' => 'test' }), cmd)
+        unless Kernel.system({ 'RACK_ENV' => 'test', 'RAILS_ENV' => 'test' }, cmd)
           raise "Could not generate JSON report for RSpec. Rake task failed when running #{cmd}"
         end
 

--- a/lib/knapsack_pro/runners/spinach_runner.rb
+++ b/lib/knapsack_pro/runners/spinach_runner.rb
@@ -15,9 +15,11 @@ module KnapsackPro
 
           KnapsackPro.tracker.set_prerun_tests(runner.test_file_paths)
 
-          cmd = %Q[KNAPSACK_PRO_REGULAR_MODE_ENABLED=true KNAPSACK_PRO_TEST_SUITE_TOKEN=#{ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN']} bundle exec spinach #{args} --features_path #{runner.test_dir} -- #{runner.stringify_test_file_paths}]
-
-          Kernel.system(cmd)
+          cmd = %Q[bundle exec spinach #{args} --features_path #{runner.test_dir} -- #{runner.stringify_test_file_paths}]
+          Kernel.system({
+            'KNAPSACK_PRO_REGULAR_MODE_ENABLED' => 'true',
+            'KNAPSACK_PRO_TEST_SUITE_TOKEN' => ENV['KNAPSACK_PRO_TEST_SUITE_TOKEN']
+          }, cmd)
           Kernel.exit(child_status.exitstatus) unless child_status.exitstatus.zero?
         end
       end

--- a/lib/tasks/queue/cucumber.rake
+++ b/lib/tasks/queue/cucumber.rake
@@ -5,7 +5,10 @@ require 'knapsack_pro'
 namespace :knapsack_pro do
   namespace :queue do
     task :cucumber, [:cucumber_args] do |_, args|
-      Kernel.exec("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:cucumber_go[#{args[:cucumber_args]}]'")
+      Kernel.exec(
+        { 'RAILS_ENV' => 'test', 'RACK_ENV' => 'test' },
+        "#{$PROGRAM_NAME} knapsack_pro:queue:cucumber_go[#{args[:cucumber_args]}]'"
+      )
     end
 
     task :cucumber_go, [:cucumber_args] do |_, args|

--- a/lib/tasks/queue/minitest.rake
+++ b/lib/tasks/queue/minitest.rake
@@ -5,7 +5,10 @@ require 'knapsack_pro'
 namespace :knapsack_pro do
   namespace :queue do
     task :minitest, [:minitest_args] do |_, args|
-      Kernel.exec("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:minitest_go[#{args[:minitest_args]}]'")
+      Kernel.exec(
+        { 'RAILS_ENV' => 'test', 'RACK_ENV' => 'test' },
+        "#{$PROGRAM_NAME} 'knapsack_pro:queue:minitest_go[#{args[:minitest_args]}]'"
+      )
     end
 
     task :minitest_go, [:minitest_args] do |_, args|

--- a/lib/tasks/queue/rspec.rake
+++ b/lib/tasks/queue/rspec.rake
@@ -5,7 +5,10 @@ require 'knapsack_pro'
 namespace :knapsack_pro do
   namespace :queue do
     task :rspec, [:rspec_args] do |_, args|
-      Kernel.exec("RAILS_ENV=test RACK_ENV=test #{$PROGRAM_NAME} 'knapsack_pro:queue:rspec_go[#{args[:rspec_args]}]'")
+      Kernel.exec(
+        { 'RAILS_ENV' => 'test', 'RACK_ENV' => 'test' },
+        "#{$PROGRAM_NAME} 'knapsack_pro:queue:rspec_go[#{args[:rspec_args]}]'"
+      )
     end
 
     task :rspec_go, [:rspec_args] do |_, args|

--- a/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack_pro/adapters/rspec_adapter_spec.rb
@@ -62,8 +62,9 @@ describe KnapsackPro::Adapters::RSpecAdapter do
       expect(KnapsackPro).to receive(:logger).and_return(logger)
       expect(logger).to receive(:info).with("Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual test cases). Thanks to that, a single slow test file can be split across parallel CI nodes. Analyzing 5 slow test files.")
 
-      cmd = 'RACK_ENV=test RAILS_ENV=test bundle exec rake knapsack_pro:rspec_test_example_detector'
-      expect(Kernel).to receive(:system).with(cmd).and_return(cmd_result)
+      cmd = 'bundle exec rake knapsack_pro:rspec_test_example_detector'
+      env = { 'RACK_ENV' => 'test', 'RAILS_ENV' => 'test' }
+      expect(Kernel).to receive(:system).with(env, cmd).and_return(cmd_result)
     end
 
     context 'when the rake task to detect RSpec test examples succeeded' do
@@ -84,7 +85,7 @@ describe KnapsackPro::Adapters::RSpecAdapter do
       let(:cmd_result) { false }
 
       it do
-        expect { subject }.to raise_error(RuntimeError, 'Could not generate JSON report for RSpec. Rake task failed when running RACK_ENV=test RAILS_ENV=test bundle exec rake knapsack_pro:rspec_test_example_detector')
+        expect { subject }.to raise_error(RuntimeError, 'Could not generate JSON report for RSpec. Rake task failed when running bundle exec rake knapsack_pro:rspec_test_example_detector')
       end
     end
   end

--- a/spec/knapsack_pro/runners/spinach_runner_spec.rb
+++ b/spec/knapsack_pro/runners/spinach_runner_spec.rb
@@ -37,7 +37,10 @@ describe KnapsackPro::Runners::SpinachRunner do
         expect(KnapsackPro).to receive(:tracker).and_return(tracker)
         expect(tracker).to receive(:set_prerun_tests).with(test_file_paths)
 
-        expect(Kernel).to receive(:system).with('KNAPSACK_PRO_REGULAR_MODE_ENABLED=true KNAPSACK_PRO_TEST_SUITE_TOKEN=spinach-token bundle exec spinach --custom-arg --features_path fake-test-dir -- features/a.feature features/b.feature')
+        expect(Kernel).to receive(:system).with(
+          { "KNAPSACK_PRO_REGULAR_MODE_ENABLED" => "true", "KNAPSACK_PRO_TEST_SUITE_TOKEN" => "spinach-token" },
+          'bundle exec spinach --custom-arg --features_path fake-test-dir -- features/a.feature features/b.feature'
+        )
 
         allow(described_class).to receive(:child_status).and_return(child_status)
       end


### PR DESCRIPTION
# Story

We're migrating some services to distroless and generally prefer to run tests in the final built image but Knapsack requires a shell for this one method. I've monkeypatched my way around it in my repos but thought it's a simple change that others may benefit from so here we are.

# Description

Rather than pass these envvars in the command, which forces `system()` to use a shell, we pass them as a hash in the first param. Now we can run knapsack in a container that lacks a shell.

# Changes

TODO: changes introduced by this PR

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
