### PR TITLE
Use main instead of master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### UNRELEASED
+
+* (patch) Update `changelog_uri` in gemspec
+
 ### 8.1.2
 
 * Allow running RSpec with `--force-color` (and the default Split by Test Examples)

--- a/knapsack_pro.gemspec
+++ b/knapsack_pro.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.metadata    = {
     'bug_tracker_uri' => 'https://github.com/KnapsackPro/knapsack_pro-ruby/issues',
-    'changelog_uri' => 'https://github.com/KnapsackPro/knapsack_pro-ruby/blob/master/CHANGELOG.md',
+    'changelog_uri' => 'https://github.com/KnapsackPro/knapsack_pro-ruby/blob/main/CHANGELOG.md',
     'documentation_uri' => 'https://docs.knapsackpro.com/knapsack_pro-ruby/guide/',
     'homepage_uri' => 'https://knapsackpro.com',
     'source_code_uri' => 'https://github.com/KnapsackPro/knapsack_pro-ruby'

--- a/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/invalid_test_suite_token.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/invalid_test_suite_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.knapsackpro.test:3000/v1/build_distributions/subset
     body:
       encoding: UTF-8
-      string: '{"fixed_test_suite_split":true,"cache_read_attempt":true,"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
+      string: '{"fixed_test_suite_split":true,"cache_read_attempt":true,"commit_hash":"abcdefg","branch":"main","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
     headers:
       Content-Type:
       - application/json

--- a/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/success.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_distributions/subset/success.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.knapsackpro.test:3000/v1/build_distributions/subset
     body:
       encoding: UTF-8
-      string: '{"fixed_test_suite_split":true,"cache_read_attempt":true,"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
+      string: '{"fixed_test_suite_split":true,"cache_read_attempt":true,"commit_hash":"abcdefg","branch":"main","node_total":"2","node_index":"1","ci_build_id":"missing-build-id"}'
     headers:
       Content-Type:
       - application/json

--- a/spec/fixtures/vcr_cassettes/api/v1/build_subsets/create/invalid_test_suite_token.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_subsets/create/invalid_test_suite_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.knapsackpro.test:3000/v1/build_subsets
     body:
       encoding: UTF-8
-      string: '{"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb","time_execution":1.2},{"path":"b_spec.rb","time_execution":0.3}],"test_suite_token":"fake"}'
+      string: '{"commit_hash":"abcdefg","branch":"main","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb","time_execution":1.2},{"path":"b_spec.rb","time_execution":0.3}]}'
     headers:
       Content-Type:
       - application/json

--- a/spec/fixtures/vcr_cassettes/api/v1/build_subsets/create/success.yml
+++ b/spec/fixtures/vcr_cassettes/api/v1/build_subsets/create/success.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.knapsackpro.test:3000/v1/build_subsets
     body:
       encoding: UTF-8
-      string: '{"commit_hash":"abcdefg","branch":"master","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb","time_execution":1.2},{"path":"b_spec.rb","time_execution":0.3}],"test_suite_token":"3fa64859337f6e56409d49f865d13fd7"}'
+      string: '{"commit_hash":"abcdefg","branch":"main","node_total":"2","node_index":"1","test_files":[{"path":"a_spec.rb","time_execution":1.2},{"path":"b_spec.rb","time_execution":0.3}]}'
     headers:
       Content-Type:
       - application/json

--- a/spec/integration/api/build_distributions_subset_spec.rb
+++ b/spec/integration/api/build_distributions_subset_spec.rb
@@ -8,7 +8,7 @@ describe 'Request API /v1/build_distributions/subset' do
     KnapsackPro::Client::API::V1::BuildDistributions.subset(
       cache_read_attempt: true,
       commit_hash: 'abcdefg',
-      branch: 'master',
+      branch: 'main',
       node_total: '2',
       node_index: '1',
       test_files: [

--- a/spec/integration/api/build_subsets_create_spec.rb
+++ b/spec/integration/api/build_subsets_create_spec.rb
@@ -7,7 +7,7 @@ describe 'Request API /v1/build_subsets' do
   let(:action) do
     KnapsackPro::Client::API::V1::BuildSubsets.create(
       commit_hash: 'abcdefg',
-      branch: 'master',
+      branch: 'main',
       node_total: '2',
       node_index: '1',
       test_files: [

--- a/spec/knapsack_pro/config/ci/app_veyor_spec.rb
+++ b/spec/knapsack_pro/config/ci/app_veyor_spec.rb
@@ -49,8 +49,8 @@ describe KnapsackPro::Config::CI::AppVeyor do
     subject { described_class.new.branch }
 
     context 'when the environment exists' do
-      let(:env) { { 'APPVEYOR_REPO_BRANCH' => 'master' } }
-      it { should eql 'master' }
+      let(:env) { { 'APPVEYOR_REPO_BRANCH' => 'main' } }
+      it { should eql 'main' }
     end
 
     context "when the environment doesn't exist" do

--- a/spec/knapsack_pro/config/ci/cirrus_ci_spec.rb
+++ b/spec/knapsack_pro/config/ci/cirrus_ci_spec.rb
@@ -63,8 +63,8 @@ describe KnapsackPro::Config::CI::CirrusCI do
     subject { described_class.new.branch }
 
     context 'when the environment exists' do
-      let(:env) { { 'CIRRUS_BRANCH' => 'master' } }
-      it { should eql 'master' }
+      let(:env) { { 'CIRRUS_BRANCH' => 'main' } }
+      it { should eql 'main' }
     end
 
     context "when the environment doesn't exist" do

--- a/spec/knapsack_pro/config/ci/codeship_spec.rb
+++ b/spec/knapsack_pro/config/ci/codeship_spec.rb
@@ -49,8 +49,8 @@ describe KnapsackPro::Config::CI::Codeship do
     subject { described_class.new.branch }
 
     context 'when the environment exists' do
-      let(:env) { { 'CI_BRANCH' => 'master' } }
-      it { should eql 'master' }
+      let(:env) { { 'CI_BRANCH' => 'main' } }
+      it { should eql 'main' }
     end
 
     context "when the environment doesn't exist" do

--- a/spec/knapsack_pro/config/ci/heroku_spec.rb
+++ b/spec/knapsack_pro/config/ci/heroku_spec.rb
@@ -63,8 +63,8 @@ describe KnapsackPro::Config::CI::Heroku do
     subject { described_class.new.branch }
 
     context 'when the environment exists' do
-      let(:env) { { 'HEROKU_TEST_RUN_BRANCH' => 'master' } }
-      it { should eql 'master' }
+      let(:env) { { 'HEROKU_TEST_RUN_BRANCH' => 'main' } }
+      it { should eql 'main' }
     end
 
     context "when the environment doesn't exist" do

--- a/spec/knapsack_pro/config/ci/semaphore2_spec.rb
+++ b/spec/knapsack_pro/config/ci/semaphore2_spec.rb
@@ -68,13 +68,13 @@ describe KnapsackPro::Config::CI::Semaphore2 do
     end
 
     context 'when both SEMAPHORE_GIT_WORKING_BRANCH and SEMAPHORE_GIT_BRANCH are set' do
-      let(:env) { { 'SEMAPHORE_GIT_WORKING_BRANCH' => 'feature', 'SEMAPHORE_GIT_BRANCH' => 'master' } }
+      let(:env) { { 'SEMAPHORE_GIT_WORKING_BRANCH' => 'feature', 'SEMAPHORE_GIT_BRANCH' => 'main' } }
       it { should eql 'feature' }
     end
 
     context 'when SEMAPHORE_GIT_BRANCH is set' do
-      let(:env) { { 'SEMAPHORE_GIT_BRANCH' => 'master' } }
-      it { should eql 'master' }
+      let(:env) { { 'SEMAPHORE_GIT_BRANCH' => 'main' } }
+      it { should eql 'main' }
     end
 
     context "when no ENVs are set" do

--- a/spec/knapsack_pro/config/ci/semaphore_spec.rb
+++ b/spec/knapsack_pro/config/ci/semaphore_spec.rb
@@ -63,8 +63,8 @@ describe KnapsackPro::Config::CI::Semaphore do
     subject { described_class.new.branch }
 
     context 'when the environment exists' do
-      let(:env) { { 'BRANCH_NAME' => 'master' } }
-      it { should eql 'master' }
+      let(:env) { { 'BRANCH_NAME' => 'main' } }
+      it { should eql 'main' }
     end
 
     context "when the environment doesn't exist" do

--- a/spec/knapsack_pro/config/ci/travis_spec.rb
+++ b/spec/knapsack_pro/config/ci/travis_spec.rb
@@ -49,8 +49,8 @@ describe KnapsackPro::Config::CI::Travis do
     subject { described_class.new.branch }
 
     context 'when the environment exists' do
-      let(:env) { { 'TRAVIS_BRANCH' => 'master' } }
-      it { should eql 'master' }
+      let(:env) { { 'TRAVIS_BRANCH' => 'main' } }
+      it { should eql 'main' }
     end
 
     context "when the environment doesn't exist" do

--- a/spec/knapsack_pro/config/env_spec.rb
+++ b/spec/knapsack_pro/config/env_spec.rb
@@ -313,8 +313,8 @@ describe KnapsackPro::Config::Env do
 
     context 'when ENV exists' do
       context 'when KNAPSACK_PRO_BRANCH has value' do
-        before { stub_const("ENV", { 'KNAPSACK_PRO_BRANCH' => 'master' }) }
-        it { should eq 'master' }
+        before { stub_const("ENV", { 'KNAPSACK_PRO_BRANCH' => 'main' }) }
+        it { should eq 'main' }
       end
 
       context 'when CI environment has value' do
@@ -335,22 +335,22 @@ describe KnapsackPro::Config::Env do
         end
 
         context 'when values are different' do
-          let(:env_value) { 'master' }
+          let(:env_value) { 'main' }
           let(:ci_value) { 'feature-branch' }
 
-          it { should eq 'master' }
+          it { should eq 'main' }
 
           it 'logs a warning' do
             expect(logger).to receive(:info).with(
-              'You have set the environment variable KNAPSACK_PRO_BRANCH to master which could be automatically determined from the CI environment as feature-branch.'
+              'You have set the environment variable KNAPSACK_PRO_BRANCH to main which could be automatically determined from the CI environment as feature-branch.'
             )
             subject
           end
         end
 
         context 'when values are the same' do
-          let(:env_value) { 'master' }
-          let(:ci_value) { 'master' }
+          let(:env_value) { 'main' }
+          let(:ci_value) { 'main' }
 
           it 'does not log a warning' do
             expect(logger).not_to receive(:info)

--- a/spec/knapsack_pro/repository_adapters/git_adapter_spec.rb
+++ b/spec/knapsack_pro/repository_adapters/git_adapter_spec.rb
@@ -28,7 +28,7 @@ describe KnapsackPro::RepositoryAdapters::GitAdapter do
   describe '#branches' do
     subject { described_class.new.branches }
 
-    it { expect(subject.include?('master')).to be true }
+    it { expect(subject.include?('main')).to be true }
     it { expect(subject.include?(circle_branch)).to be true } if ENV['CIRCLECI']
   end
 


### PR DESCRIPTION
# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
