### PR TITLE
Do not load Rake tasks on behalf of the user for RSpec and Minitest in Queue Mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,19 +446,19 @@ workflows:
           matrix:
             parameters:
               ruby: ["3.2", "3.3", "3.4"]
-              rspec: ["3.10.2", "3.11.0", "3.12.2"]
+              rspec: ["3.12.3", "3.13.3"]
       - e2e-regular-rspec:
           name: e2e-regular__ruby-<< matrix.ruby >>__rspec-<< matrix.rspec >>
           matrix:
             parameters:
               ruby: ["3.2", "3.3", "3.4"]
-              rspec: ["3.10.2", "3.11.0", "3.12.2"]
+              rspec: ["3.12.3", "3.13.3"]
       - e2e-queue-rspec:
           name: e2e-queue__ruby-<< matrix.ruby >>__rspec-<< matrix.rspec >>
           matrix:
             parameters:
               ruby: ["3.2", "3.3", "3.4"]
-              rspec: ["3.10.2", "3.11.0", "3.12.2"]
+              rspec: ["3.12.3", "3.13.3"]
       - e2e-regular-minitest:
           name: e2e-regular__ruby-<< matrix.ruby >>__minitest
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,27 +445,27 @@ workflows:
           name: integration__ruby-<< matrix.ruby >>__rspec-<< matrix.rspec >>
           matrix:
             parameters:
-              ruby: ["3.0", "3.1", "3.2", "3.3"]
+              ruby: ["3.2", "3.3", "3.4"]
               rspec: ["3.10.2", "3.11.0", "3.12.2"]
       - e2e-regular-rspec:
           name: e2e-regular__ruby-<< matrix.ruby >>__rspec-<< matrix.rspec >>
           matrix:
             parameters:
-              ruby: ["3.0", "3.1", "3.2", "3.3"]
+              ruby: ["3.2", "3.3", "3.4"]
               rspec: ["3.10.2", "3.11.0", "3.12.2"]
       - e2e-queue-rspec:
           name: e2e-queue__ruby-<< matrix.ruby >>__rspec-<< matrix.rspec >>
           matrix:
             parameters:
-              ruby: ["3.0", "3.1", "3.2", "3.3"]
+              ruby: ["3.2", "3.3", "3.4"]
               rspec: ["3.10.2", "3.11.0", "3.12.2"]
       - e2e-regular-minitest:
           name: e2e-regular__ruby-<< matrix.ruby >>__minitest
           matrix:
             parameters:
-              ruby: ["3.0", "3.1", "3.2", "3.3"]
+              ruby: ["3.2", "3.3", "3.4"]
       - e2e-queue-minitest:
           name: e2e-queue__ruby-<< matrix.ruby >>__minitest
           matrix:
             parameters:
-              ruby: ["3.0", "3.1", "3.2", "3.3"]
+              ruby: ["3.2", "3.3", "3.4"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+### 8.1.1
+
+* Do not load Rake tasks on behalf of the user for RSpec and Minitest in Queue Mode
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/297
+
+    Workarounds like [this one](https://docs.knapsackpro.com/ruby/troubleshooting/#rake-tasks-under-tests-are-run-more-than-once-in-queue-mode) are no more needed to test Rake tasks, you can now remove them and test Rake tasks like you would normally do:
+
+    RSpec:
+
+    ```ruby
+    before do
+      MY_APPLICATION_NAME::Application.load_tasks if Rake::Task.tasks.empty?
+    end
+
+    after do
+      Rake::Task[MY_TASK_NAME].reenable
+    end
+
+    it "tests the rake task" do
+      Rake::Task[MY_TASK_NAME].invoke
+      # ...
+    end
+    ```
+
+    Minitest:
+
+    ```ruby
+    setup do
+      MY_APPLICATION_NAME::Application.load_tasks if Rake::Task.tasks.empty?
+    end
+
+    teardown do
+      Rake::Task[MY_TASK_NAME].reenable
+    end
+
+    test "tests the rake task" do
+      Rake::Task[MY_TASK_NAME].invoke
+      # ...
+    end
+    ```
+
+    It's also ok to use `Rake.application.rake_require("tasks/MY_TASK")` instead of `MY_APPLICATION_NAME::Application.load_tasks if Rake::Task.tasks.empty?`.
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v8.1.0...v8.1.1
+
 ### 8.1.0
 
 * Improve the performance of the [RSpec split by test examples](https://docs.knapsackpro.com/ruby/split-by-test-examples/).

--- a/lib/tasks/queue/minitest.rake
+++ b/lib/tasks/queue/minitest.rake
@@ -9,6 +9,7 @@ namespace :knapsack_pro do
     end
 
     task :minitest_go, [:minitest_args] do |_, args|
+      Rake::Task.clear
       KnapsackPro::Runners::Queue::MinitestRunner.run(args[:minitest_args])
     end
   end

--- a/lib/tasks/queue/rspec.rake
+++ b/lib/tasks/queue/rspec.rake
@@ -9,6 +9,7 @@ namespace :knapsack_pro do
     end
 
     task :rspec_go, [:rspec_args] do |_, args|
+      Rake::Task.clear
       KnapsackPro::Runners::Queue::RSpecRunner.run(args[:rspec_args])
     end
   end


### PR DESCRIPTION
# Story

https://trello.com/c/Y4wzIYVr

# Description

We want Knapsack Pro not to modify the behaviour of the underlying test runner, so that users don't have to modify their test to use Knapsack Pro.

When people run RSpec (`bin/rspec` or `bundle exec rspec`), Minitest (`bin/rails test` or `ruby -Ilib:test test/my_test.rb`), or Cucumber (`bin/cucumber` or `bundle exec cucumber`), to test rake tasks, they have to do something like `Rake.application.rake_require("tasks/my_task")`, `Rake.load_rakefile("tasks/my_task.rake")`, or `Rails.application.load_tasks`.

In Queue Mode, Knapsack Pro, given how it's run, loads tasks for RSpec and Minitest, so we have to clear them. In the long term, we should review the invocation chain so that we don't load tasks just to remove them.

Notice that Cucumber shells out with a `Kernel.system` passing it a command that does not load tasks, so we don't have to apply the same to that code path:

https://github.com/KnapsackPro/knapsack_pro-ruby/blob/c3b552e83cc0cbbe166fa04df3876c214f4742d5/lib/knapsack_pro/runners/queue/cucumber_runner.rb#L96-L101

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
