### PR TITLE
Fix infinite recursion when logger gets into the loop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,23 @@ jobs:
             rm .rspec
             mv .rspec.off .rspec
             exit $RSPEC_EXIT_CODE
+      - run:
+          working_directory: ~/rails-app-with-knapsack_pro
+          # https://github.com/KnapsackPro/knapsack_pro-ruby/issues/269
+          command: |
+            # custom logger ||
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--custom-logger"
+            export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
+            # run a few tests to keep it quick
+            export KNAPSACK_PRO_TEST_FILE_PATTERN="{spec/foo_spec.rb,spec/bar_spec.spec}"
+            # custom log directory
+            export KNAPSACK_PRO_LOG_DIR=log
+            export KNAPSACK_PRO_LOG_LEVEL=debug
+            # other CI provider env vars to trigger a conflict info message to be logged
+            export BUILDKITE=true
+            export BUILDKITE_PARALLEL_JOB=9
+            export BUILDKITE_PARALLEL_JOB_COUNT=10
+            bundle exec rake knapsack_pro:queue:rspec
 
   e2e-regular-minitest:
     parallelism: 2

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -294,7 +294,12 @@ module KnapsackPro
           ci_env_value = ci_env_for(ci_env_method)
 
           if !knapsack_env_value.nil? && !ci_env_value.nil? && knapsack_env_value != ci_env_value.to_s
-            KnapsackPro.logger.info("You have set the environment variable #{knapsack_env_name} to #{knapsack_env_value} which could be automatically determined from the CI environment as #{ci_env_value}.")
+            @logged_message ||= {}
+            key = [knapsack_env_name, ci_env_method].join(',').to_sym
+            unless @logged_message.has_key?(key)
+              @logged_message[key] = true
+              KnapsackPro.logger.info("You have set the environment variable #{knapsack_env_name} to #{knapsack_env_value} which could be automatically determined from the CI environment as #{ci_env_value}.")
+            end
           end
 
           knapsack_env_value != nil ? knapsack_env_value : ci_env_value

--- a/lib/knapsack_pro/config/env.rb
+++ b/lib/knapsack_pro/config/env.rb
@@ -293,7 +293,7 @@ module KnapsackPro
           knapsack_env_value = ENV[knapsack_env_name]
           ci_env_value = ci_env_for(ci_env_method)
 
-          if !knapsack_env_value.nil? && !ci_env_value.nil? && knapsack_env_value != ci_env_value.to_s
+          if !knapsack_env_value.nil? && !ci_env_value.nil? && knapsack_env_value != ci_env_value.to_s && !(within_parallel_tests_gem? && (ci_env_method == :node_total || ci_env_method == :node_index))
             @logged_message ||= {}
             key = [knapsack_env_name, ci_env_method].join(',').to_sym
             unless @logged_message.has_key?(key)
@@ -307,6 +307,10 @@ module KnapsackPro
 
         def ci_env_for(env_name)
           detected_ci.new.send(env_name)
+        end
+
+        def within_parallel_tests_gem?
+          ENV.has_key?('TEST_ENV_NUMBER')
         end
       end
     end


### PR DESCRIPTION
# Story

https://trello.com/c/yROeD8FX

## Related

* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/269

# Description

Fix infinite recursion when the logger gets into the loop.

# Changes:

* Log info message only once to prevent infinite recursion
* Do not log the message for CI node index and CI node total conflict if Knapsack Pro is running within the parallel_tests gem context. This message could be confusing as suggested [here](https://github.com/KnapsackPro/knapsack_pro-ruby/issues/269#issuecomment-3056392927).

# Checklist reminder

- [ ] You added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (ie, patch, minor, major)
- [ ] You follow the architecture outlined below for RSpec in Queue Mode, which is a work in progress (feel free to propose changes):
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and e2e tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and e2e tested.
