### PR TITLE
fix(CI): fix CI misconfiguration to avoid skipped tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
           working_directory: ~/rails-app-with-knapsack_pro
           command: |
             # split by test examples AND a single CI node ||
-            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--split--single-node"
+            export KNAPSACK_PRO_BRANCH="$CIRCLE_BRANCH--$CIRCLE_BUILD_NUM--queue--split--single-node--$CIRCLE_NODE_INDEX"
             export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
             export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
             export KNAPSACK_PRO_CI_NODE_TOTAL=1


### PR DESCRIPTION
# Description

Fix CI misconfiguration to avoid skipped tests

* [ ] Resolve [the exception](https://app.rollbar.com/a/knapsack-pro-api-staging/fix/item/knapsack-pro-api-staging/255) once the PR is merged

# Checks

- [ ] I added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (i.e., patch, minor, major)
- [ ] I followed the architecture outlined below for RSpec in Queue Mode:
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and E2E tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and E2E tested.
