### PR TITLE
Fix failing rspec test by reading coverage data from `coverage_data.js`

### DIFF
--- a/spec/integration/runners/queue/rspec_runner_spec.rb
+++ b/spec/integration/runners/queue/rspec_runner_spec.rb
@@ -2336,7 +2336,9 @@ describe "#{KnapsackPro::Runners::Queue::RSpecRunner} - Integration tests", :cle
 
   context 'when the RSpec split by test examples is enabled AND simplecov is used' do
     let(:coverage_dir) { "#{KNAPSACK_PRO_TMP_DIR}/coverage" }
-    let(:coverage_file) { "#{coverage_dir}/index.html" }
+    # SimpleCov >= 1.0 renders index.html from data stored in coverage_data.js,
+    # so the covered files are listed there instead of in the HTML.
+    let(:coverage_file) { "#{coverage_dir}/coverage_data.js" }
 
     before do
       ENV['KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES'] = 'true'


### PR DESCRIPTION
# Description

AI Disclosure: Had Claude investigate and fix the problem, verified it myself for correctness.

Fix the test failure caused by the simplecov version upgrade.

SimpleCov 1.0 rewrote its HTML formatter: `index.html` is now static and loads a client-side viewer, and the report data lives in `coverage_data.js`. So we want to check that file instead.

This is a test change so I don't think it makes sense to update the CHANGELOG?

# Checks

- [x] I added the changes to the `UNRELEASED` section of the `CHANGELOG.md`, including the needed bump (i.e., patch, minor, major)
- [x] I followed the architecture outlined below for RSpec in Queue Mode:
  - Pure: `lib/knapsack_pro/pure/queue/rspec_pure.rb` contains pure functions that are unit tested.
  - Extension: `lib/knapsack_pro/extensions/rspec_extension.rb` encapsulates calls to RSpec internals and is integration and E2E tested.
  - Runner: `lib/knapsack_pro/runners/queue/rspec_runner.rb` invokes the pure code and the extension to produce side effects, which are integration and E2E tested.
