### PR TITLE
[RSpec] Fix issues in TimeTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-### UNRELEASED
+### UNRELEASED (patch)
+
+* Fix RSpec TimeTracker to properly track `before(:all)/after(:all)`.
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/303
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v8.3.0...v8.3.1
+
 
 ### 8.3.0
 


### PR DESCRIPTION
# Story

https://trello.com/c/zrjMajhs/758-support-fix-time-tracker

# Description

The time tracker missed some `before(:all)/after(:all)` that weren't in the top level group.

With this change, the following `X` gaps are considered `before(:all)/after(:all)`:

```ruby
describe do
  X (example_started)
  it {}
  X (example_group_started)
  describe do
    X (example_started)
    it {}
    X (example_group_finished)
  end
  X (example_group_started)
  describe do
    X (example_started)
    it {}
  end
  X (example_group_finished)
end
```

# Checklist reminder

- [x] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [x] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
