### PR TITLE
GHA: Use proper branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-### UNRELEASED (patch)
+### UNRELEASED (minor)
+
+* GitHub Actions: Detect either head branch in Pull Requests or short ref name (vs fully-formed ref) in the other cases
+
+    https://github.com/KnapsackPro/knapsack_pro-ruby/pull/308
+
+https://github.com/KnapsackPro/knapsack_pro-ruby/compare/v8.4.0...v8.5.0
 
 ### 8.4.0
 

--- a/lib/knapsack_pro/config/ci/github_actions.rb
+++ b/lib/knapsack_pro/config/ci/github_actions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+# https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 module KnapsackPro
   module Config
     module CI
@@ -31,9 +31,11 @@ module KnapsackPro
         end
 
         def branch
-          # GITHUB_REF - The branch or tag ref that triggered the workflow. For example, refs/heads/feature-branch-1.
-          # If neither a branch or tag is available for the event type, the variable will not exist.
-          ENV['GITHUB_REF'] || ENV['GITHUB_SHA']
+          # `on: push` has `GITHUB_HEAD_REF=`
+          head_ref = ENV.fetch('GITHUB_HEAD_REF', '')
+          return head_ref unless head_ref == ''
+
+          ENV['GITHUB_REF_NAME'] || ENV['GITHUB_SHA']
         end
 
         def project_dir

--- a/spec/knapsack_pro/config/ci/github_actions_spec.rb
+++ b/spec/knapsack_pro/config/ci/github_actions_spec.rb
@@ -61,30 +61,52 @@ describe KnapsackPro::Config::CI::GithubActions do
   describe '#branch' do
     subject { described_class.new.branch }
 
-    context 'when the environment exists' do
-      context 'when GITHUB_REF has value' do
-        let(:env) do
-          {
-            'GITHUB_REF' => 'main',
-            'GITHUB_SHA' => '2e13512fc230d6f9ebf4923352718e4d',
-          }
-        end
-
-        it { should eql 'main' }
+    context 'when GITHUB_HEAD_REF is set' do
+      let(:env) do
+        {
+          'GITHUB_HEAD_REF' => 'feature',
+          'GITHUB_REF_NAME' => 'main',
+          'GITHUB_SHA' => '2e13512fc230d6f9ebf4923352718e4d'
+        }
       end
 
-      context 'when GITHUB_REF is not set' do
-        let(:env) do
-          {
-            'GITHUB_SHA' => '2e13512fc230d6f9ebf4923352718e4d',
-          }
-        end
-
-        it { should eql '2e13512fc230d6f9ebf4923352718e4d' }
-      end
+      it { should eql 'feature' }
     end
 
-    context "when the environment doesn't exist" do
+    context 'when GITHUB_REF_NAME is set' do
+      let(:env) do
+        {
+          'GITHUB_REF_NAME' => 'main',
+          'GITHUB_SHA' => '2e13512fc230d6f9ebf4923352718e4d'
+        }
+      end
+
+      it { should eql 'main' }
+    end
+
+    context 'when GITHUB_HEAD_REF is set to empty string' do
+      let(:env) do
+        {
+          'GITHUB_HEAD_REF' => '',
+          'GITHUB_REF_NAME' => 'main',
+          'GITHUB_SHA' => '2e13512fc230d6f9ebf4923352718e4d'
+        }
+      end
+
+      it { should eql 'main' }
+    end
+
+    context 'when GITHUB_SHA is set' do
+      let(:env) do
+        {
+          'GITHUB_SHA' => '2e13512fc230d6f9ebf4923352718e4d'
+        }
+      end
+
+      it { should eql '2e13512fc230d6f9ebf4923352718e4d' }
+    end
+
+    context 'with no ENVs' do
       it { should be nil }
     end
   end


### PR DESCRIPTION
# Description

Ticket:
- https://trello.com/c/dMGAmdR3/155-remove-refs-heads-from-detected-branch-on-gha
- https://trello.com/c/umXBSwad/857-fix-retry-when-branch-name-is-different-locally-vs-ci

# Checks

- [x] I added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (i.e., patch, minor, major)
- [x] I followed the architecture outlined below for RSpec in Queue Mode:
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and E2E tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and E2E tested.
