### PR TITLE
Fix a Hash#sum bug in the time tracker for RSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### UNRELEASED (patch)
 
+### 8.3.3
+
+* Fix a `Hash#sum` bug in the time tracker for RSpec
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/305
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v8.3.2...v8.3.3
+
 ### 8.3.2
 
 * Fix infinite recursion when the logger enters a loop. [The issue](https://github.com/KnapsackPro/knapsack_pro-ruby/issues/269) occurs when `KNAPSACK_PRO_LOG_DIR=log` is set and a conflict arises between the values of environment variables from the CI provider and those configured by the user (e.g., `KNAPSACK_PRO_CI_NODE_INDEX`, `KNAPSACK_PRO_CI_NODE_TOTAL`).

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -38,11 +38,13 @@ module KnapsackPro
       end
 
       def example_group_started(notification)
+        puts "example_group_started: #{notification.group.parent_groups[1].inspect}"
         record_time_all(notification.group.parent_groups[1], @time_all_by_group_id_path, @time_all)
         @time_all = now
       end
 
       def example_started(notification)
+        puts "example_started: #{notification.example.example_group.inspect}"
         record_time_all(notification.example.example_group, @time_all_by_group_id_path, @time_all)
         @time_each = now
       end
@@ -109,7 +111,11 @@ module KnapsackPro
         group.each do |_, example|
           next if example[:time_execution] == 0.0
 
+          puts "time_all_by_group_id_path: #{time_all_by_group_id_path.inspect}"
           example[:time_execution] += time_all_by_group_id_path.reduce(0.0) do |sum, (group_id_path, time)|
+            puts "group_id_path: #{group_id_path.inspect}"
+            puts "time: #{time.inspect}"
+            puts
             # :path is a file path (a_spec.rb), sum any before/after(:all) in the file
             next sum + time if group_id_path.start_with?(example[:path])
             # :path is an id path (a_spec.rb[1:1]), sum any before/after(:all) above it
@@ -134,7 +140,10 @@ module KnapsackPro
       def record_time_all(group, time_all_by_group_id_path, time_all)
         return unless group # above top level group
 
+        puts "group: #{group.inspect}"
+        puts "group id: #{group.id.inspect}"
         group_id_path = KnapsackPro::TestFileCleaner.clean(group.id)
+        puts "group_id_path: #{group_id_path.inspect}"
         time_all_by_group_id_path[group_id_path] += now - time_all
       end
 

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -109,7 +109,12 @@ module KnapsackPro
         group.each do |_, example|
           next if example[:time_execution] == 0.0
 
+          puts "time_all_by_group_id_path:"
+          puts time_all_by_group_id_path.inspect
           example[:time_execution] += time_all_by_group_id_path.sum do |group_id_path, time|
+            puts "group_id_path: #{group_id_path.inspect}"
+            puts "time: #{time.inspect}"
+            puts
             # :path is a file path (a_spec.rb), sum any before/after(:all) in the file
             next time if group_id_path.start_with?(example[:path])
             # :path is an id path (a_spec.rb[1:1]), sum any before/after(:all) above it

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -38,11 +38,13 @@ module KnapsackPro
       end
 
       def example_group_started(notification)
+        puts "example_group_started: #{notification.group.parent_groups[1].inspect}"
         record_time_all(notification.group.parent_groups[1], @time_all_by_group_id_path, @time_all)
         @time_all = now
       end
 
       def example_started(notification)
+        puts "example_started: #{notification.example.example_group.inspect}"
         record_time_all(notification.example.example_group, @time_all_by_group_id_path, @time_all)
         @time_each = now
       end
@@ -109,8 +111,7 @@ module KnapsackPro
         group.each do |_, example|
           next if example[:time_execution] == 0.0
 
-          puts "time_all_by_group_id_path:"
-          puts time_all_by_group_id_path.inspect
+          puts "time_all_by_group_id_path: #{time_all_by_group_id_path.inspect}"
           example[:time_execution] += time_all_by_group_id_path.sum do |group_id_path, time|
             puts "group_id_path: #{group_id_path.inspect}"
             puts "time: #{time.inspect}"
@@ -139,7 +140,10 @@ module KnapsackPro
       def record_time_all(group, time_all_by_group_id_path, time_all)
         return unless group # above top level group
 
+        puts "group: #{group.inspect}"
+        puts "group id: #{group.id.inspect}"
         group_id_path = KnapsackPro::TestFileCleaner.clean(group.id)
+        puts "group_id_path: #{group_id_path.inspect}"
         time_all_by_group_id_path[group_id_path] += now - time_all
       end
 

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -112,15 +112,15 @@ module KnapsackPro
           next if example[:time_execution] == 0.0
 
           puts "time_all_by_group_id_path: #{time_all_by_group_id_path.inspect}"
-          example[:time_execution] += time_all_by_group_id_path.sum do |group_id_path, time|
+          example[:time_execution] += time_all_by_group_id_path.reduce(0.0) do |sum, (group_id_path, time)|
             puts "group_id_path: #{group_id_path.inspect}"
             puts "time: #{time.inspect}"
             puts
             # :path is a file path (a_spec.rb), sum any before/after(:all) in the file
-            next time if group_id_path.start_with?(example[:path])
+            next sum + time if group_id_path.start_with?(example[:path])
             # :path is an id path (a_spec.rb[1:1]), sum any before/after(:all) above it
-            next time if example[:path].start_with?(group_id_path[0..-2])
-            0
+            next sum + time if example[:path].start_with?(group_id_path[0..-2])
+            sum
           end
         end
       end

--- a/lib/knapsack_pro/formatters/time_tracker.rb
+++ b/lib/knapsack_pro/formatters/time_tracker.rb
@@ -38,13 +38,11 @@ module KnapsackPro
       end
 
       def example_group_started(notification)
-        puts "example_group_started: #{notification.group.parent_groups[1].inspect}"
         record_time_all(notification.group.parent_groups[1], @time_all_by_group_id_path, @time_all)
         @time_all = now
       end
 
       def example_started(notification)
-        puts "example_started: #{notification.example.example_group.inspect}"
         record_time_all(notification.example.example_group, @time_all_by_group_id_path, @time_all)
         @time_each = now
       end
@@ -111,11 +109,7 @@ module KnapsackPro
         group.each do |_, example|
           next if example[:time_execution] == 0.0
 
-          puts "time_all_by_group_id_path: #{time_all_by_group_id_path.inspect}"
           example[:time_execution] += time_all_by_group_id_path.reduce(0.0) do |sum, (group_id_path, time)|
-            puts "group_id_path: #{group_id_path.inspect}"
-            puts "time: #{time.inspect}"
-            puts
             # :path is a file path (a_spec.rb), sum any before/after(:all) in the file
             next sum + time if group_id_path.start_with?(example[:path])
             # :path is an id path (a_spec.rb[1:1]), sum any before/after(:all) above it
@@ -140,10 +134,7 @@ module KnapsackPro
       def record_time_all(group, time_all_by_group_id_path, time_all)
         return unless group # above top level group
 
-        puts "group: #{group.inspect}"
-        puts "group id: #{group.id.inspect}"
         group_id_path = KnapsackPro::TestFileCleaner.clean(group.id)
-        puts "group_id_path: #{group_id_path.inspect}"
         time_all_by_group_id_path[group_id_path] += now - time_all
       end
 


### PR DESCRIPTION
# Description

The `Hash#sum` method yields an unpredictable result when extracting key and value pairs from a `Hash`. Use `Hash#reduce` to get consistent results.

## Issue

```ruby
time_all_by_group_id_path = {
  "packs/a_spec.rb[1]" => 0.4432561059966247,
  "packs/a_spec.rb[1:5]" => 0.001432769997336436,
  "packs/a_spec.rb[1:6]" => 0.00025801000083447434,
  "packs/a_spec.rb[1:6:1]" => 0.00034806999974534847,
  "packs/a_spec.rb[1:6:2]" => 0.00036408000050869305,
  "packs/a_spec.rb[1:6:3]" => 0.0003385700001672376
}
```

Code that iterates over the Hash.

```ruby
example[:path] = "packs/a_spec.rb[1]"
time_all_by_group_id_path.sum do |group_id_path, time|
  puts "group_id_path: #{group_id_path.inspect}"
  puts "time: #{time.inspect}"
  puts
  # :path is a file path (a_spec.rb), sum any before/after(:all) in the file
  next time if group_id_path.start_with?(example[:path])
  # :path is an id path (a_spec.rb[1:1]), sum any before/after(:all) above it
  next time if example[:path].start_with?(group_id_path[0..-2])
  0
end
```


`group_id_path.start_with?(example[:path])` fails with:

```
E, [2025-07-15T10:06:58.711768 #286] ERROR -- : [knapsack_pro] An unexpected exception happened. RSpec cannot handle it. The exception: #<NoMethodError: undefined method `start_with?' for an instance of Float>
E, [2025-07-15T10:06:58.711810 #286] ERROR -- : [knapsack_pro] Exception message: undefined method `start_with?' for an instance of Float
E, [2025-07-15T10:06:58.711890 #286] ERROR -- : [knapsack_pro] Exception backtrace: /home/app/webapp/vendor/bundle/ruby/3.3.0/gems/knapsack_pro-8.3.2/lib/knapsack_pro/formatters/time_tracker.rb:114:in `block (2 levels) in add_hooks_time'
```

This error happens in the customer environment but not when reproduced locally in my environment.

In the customer environment, the values are:

```
group_id_path = 0.4432561059966247 # which is value for packs/a_spec.rb[1]
time = nil
```

The fix in this PR fixes the issue for the customer.

# Checks

- [x] I added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (i.e., patch, minor, major)
- [ ] I followed the architecture outlined below for RSpec in Queue Mode:
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and E2E tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and E2E tested.
